### PR TITLE
test(stryker): Eat own dogfood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 .tscache
 .stryker-tmp
+reports
 typings
 *.js.map
 src/**/*.js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -76,14 +76,14 @@
       "name": "Run own dog food",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceRoot}/bin/run.js",
-      // "preLaunchTask": "build",
+      "program": "${workspaceRoot}/bin/stryker",
+      "preLaunchTask": "build",
       "stopOnEntry": false,
       "args": [
         "--configFile",
         "stryker.conf.js",
         "--logLevel",
-        "trace"
+        "info"
       ],
       "cwd": "${workspaceRoot}",
       "runtimeExecutable": null,

--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
     "stryker-api": "^0.1.2",
+    "stryker-html-reporter": "^0.1.1",
     "stryker-karma-runner": "^0.1.0",
+    "stryker-mocha-runner": "0.0.2",
     "typescript": "^1.8.9",
     "typings": "^0.7.11"
   },

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,0 +1,10 @@
+module.exports = function (config) {
+  config.set({
+    files: ['test/helpers/**/*.js', 'test/unit/**/*.js', { pattern: 'src/**/*.js', included: false, mutated: true }],
+    testFramework: 'mocha',
+    testRunner: 'mocha',
+    reporter: ['progress', 'clear-text', 'html', 'event-recorder'],
+    testSelector: null,
+    plugins: ['stryker-mocha-runner', 'stryker-html-reporter']
+  });
+}


### PR DESCRIPTION
It has been a long time comming, but we can now finally run stryker on stryker itself. :dog:. Add stryker-mocha-runner and stryker-html-reporter as dev dependencies. Add the stryker.conf.js used to run stryker.