### PR TITLE
fix(parserUtils): Add support for duplicate ast

### DIFF
--- a/src/utils/parserUtils.ts
+++ b/src/utils/parserUtils.ts
@@ -41,14 +41,14 @@ export function parse(code: string): any {
 export function collectFrozenNodes(abstractSyntaxTree: any, nodes?: any[]): any[] {
   nodes = nodes || [];
 
-  if (abstractSyntaxTree instanceof Object && !(abstractSyntaxTree instanceof Array) && abstractSyntaxTree.type) {
+  if (!_.isArray(abstractSyntaxTree) && _.isObject(abstractSyntaxTree) && abstractSyntaxTree.type && _.isUndefined(abstractSyntaxTree.nodeID)) {
     abstractSyntaxTree.nodeID = nodes.length;
     nodes.push(abstractSyntaxTree);
   }
 
   Object.freeze(abstractSyntaxTree);
-
-  _.forOwn(abstractSyntaxTree, (childNode) => {
+  
+  _.forOwn(abstractSyntaxTree, (childNode, i) => {
     if (childNode instanceof Object && !(childNode instanceof Array)) {
       collectFrozenNodes(childNode, nodes);
     } else if (childNode instanceof Array) {

--- a/test/unit/utils/parserUtilsSpec.ts
+++ b/test/unit/utils/parserUtilsSpec.ts
@@ -4,20 +4,40 @@ var expect = require('chai').expect;
 import * as parserUtils from '../../../src/utils/parserUtils';
 require('mocha-sinon');
 
-describe('parserUtils', function() {
+describe('parserUtils', () => {
 
-  describe('should throw an error', function(){
-    it('if no code is provided when parsing', function() {
-      expect(parserUtils.parse).to.throw(Error);
+  describe('collectFrozenNodes', () => {
+
+    it('when provided a try catch block', () => {
+      // A try catch block has recursion. See
+      // http://esprima.org/demo/parse.html?code=try%20%7B%0D%0A%20%20%20%20%20%20%20%20configModule(config)%3B%0D%0A%20%20%20%20%20%20%7D%0D%0A%20%20%20%20%20%20catch%20(e)%20%7B%0D%0A%20%20%20%20%20%20%20%20process.exit(1)%3B%0D%0A%20%20%20%20%20%20%7D
+
+      let parsedTryCatch = parserUtils.parse(`try {
+        configModule(config);
+      }
+      catch (e) {
+        process.exit(1);
+      }`);
+      parserUtils.collectFrozenNodes(parsedTryCatch);
     });
-
   });
 
-  it('should return an empty object if an empty string is parsed', function() {
-    var emptyObject = {};
+  describe('parse', () => {
 
-    var result = parserUtils.parse('');
-    expect(JSON.stringify(result)).to.equal(JSON.stringify(emptyObject));
+    describe('should throw an error', () => {
+      it('if no code is provided when parsing', () => {
+        expect(parserUtils.parse).to.throw(Error);
+      });
+
+    });
+
+
+    it('should return an empty object if an empty string is parsed', () => {
+      var emptyObject = {};
+
+      var result = parserUtils.parse('');
+      expect(JSON.stringify(result)).to.equal(JSON.stringify(emptyObject));
+    });
   });
 
 });


### PR DESCRIPTION
The parser utils is responsible to add id's to ast nodes. I add support for having properties which refer to the same part of the ast. This happens for example with a try catch:
http://esprima.org/demo/parse.html?code=try%7B%0D%0A%7Dcatch(error)%7B%0D%0A%7D