### PR TITLE
refactor(RunnerOptions) Make the port number optional

### DIFF
--- a/src/api/test_runner/RunnerOptions.ts
+++ b/src/api/test_runner/RunnerOptions.ts
@@ -12,7 +12,7 @@ interface RunnerOptions{
   /**
    * Represents a free port which the test runner can choose to use
    */
-  port: number;
+  port?: number;
    
   /**
    * The underlying strykerOptions


### PR DESCRIPTION
Mocha doesn't use a port but the runner options force you to specify a port so I made it optional.