### PR TITLE
feat(test-runner): Support lifecycle events

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,12 +66,12 @@
     "mocha-sinon": "^1.1.4",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
-    "stryker-api": "^0.1.0",
+    "stryker-api": "^0.1.1",
     "stryker-karma-runner": "^0.1.0",
     "typescript": "^1.8.9",
     "typings": "^0.7.11"
   },
   "peerDependencies": {
-    "stryker-api": "^0.1.0"
+    "stryker-api": "^0.1.1"
   }
 }

--- a/src/isolated-runner/Message.ts
+++ b/src/isolated-runner/Message.ts
@@ -1,13 +1,17 @@
 
-export enum MessageType{
+export enum MessageType {
   Start,
+  Init,
+  InitDone,
   Run,
-  Result
+  Result,
+  Dispose,
+  DisposeDone
 }
 
-interface Message<T> {
+export interface Message<T> {
   type: MessageType;
-  body: T;
+  body?: T;
 }
 
 export default Message;

--- a/test/helpers/log4jsMock.ts
+++ b/test/helpers/log4jsMock.ts
@@ -1,4 +1,3 @@
-console.log('l4js:', require.resolve('log4js'));
 import * as log4js from 'log4js';
 import * as sinon from 'sinon';
 

--- a/test/integration/isolated-runner/IsolatedTestRunnerAdapterSpec.ts
+++ b/test/integration/isolated-runner/IsolatedTestRunnerAdapterSpec.ts
@@ -5,18 +5,22 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 let expect = chai.expect;
+import * as log4js from 'log4js';
 
-describe('TestRunnerChildProcessAdapter', function() {
+describe('TestRunnerChildProcessAdapter', function () {
 
   this.timeout(10000);
-  
+
   let sut: TestRunnerChildProcessAdapter;
   let options: RunnerOptions = {
     strykerOptions: {
-      plugins: ['../../test/integration/isolated-runner/DirectResolvedTestRunner', '../../test/integration/isolated-runner/NeverResolvedTestRunner'],
+      plugins: [
+        '../../test/integration/isolated-runner/DirectResolvedTestRunner',
+        '../../test/integration/isolated-runner/NeverResolvedTestRunner',
+        '../../test/integration/isolated-runner/SlowInitAndDisposeTestRunner'],
       testRunner: 'karma',
       testFrameork: 'jasmine',
-      port: null  
+      port: null
     },
     files: [],
     port: null,
@@ -35,6 +39,7 @@ describe('TestRunnerChildProcessAdapter', function() {
   describe('when test runner behind never responds', () => {
     before(() => {
       sut = new TestRunnerChildProcessAdapter('never-resolved', options);
+      return sut.init();
     });
 
     it('should run and resolve in a timeout', () =>
@@ -42,6 +47,20 @@ describe('TestRunnerChildProcessAdapter', function() {
 
     it('should be able to recover from a timeout', () =>
       expect(sut.run({ timeout: 1000 }).then(() => sut.run({ timeout: 1000 }))).to.eventually.satisfy((result: RunResult) => result.result === TestResult.Timeout));
+  });
+
+  describe('when test runner behind has a slow init and dispose cycle', () => {
+    before(() => {
+      sut = new TestRunnerChildProcessAdapter('slow-init-dispose', options);
+      return sut.init();
+    });
+    it('should run only after it is initialized',
+      () => expect(sut.run({ timeout: 20 })).to.eventually.satisfy((result: RunResult) => result.result === TestResult.Complete));
+
+    it('should be able to run twice in quick succession',
+      () => expect(sut.run({ timeout: 20 }).then(() => sut.run({ timeout: 20 }))).to.eventually.satisfy((result: RunResult) => result.result === TestResult.Complete));
+
+    after(() => sut.dispose());
   });
 
 }); 

--- a/test/integration/isolated-runner/SlowInitAndDisposeTestRunner.ts
+++ b/test/integration/isolated-runner/SlowInitAndDisposeTestRunner.ts
@@ -1,0 +1,30 @@
+import {TestRunnerFactory, TestRunner, RunOptions, RunResult, TestResult} from 'stryker-api/test_runner';
+
+class SlowInitAndDisposeTestRunner implements TestRunner {
+  
+  inInit: boolean;
+  runResult: RunResult = { result: TestResult.Complete, testNames: []};
+
+  init(){
+    return new Promise<void>( resolve => {
+      this.inInit = true;
+      setTimeout(() => {
+        this.inInit = false;
+        resolve();
+      }, 1000);
+    });
+  }
+
+  run(options: RunOptions){
+    if(this.inInit){
+      throw new Error("Test should fail! Not yet initialized!")
+    }
+    return new Promise<RunResult>(res => res(this.runResult));
+  }
+
+  dispose(){
+    return this.init();
+  }
+}
+
+TestRunnerFactory.instance().register('slow-init-dispose', SlowInitAndDisposeTestRunner);

--- a/test/unit/TestRunnerOrchestratorSpec.ts
+++ b/test/unit/TestRunnerOrchestratorSpec.ts
@@ -40,12 +40,14 @@ describe('TestRunnerOrchestrator', () => {
 
   beforeEach(() => {
     firstTestRunner = {
+      init: sinon.stub().returns(Promise.resolve()),
       run: sinon.stub(),
-      dispose: sinon.stub()
+      dispose: sinon.stub().returns(Promise.resolve())
     };
     secondTestRunner = {
+      init: sinon.stub().returns(Promise.resolve()),
       run: sinon.stub(),
-      dispose: sinon.stub()
+      dispose: sinon.stub().returns(Promise.resolve())
     };
     firstTestRunner.run
       .onFirstCall().returns(Promise.resolve({ result: TestResult.Complete, succeeded: 1 }))


### PR DESCRIPTION
Add support for test runner lifecycle events: init and dispose. These are called once in every test runner life cycle (if implemented).  If they return a promise, we will wait for those promises to be resolved before proceding. We will only wait for max 2 seconds with the dispose before forcing the child process to be killed.