### PR TITLE
refactor(grunt) Remove 'typings' from grunt build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
 # 2 space indentation
-[{*.ts,*.js}]
+[{*.ts,*.js,*.json}]
 indent_style = space
 indent_size = 2

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,10 +16,6 @@ module.exports = function(grunt) {
       }
     },
 
-    typings: {
-      install: {}
-    },
-
     jshint: {
       files: ['Gruntfile.js', 'dist/src/**/*.js', 'dist/test/**/*.js'],
       options: {
@@ -43,7 +39,7 @@ module.exports = function(grunt) {
     watch: {
       testFiles: {
         files: ['dist/**/*.js'],
-        tasks: ['coverage']
+        tasks: ['mochaTest:unit']
       }
     },
     mochaTest: {
@@ -66,7 +62,7 @@ module.exports = function(grunt) {
     mocha_istanbul: {
       coverage: {
         // Register helpers before, it includes a log4js mock which has to be loaded as early as possible
-        src: ['dist/test/helpers/**/*.js', 'dist/test/integration/**/*.js', 'dist/test/unit/**/*.js'],
+        src: ['dist/test/helpers/**/*.js', 'dist/test/unit/**/*.js', 'dist/test/integration/**/*.js'],
       }
     },
     istanbul_check_coverage: {
@@ -103,7 +99,7 @@ module.exports = function(grunt) {
   grunt.registerTask('default', ['test']);
   grunt.registerTask('watch-test', ['test', 'watch']);
   grunt.registerTask('test', ['build', 'coverage']);
-  grunt.registerTask('build', ['typings', 'clean', 'ts']);
+  grunt.registerTask('build', ['clean', 'ts']);
   grunt.registerTask('integration', ['mochaTest:integration']);
   grunt.registerTask('coverage', ['mocha_istanbul:coverage']);
   grunt.registerTask('serve', ['watch']);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/src/Stryker.js",
   "typings": "dist/src/Stryker.d.ts",
   "scripts": {
+    "pretest": "typings install",
     "test": "grunt test",
     "start": "concurrently \"npm run tsc:w\" \"grunt serve\"",
     "tsc:w": "tsc -w",
@@ -62,7 +63,6 @@
     "grunt-mocha-istanbul": "^3.0.1",
     "grunt-mocha-test": "^0.12.7",
     "grunt-ts": "5.4.0",
-    "grunt-typings": "^0.1.4",
     "istanbul": "^0.4.0",
     "mocha": "^2.3.3",
     "mocha-sinon": "^1.1.4",


### PR DESCRIPTION
* Remove typings, now done on npm pretest script
* Refactored the grunt serve task to now only run unit tests