### PR TITLE
Fix(TestRunnerOrchestrator) Mention the initial test run

### DIFF
--- a/src/TestRunnerOrchestrator.ts
+++ b/src/TestRunnerOrchestrator.ts
@@ -32,6 +32,7 @@ export default class TestRunnerOrchestrator {
   }
 
   initialRun(): Promise<RunResult[]> {
+    log.info(`Starting initial test run. This may take a while.`);
     if (this.testSelector) {
       return this.initialRunWithTestSelector();
     } else {


### PR DESCRIPTION
Added a logging statement to indicate that Stryker is busy with the initial test run