### PR TITLE
Copy test files to the temp directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma-phantomjs-launcher": "^0.2.1",
     "lodash": "^3.10.1",
     "log4js": "^0.6.33",
+    "mkdirp": "^0.5.1",
     "node-glob": "^1.2.0",
     "phantomjs": "^1.9.18"
   },

--- a/src/TestRunnerOrchestrator.ts
+++ b/src/TestRunnerOrchestrator.ts
@@ -182,7 +182,7 @@ export default class TestRunnerOrchestrator {
       let copyPromises: Promise<any>[] = this.files.map(file => {
         let relativePath = file.path.substr(cwd.length);
         let folderName = StrykerTempFolder.ensureFolderExists(tempFolder + path.dirname(relativePath));
-        let targetFile = folderName + path.sep + path.basename(relativePath);
+        let targetFile = path.join(folderName, path.basename(relativePath));
         fileMap[file.path] = targetFile;
         return StrykerTempFolder.copyFile(file.path, targetFile);
       });

--- a/src/TestRunnerOrchestrator.ts
+++ b/src/TestRunnerOrchestrator.ts
@@ -176,10 +176,13 @@ export default class TestRunnerOrchestrator {
   private copyAllFilesToTempFolder() {
     return new Promise<FileMap>((resolve, reject) => {
       let fileMap: FileMap = Object.create(null);
+      let cwd = process.cwd();
       var tempFolder = StrykerTempFolder.createRandomFolder('test-runner-files');
       log.debug('Making a sandbox for files in %s', tempFolder);
       let copyPromises: Promise<any>[] = this.files.map(file => {
-        let targetFile = tempFolder + path.sep + path.basename(file.path);
+        let relativePath = file.path.substr(cwd.length);
+        let folderName = StrykerTempFolder.ensureFolderExists(tempFolder + path.dirname(relativePath));
+        let targetFile = folderName + path.sep + path.basename(relativePath);
         fileMap[file.path] = targetFile;
         return StrykerTempFolder.copyFile(file.path, targetFile);
       });

--- a/src/api/util/StrykerTempFolder.ts
+++ b/src/api/util/StrykerTempFolder.ts
@@ -1,6 +1,7 @@
 import * as os from 'os'
 import * as fs from 'fs';
 import * as path from 'path';
+import * as mkdirp from 'mkdirp';
 
 let baseTempFolder = os.tmpdir() + path.sep + 'stryker';
 let tempFolder = baseTempFolder + path.sep + random();
@@ -31,7 +32,7 @@ function random(): number {
  */
 function ensureFolderExists(path: string): string {
   if (!fileOrFolderExists(path)) {
-    fs.mkdirSync(path);
+    mkdirp.sync(path);
   }
   return path;
 }
@@ -88,5 +89,6 @@ function copyFile(fromFilename: string, toFilename: string): Promise<void> {
 export default {
   createRandomFolder,
   writeFile,
-  copyFile
+  copyFile,
+  ensureFolderExists
 };

--- a/test/unit/TestRunnerOrchestratorSpec.ts
+++ b/test/unit/TestRunnerOrchestratorSpec.ts
@@ -18,10 +18,10 @@ describe('TestRunnerOrchestrator', () => {
   let sut: TestRunnerOrchestrator;
   let sandbox: sinon.SinonSandbox;
   let files = [
-    { path: process.cwd() + path.sep + 'a.js', shouldMutate: true },
-    { path: process.cwd() + path.sep + 'b.js', shouldMutate: true },
-    { path: process.cwd() + path.sep + 'aSpec.js', shouldMutate: false },
-    { path: process.cwd() + path.sep + 'bSpec.js', shouldMutate: false }
+    { path: path.join(process.cwd(), 'a.js'), shouldMutate: true },
+    { path: path.join(process.cwd(), 'b.js'), shouldMutate: true },
+    { path: path.join(process.cwd(), 'aSpec.js'), shouldMutate: false },
+    { path: path.join(process.cwd(), 'bSpec.js'), shouldMutate: false }
   ];
   let strykerOptions = { testFramework: 'superFramework', testRunner: 'superRunner', port: 42 };
   let firstTestRunner: any;

--- a/test/unit/TestRunnerOrchestratorSpec.ts
+++ b/test/unit/TestRunnerOrchestratorSpec.ts
@@ -17,7 +17,12 @@ let expect = chai.expect;
 describe('TestRunnerOrchestrator', () => {
   let sut: TestRunnerOrchestrator;
   let sandbox: sinon.SinonSandbox;
-  let files = [{ path: 'a.js', shouldMutate: true }, { path: 'b.js', shouldMutate: true }, { path: 'aSpec.js', shouldMutate: false }, { path: 'bSpec.js', shouldMutate: false }];
+  let files = [
+    { path: process.cwd() + path.sep + 'a.js', shouldMutate: true },
+    { path: process.cwd() + path.sep + 'b.js', shouldMutate: true },
+    { path: process.cwd() + path.sep + 'aSpec.js', shouldMutate: false },
+    { path: process.cwd() + path.sep + 'bSpec.js', shouldMutate: false }
+  ];
   let strykerOptions = { testFramework: 'superFramework', testRunner: 'superRunner', port: 42 };
   let firstTestRunner: any;
   let secondTestRunner: any;
@@ -108,6 +113,7 @@ describe('TestRunnerOrchestrator', () => {
     beforeEach(() => {
       sandbox.stub(os, 'cpus', () => [1, 2]); // stub 2 cpus
       sandbox.stub(StrykerTempFolder, 'createRandomFolder').returns('a-folder');
+      sandbox.stub(StrykerTempFolder, 'ensureFolderExists').returns('a-folder');
       sandbox.stub(StrykerTempFolder, 'copyFile').returns(Promise.resolve());
 
       var untestedMutant = mockMutant(0);
@@ -124,8 +130,8 @@ describe('TestRunnerOrchestrator', () => {
         { path: 'files', shouldMutate: false },
         { path: `a-folder${path.sep}a.js`, shouldMutate: true },
         { path: `a-folder${path.sep}b.js`, shouldMutate: true },
-        { path: 'aSpec.js', shouldMutate: false },
-        { path: 'bSpec.js', shouldMutate: false }
+        { path: `a-folder${path.sep}aSpec.js`, shouldMutate: false },
+        { path: `a-folder${path.sep}bSpec.js`, shouldMutate: false }
       ];
 
       expect(IsolatedTestRunnerAdapterFactory.create).to.have.been.calledWithMatch

--- a/typings.json
+++ b/typings.json
@@ -18,6 +18,7 @@
     "express-serve-static-core": "registry:dt/express-serve-static-core#0.0.0+20160322035842",
     "log4js": "registry:dt/log4js#0.0.0+20160316155526",
     "mime": "registry:dt/mime#0.0.0+20160316155526",
+    "mkdirp": "registry:dt/mkdirp#0.3.0+20160317120654",
     "mocha": "registry:dt/mocha#2.2.5+20160317120654",
     "node": "registry:dt/node#4.0.0+20160330064709",
     "serve-static": "registry:dt/serve-static#0.0.0+20160317120654"


### PR DESCRIPTION
Mocha requires Stryker to copy not only the source files, but also the test files.

This PR ensures that Stryker copies all files to the temp folder and that a directory structure is created which matches the original directory structure.