### PR TITLE
refactor(cli): Add stryker as binary

### DIFF
--- a/bin/stryker
+++ b/bin/stryker
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+'use strict';
+
+process.title = 'grunt';
+
+// Run the TypeScript compiled stryker-cli.js
+require('../src/stryker-cli');

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "engines": {
     "node": ">=0.12.0"
   },
+  "bin": {
+    "stryker": "./bin/stryker"
+  },
   "dependencies": {
     "chalk": "^1.1.1",
     "commander": "^2.9.0",

--- a/src/Stryker.ts
+++ b/src/Stryker.ts
@@ -1,7 +1,6 @@
 'use strict';
 
 import * as _ from 'lodash';
-var program = require('commander');
 import {normalize} from './utils/fileUtils';
 import MutatorOrchestrator from './MutatorOrchestrator';
 import Mutant from './Mutant';
@@ -15,7 +14,7 @@ import {RunResult, TestResult} from 'stryker-api/test_runner';
 import TestSelectorOrchestrator from './TestSelectorOrchestrator';
 import MutantRunResultMatcher from './MutantRunResultMatcher';
 import InputFileResolver from './InputFileResolver';
-import ConfigReader, {CONFIG_SYNTAX_HELP} from './ConfigReader';
+import ConfigReader from './ConfigReader';
 import PluginLoader from './PluginLoader';
 import {freezeRecursively, isPromise} from './utils/objectUtils';
 import * as log4js from 'log4js';
@@ -157,38 +156,3 @@ export default class Stryker {
     }
   }
 }
-
-(function run() {
-  function list(val: string) {
-    return val.split(',');
-  }
-  program
-    .usage('-f <files> -m <filesToMutate> -c <configFileLocation> [other options]')
-    .description('Starts the stryker mutation testing process. Required arguments are --mutate, --files, --testFramework and --testRunner. You can use globbing expressions to target multiple files. See https://github.com/isaacs/node-glob#glob-primer for more information about the globbing syntax.')
-    .option('-m, --mutate <filesToMutate>', `A comma seperated list of globbing expression used for selecting the files that should be mutated.
-                              Example: src/**/*.js,a.js`, list)
-    .option('-f, --files <allFiles>', `A comma seperated list of globbing expression used for selecting all files needed to run the tests. These include library files, test files and files to mutate, but should NOT include test framework files (for example jasmine).
-                              Example: node_modules/a-lib/**/*.js,src/**/*.js,a.js,test/**/*.js`, list)
-    .option('--testFramework <name>', `The name of the test framework you want to use`)
-    .option('--testRunner <name>', `The name of the test runner you want to use`)
-    .option('--testSelector <name>', `The name of the test selector you want to use`)
-    .option('-c, --configFile <configFileLocation>', 'A location to a config file. That file should export a function which accepts a "config" object\n' +
-    CONFIG_SYNTAX_HELP)
-    .option('--logLevel <level>', 'Set the log4js loglevel. Possible values: fatal, error, warn, info, debug, trace, all and off. Default is "info"')
-    .parse(process.argv);
-
-  log4js.setGlobalLogLevel(program['logLevel'] || 'info')
-
-  // Cleanup commander state
-  delete program.options;
-  delete program.rawArgs;
-  delete program.args;
-  delete program.commands;
-  for (let i in program) {
-    if (i.charAt(0) === '_') {
-      delete program[i];
-    }
-  }
-
-  new Stryker(program).runMutationTest();
-})();

--- a/src/stryker-cli.ts
+++ b/src/stryker-cli.ts
@@ -1,0 +1,37 @@
+var program = require('commander');
+import {CONFIG_SYNTAX_HELP} from './ConfigReader';
+import Stryker from './Stryker';
+import * as log4js from 'log4js';
+
+function list(val: string) {
+  return val.split(',');
+}
+program
+  .usage('-f <files> -m <filesToMutate> -c <configFileLocation> [other options]')
+  .description('Starts the stryker mutation testing process. Required arguments are --mutate, --files, --testFramework and --testRunner. You can use globbing expressions to target multiple files. See https://github.com/isaacs/node-glob#glob-primer for more information about the globbing syntax.')
+  .option('-m, --mutate <filesToMutate>', `A comma seperated list of globbing expression used for selecting the files that should be mutated.
+                              Example: src/**/*.js,a.js`, list)
+  .option('-f, --files <allFiles>', `A comma seperated list of globbing expression used for selecting all files needed to run the tests. These include library files, test files and files to mutate, but should NOT include test framework files (for example jasmine).
+                              Example: node_modules/a-lib/**/*.js,src/**/*.js,a.js,test/**/*.js`, list)
+  .option('--testFramework <name>', `The name of the test framework you want to use`)
+  .option('--testRunner <name>', `The name of the test runner you want to use`)
+  .option('--testSelector <name>', `The name of the test selector you want to use`)
+  .option('-c, --configFile <configFileLocation>', 'A location to a config file. That file should export a function which accepts a "config" object\n' +
+  CONFIG_SYNTAX_HELP)
+  .option('--logLevel <level>', 'Set the log4js loglevel. Possible values: fatal, error, warn, info, debug, trace, all and off. Default is "info"')
+  .parse(process.argv);
+
+log4js.setGlobalLogLevel(program['logLevel'] || 'info')
+
+// Cleanup commander state
+delete program.options;
+delete program.rawArgs;
+delete program.args;
+delete program.commands;
+for (let i in program) {
+  if (i.charAt(0) === '_') {
+    delete program[i];
+  }
+}
+
+new Stryker(program).runMutationTest();

--- a/testResources/module/package.json
+++ b/testResources/module/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "tsc": "tsc",
     "postinstall": "typings install",
-    "stryker:config": "node node_modules/stryker/src/Stryker.js --configFile stryker.conf.js"
+    "stryker:config": "stryker --configFile stryker.conf.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Refactor Stryker class to not include the cli. Also add stryker as bin so it can be used directly from an npm script (i.e. "stryker": "stryker --configFile stryker.conf.js")