### PR TITLE
Lowest node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-   - "5"
+  - "5"
   - "5.1"
   - "4"
   - "4.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 language: node_js
 node_js:
+   - "5"
+  - "5.1"
+  - "4"
+  - "4.2"
   - "4.1"
   - "4.0"
+  - "0.12"
+  - "0.11"
+  - "0.10"
+  - "0.8"
+  - "0.6"
+  - "iojs"
 before_install: npm install -g grunt-cli
 install: npm install
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,8 @@
 language: node_js
 node_js:
   - "5"
-  - "5.1"
   - "4"
-  - "4.2"
-  - "4.1"
-  - "4.0"
   - "0.12"
-  - "0.11"
-  - "0.10"
-  - "0.8"
-  - "0.6"
-  - "iojs"
 before_install: npm install -g grunt-cli
 install: npm install
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/stryker-mutator/stryker.svg?branch=master)](https://travis-ci.org/stryker-mutator/stryker)
 [![NPM](https://img.shields.io/npm/dm/stryker.svg)](https://www.npmjs.com/package/stryker)
+[![Node version](https://img.shields.io/node/v/stryker.svg)](https://img.shields.io/node/v/stryker.svg)
 [![Gitter](https://badges.gitter.im/stryker-mutator/stryker.svg)](https://gitter.im/stryker-mutator/stryker?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 ![Stryker](stryker-80x80.png)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "Nico Jansen <nicoj@infosupport.com> https://nicojs.github.io"
   ],
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=0.12.0"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixes #91 

Travis now builds the following node versions:
* 0.12.0 (lowest supported version)
* 4.x.x
* 5.x.x

The node version badge in the README will *probably* work after a new release.