### PR TITLE
feat(unincluded-files): Add support for unincluded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 coverage
 .tscache
+.stryker-tmp
 typings
 *.js.map
 src/**/*.js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,7 @@
       "name": "Run stryker example",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceRoot}/src/Stryker.js",
+      "program": "${workspaceRoot}/bin/stryker",
       "preLaunchTask": "build",
       "stopOnEntry": false,
       "args": [

--- a/package.json
+++ b/package.json
@@ -69,12 +69,12 @@
     "mocha-sinon": "^1.1.4",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
-    "stryker-api": "0.1.1",
+    "stryker-api": "^0.1.2",
     "stryker-karma-runner": "^0.1.0",
     "typescript": "^1.8.9",
     "typings": "^0.7.11"
   },
   "peerDependencies": {
-    "stryker-api": "0.1.1"
+    "stryker-api": "^0.1.2"
   }
 }

--- a/src/InputFileResolver.ts
+++ b/src/InputFileResolver.ts
@@ -1,51 +1,99 @@
-import {InputFile} from 'stryker-api/core';
+import {InputFile, InputFileDescriptor} from 'stryker-api/core';
 import {glob, normalize} from './utils/fileUtils';
 import * as _ from 'lodash';
 import * as log4js from 'log4js';
 
 const log = log4js.getLogger('InputFileResolver');
+const DEFAULT_INPUT_FILE_PROPERTIES = { mutated: false, included: true };
 
 export default class InputFileResolver {
 
-  constructor(private mutateFileExpressions: string[], private allFileExpressions: string[]) {
-  }
+  private inputFileDescriptors: InputFileDescriptor[];
+  private mutateFileExpressions: string[];
 
-  public resolve(): Promise<InputFile[]> {
-    return new Promise<InputFile[]>((resolve, reject) => {
-      let errors: string[] = [];
-
-      Promise.all([InputFileResolver.resolveFileGlobs(this.mutateFileExpressions), InputFileResolver.resolveFileGlobs(this.allFileExpressions)])
-        .then((files) => {
-          let mutateFiles = files[0];
-          let allFiles = files[1];
-          normalize(allFiles);
-          normalize(mutateFiles);
-
-          mutateFiles.forEach(mutateFile => {
-            if (allFiles.indexOf(mutateFile) < 0) {
-              errors.push(`Could not find mutate file "${mutateFile}" in list of files.`);
-            }
-          });
-          if (errors.length > 0) {
-            reject(errors);
-          } else {
-            resolve(allFiles.map(file => { return { path: file, shouldMutate: mutateFiles.some(mutateFile => mutateFile === file) }; }))
-          }
-        }, error => reject(error));
+  constructor(mutate: string[], allFileExpressions: Array<InputFileDescriptor | string>) {
+    this.mutateFileExpressions = mutate || [];
+    this.inputFileDescriptors = allFileExpressions.map(maybePattern => {
+      if (InputFileResolver.isInputFileDescriptor(maybePattern)) {
+        return maybePattern;
+      } else {
+        return <InputFileDescriptor>_.assign({ pattern: maybePattern }, DEFAULT_INPUT_FILE_PROPERTIES);
+      }
     });
   }
 
+  public resolve(): Promise<InputFile[]> {
+    let mutateFilePromise = this.resolveMutateFileGlobs();
+    return this.resolveInputFileGlobs().then((allInputFiles) => mutateFilePromise.then(additionalMutateFiles => {
+      InputFileResolver.markAdditionalFilesToMutate(allInputFiles, additionalMutateFiles);
+      InputFileResolver.warnAboutNoFilesToMutate(allInputFiles);
+      return allInputFiles;
+    }));
+  }
+
+  private static markAdditionalFilesToMutate(allInputFiles: InputFile[], additionalMutateFiles: string[]) {
+    let errors: string[] = [];
+    additionalMutateFiles.forEach(mutateFile => {
+      if (!allInputFiles.filter(inputFile => inputFile.path === mutateFile).length) {
+        errors.push(`Could not find mutate file "${mutateFile}" in list of files.`);
+      }
+    });
+    if (errors.length > 0) {
+      throw new Error(errors.join(' '));
+    }
+    allInputFiles.forEach(file => file.mutated = additionalMutateFiles.some(mutateFile => mutateFile === file.path) || file.mutated);
+  }
+  private static warnAboutNoFilesToMutate(allInputFiles: InputFile[]) {
+    let mutateFiles = allInputFiles.filter(file => file.mutated);
+    if (mutateFiles.length) {
+      log.info(`Found ${mutateFiles.length} file(s) to be mutated.`);
+    } else {
+      log.warn(`No files marked to be mutated, stryker will perform a dry-run without actually mutating anything.`);
+    }
+  }
 
   private static reportEmptyGlobbingExpression(expression: string) {
     log.warn(`Globbing expression "${expression}" did not result in any files.`);
   }
 
-  private static resolveFileGlobs(sourceExpressions: string[]): Promise<string[]> {
-    return Promise.all(sourceExpressions.map(expression => glob(expression).then(files => {
+  private static isInputFileDescriptor(maybeInputFileDescriptor: InputFileDescriptor | string): maybeInputFileDescriptor is InputFileDescriptor {
+    if (_.isObject(maybeInputFileDescriptor)) {
+      if (Object.keys(maybeInputFileDescriptor).indexOf('pattern') > -1) {
+        return true;
+      }else{
+        throw Error(`File descriptor ${JSON.stringify(maybeInputFileDescriptor)} is missing mandatory property 'pattern'.`);
+      }
+    } else {
+      return false;
+    }
+  }
+
+  private resolveMutateFileGlobs(): Promise<string[]> {
+    return Promise.all(this.mutateFileExpressions.map(InputFileResolver.resolveFileGlob))
+      .then(files => _.flatten(files));
+  }
+
+  private resolveInputFileGlobs(): Promise<InputFile[]> {
+    return Promise.all(
+      this.inputFileDescriptors.map(descriptor => InputFileResolver.resolveFileGlob(descriptor.pattern)
+        .then(sourceFiles => sourceFiles.map(sourceFile => InputFileResolver.createInputFile(sourceFile, descriptor))))
+    ).then(promises => _.flatten(promises));
+  }
+
+  private static createInputFile(path: string, descriptor: InputFileDescriptor): InputFile {
+    let inputFile: InputFile = <InputFile>_.assign({ path }, DEFAULT_INPUT_FILE_PROPERTIES, descriptor);
+    delete (<any>inputFile)['pattern'];
+    return inputFile;
+  }
+
+
+  private static resolveFileGlob(expression: string): Promise<string[]> {
+    return glob(expression).then(files => {
       if (files.length === 0) {
         this.reportEmptyGlobbingExpression(expression);
       }
+      normalize(files);
       return files;
-    }))).then(files => _.flatten(files));
+    });
   }
 }

--- a/src/Stryker.ts
+++ b/src/Stryker.ts
@@ -64,7 +64,7 @@ export default class Stryker {
           this.logInitialTestRunSucceeded(runResults);
           let mutatorOrchestrator = new MutatorOrchestrator(reporter);
           let mutants = mutatorOrchestrator.generateMutants(inputFiles
-            .filter(inputFile => inputFile.shouldMutate)
+            .filter(inputFile => inputFile.mutated)
             .map(file => file.path));
           log.info(`${mutants.length} Mutant(s) generated`);
 

--- a/src/TestRunnerOrchestrator.ts
+++ b/src/TestRunnerOrchestrator.ts
@@ -191,19 +191,18 @@ export default class TestRunnerOrchestrator {
   private createInitializedSandbox(index: number): Promise<TestRunnerSandbox> {
     var tempFolder = this.createTempFolder();
     return this.copyAllFilesToFolder(tempFolder).then(fileMap => {
-      let runnerFiles: InputFile[] = [];
       let testSelectionFilePath: string = null;
       if (this.testSelector) {
         testSelectionFilePath = this.createTestSelectorFileName(tempFolder);
       }
-      this.files.forEach(originalFile => runnerFiles.push({ path: fileMap[originalFile.path], shouldMutate: originalFile.shouldMutate }));
+      let runnerFiles = this.files.map(originalFile => <InputFile>_.assign(_.cloneDeep(originalFile), { path: fileMap[originalFile.path] }));
       let runner = this.createTestRunner(runnerFiles, false, testSelectionFilePath, index);
-      return runner.init().then(() => ({
+      return {
         index,
         fileMap,
         runner,
         testSelectionFilePath
-      }));
+      }
     });
   }
 
@@ -234,7 +233,7 @@ export default class TestRunnerOrchestrator {
 
   private createTestRunner(files: InputFile[], coverageEnabled: boolean, testSelectionFilePath?: string, index: number = 0): IsolatedTestRunnerAdapter {
     if (testSelectionFilePath) {
-      files = [{ path: testSelectionFilePath, shouldMutate: false }].concat(files);
+      files = [{ path: testSelectionFilePath, mutated: false, included: true }].concat(files);
     }
     let settings = {
       coverageEnabled,

--- a/src/stryker-cli.ts
+++ b/src/stryker-cli.ts
@@ -3,6 +3,8 @@ import {CONFIG_SYNTAX_HELP} from './ConfigReader';
 import Stryker from './Stryker';
 import * as log4js from 'log4js';
 
+const log = log4js.getLogger('stryker-cli');
+
 function list(val: string) {
   return val.split(',');
 }
@@ -34,4 +36,5 @@ for (let i in program) {
   }
 }
 
-new Stryker(program).runMutationTest();
+new Stryker(program).runMutationTest()
+  .catch(err => log.error(`an error occurred`, err));

--- a/test/unit/InputFileResolverSpec.ts
+++ b/test/unit/InputFileResolverSpec.ts
@@ -3,13 +3,14 @@ import * as sinon from 'sinon';
 import * as fileUtils from '../../src/utils/fileUtils';
 import {InputFile} from 'stryker-api/core';
 import {expect} from 'chai';
-import {normalize} from 'path';
+import {normalize, resolve} from 'path';
 import log from '../helpers/log4jsMock';
 
 describe('InputFileResolver', () => {
   let sandbox: sinon.SinonSandbox;
   let globStub: sinon.SinonStub;
   let sut: InputFileResolver;
+  let results: InputFile[];
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -18,7 +19,6 @@ describe('InputFileResolver', () => {
   });
 
   describe('with mutant file expressions which result in files which are included in result of all globbing files', () => {
-    let results: InputFile[];
     beforeEach(() => {
       sut = new InputFileResolver(['mut*tion*'], ['file1', 'mutation1', 'file2', 'mutation2', 'file3']);
       globStub.withArgs('mut*tion*').returns(Promise.resolve(['/mute1.js', '/mute2.js']))
@@ -36,10 +36,51 @@ describe('InputFileResolver', () => {
 
       it('should result in the expected input files', () => {
         expect(results.length).to.be.eq(5);
-        expect(results.map(m => m.shouldMutate)).to.deep.equal([false, true, false, true, false])
+        expect(results.map(m => m.mutated)).to.deep.equal([false, true, false, true, false])
         expect(results.map(m => m.path.substr(m.path.length - 8))).to.deep.equal(['file1.js', 'mute1.js', 'file2.js', 'mute2.js', 'file3.js'])
       });
     });
+  });
+
+  describe('when supplying an InputFileDescriptor without `pattern` property', () => {
+    let result: Error;
+    beforeEach(() => {
+      try {
+        sut = new InputFileResolver(undefined, [<any>{ included: false, mutated: true }]);
+      } catch (error) {
+        result = error;
+      }
+    });
+
+    it('should result in an error', () => expect(result.message).to.be.eq('File descriptor {"included":false,"mutated":true} is missing mandatory property \'pattern\'.'));
+  });
+
+  describe('without mutate property, but with mutated: true in files', () => {
+
+    beforeEach(() => {
+      sut = new InputFileResolver(undefined, ['file1', { pattern: 'mutation1', included: false, mutated: true }]);
+      globStub.withArgs('file1').returns(Promise.resolve(['/file1.js']));
+      globStub.withArgs('mutation1').returns(Promise.resolve(['/mutation1.js']));
+      return sut.resolve().then(r => results = r);
+    });
+
+    it('should result in the expected input files', () => expect(results).to.deep.equal([
+      { included: true, mutated: false, path: resolve('/file1.js') },
+      { included: false, mutated: true, path: resolve('/mutation1.js') }]));
+
+    it('should log that one file is about to be mutated', () => expect(log.info).to.have.been.calledWith('Found 1 file(s) to be mutated.'));
+  });
+
+  describe('without mutate property and without mutated: true in files', () => {
+
+    beforeEach(() => {
+      sut = new InputFileResolver(undefined, ['file1', { pattern: 'mutation1', included: false, mutated: false }]);
+      globStub.withArgs('file1').returns(Promise.resolve(['/file1.js']));
+      globStub.withArgs('mutation1').returns(Promise.resolve(['/mutation1.js']));
+      return sut.resolve().then(r => results = r);
+    });
+
+    it('should warn about dry-run', () => expect(log.warn).to.have.been.calledWith('No files marked to be mutated, stryker will perform a dry-run without actually mutating anything.'));
   });
 
   describe('with file expressions that resolve in different order', () => {
@@ -57,7 +98,7 @@ describe('InputFileResolver', () => {
     });
 
     it('should retain original glob order', () => {
-        expect(results.map(m => m.path.substr(m.path.length - 5))).to.deep.equal(['file1', 'file2'])
+      expect(results.map(m => m.path.substr(m.path.length - 5))).to.deep.equal(['file1', 'file2'])
     });
   });
 
@@ -75,11 +116,10 @@ describe('InputFileResolver', () => {
       let expectedFilesNames = ['/mute1.js', '/mute2.js'];
       fileUtils.normalize(expectedFilesNames)
       expect(results).to.not.be.ok;
-      expect(error).to.deep.equal(
-        [
-          `Could not find mutate file "${expectedFilesNames[0]}" in list of files.`,
-          `Could not find mutate file "${expectedFilesNames[1]}" in list of files.`
-        ]);
+      expect(error.message).to.be.eq([
+        `Could not find mutate file "${expectedFilesNames[0]}" in list of files.`,
+        `Could not find mutate file "${expectedFilesNames[1]}" in list of files.`
+      ].join(' '));
     });
   });
 

--- a/test/unit/StrykerSpec.ts
+++ b/test/unit/StrykerSpec.ts
@@ -111,7 +111,7 @@ describe('Stryker', function () {
 
     describe('with correct input file globbing', () => {
       beforeEach(() => {
-        inputFiles = [{ path: 'someFile', shouldMutate: true }];
+        inputFiles = [{ path: 'someFile', mutated: true, included: true }];
         inputFileResolverStub = {
           resolve: sandbox.stub().returns(Promise.resolve(inputFiles))
         }

--- a/test/unit/TestRunnerOrchestratorSpec.ts
+++ b/test/unit/TestRunnerOrchestratorSpec.ts
@@ -27,10 +27,10 @@ describe('TestRunnerOrchestrator', () => {
   let sut: TestRunnerOrchestrator;
   let sandbox: sinon.SinonSandbox;
   let files = [
-    { path: path.join(process.cwd(), 'a.js'), shouldMutate: true },
-    { path: path.join(process.cwd(), 'b.js'), shouldMutate: true },
-    { path: path.join(process.cwd(), 'aSpec.js'), shouldMutate: false },
-    { path: path.join(process.cwd(), 'bSpec.js'), shouldMutate: false }
+    { path: path.join(process.cwd(), 'a.js'), mutated: true, included: true },
+    { path: path.join(process.cwd(), 'b.js'), mutated: true, included: false },
+    { path: path.join(process.cwd(), 'aSpec.js'), mutated: false, included: true },
+    { path: path.join(process.cwd(), 'bSpec.js'), mutated: false, included: false }
   ];
   let strykerOptions: StrykerOptions = { testRunner: 'superRunner', port: 42, timeoutFactor: 1, timeoutMs: 0 };
   let firstTestRunner: { init: sinon.SinonStub, run: sinon.SinonStub, dispose: sinon.SinonStub };
@@ -124,7 +124,7 @@ describe('TestRunnerOrchestrator', () => {
       beforeEach(() => sut.initialRun().then(res => results = res));
 
       it('should have created an isolated test runner', () => {
-        let expectedFiles = [{ path: path.join('a-folder', '___testSelection.js'), shouldMutate: false }];
+        let expectedFiles = [{ path: path.join('a-folder', '___testSelection.js'), mutated: false, included: true }];
         files.forEach(file => expectedFiles.push(file));
         expect(IsolatedTestRunnerAdapterFactory.create).to.have.been.calledWith({ files: expectedFiles, port: 42, coverageEnabled: true, strykerOptions });
       });
@@ -167,11 +167,11 @@ describe('TestRunnerOrchestrator', () => {
 
       it('should have created 2 test runners', () => {
         let expectedFiles = [
-          { path: `a-folder${path.sep}___testSelection.js`, shouldMutate: false },
-          { path: `a-folder${path.sep}a.js`, shouldMutate: true },
-          { path: `a-folder${path.sep}b.js`, shouldMutate: true },
-          { path: `a-folder${path.sep}aSpec.js`, shouldMutate: false },
-          { path: `a-folder${path.sep}bSpec.js`, shouldMutate: false }
+          { path: `a-folder${path.sep}___testSelection.js`, mutated: false, included: true },
+          { path: `a-folder${path.sep}a.js`, mutated: true, included: true },
+          { path: `a-folder${path.sep}b.js`, mutated: true, included: false },
+          { path: `a-folder${path.sep}aSpec.js`, mutated: false, included: true },
+          { path: `a-folder${path.sep}bSpec.js`, mutated: false, included: false }
         ];
 
         expect(IsolatedTestRunnerAdapterFactory.create).to.have.been.calledWithMatch

--- a/testResources/module/package.json
+++ b/testResources/module/package.json
@@ -17,7 +17,7 @@
     "karma-jasmine": "^1.0.2",
     "karma-phantomjs-launcher": "^1.0.1",
     "stryker": "file:../../",
-    "stryker-api": "0.1.1",
+    "stryker-api": "^0.1.2",
     "stryker-karma-runner": "^0.1.0",
     "typescript": "~1.8.9",
     "typings": "^0.7.9"

--- a/testResources/sampleProject/stryker.conf.js
+++ b/testResources/sampleProject/stryker.conf.js
@@ -1,7 +1,6 @@
-module.exports = function(config){
+module.exports = function (config) {
   config.set({
-    files: ['testResources/sampleProject/src/?(Circle|Add).js', 'testResources/sampleProject/test/?(AddSpec|CircleSpec).js'],
-    mutate: ['testResources/sampleProject/src/?(Circle|Add).js'],
+    files: [{ pattern: 'testResources/sampleProject/src/?(Circle|Add).js', mutated: true }, 'testResources/sampleProject/test/?(AddSpec|CircleSpec).js'],
     testFramework: 'jasmine',
     testRunner: 'karma',
     // testSelector: null,

--- a/typings.json
+++ b/typings.json
@@ -18,9 +18,11 @@
     "express-serve-static-core": "registry:dt/express-serve-static-core#0.0.0+20160322035842",
     "log4js": "registry:dt/log4js#0.0.0+20160316155526",
     "mime": "registry:dt/mime#0.0.0+20160316155526",
-    "mkdirp": "registry:dt/mkdirp#0.3.0+20160317120654",
     "mocha": "registry:dt/mocha#2.2.5+20160317120654",
     "node": "registry:dt/node#4.0.0+20160330064709",
     "serve-static": "registry:dt/serve-static#0.0.0+20160317120654"
+  },
+  "devDependencies": {
+    "mkdirp": "registry:npm/mkdirp#0.5.0+20160222053049"
   }
 }


### PR DESCRIPTION
Add support for InputFileDescriptor object format instead of the string format in the `files` array . The object includes the `included` and `mutated` optional properties. Also updated the stryker-api version.