### PR TITLE
fix(stryker): Stop running if there are no mutants

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
       "env": {
         "NODE_ENV": "development"
       },
-      "externalConsole": false,
+      "console": "internalConsole",
       "sourceMaps": true,
       "outDir": "${workspaceRoot}"
     },
@@ -41,7 +41,7 @@
       "env": {
         "NODE_ENV": "development"
       },
-      "externalConsole": false,
+      "console": "internalConsole",
       "sourceMaps": true,
       "outDir": "${workspaceRoot}"
     },
@@ -50,13 +50,13 @@
       "type": "node",
       "request": "launch",
       "program": "${workspaceRoot}/bin/stryker",
-      "preLaunchTask": "build",
+      // "preLaunchTask": "build",
       "stopOnEntry": false,
       "args": [
         "--configFile",
         "testResources/sampleProject/stryker.conf.js",
         "--logLevel",
-        "trace",
+        "info",
         "--testFramework",
         "jasmine"
       ],
@@ -68,7 +68,7 @@
       "env": {
         "NODE_ENV": "development"
       },
-      "externalConsole": false,
+      "console": "internalConsole",
       "sourceMaps": true,
       "outDir": "${workspaceRoot}"
     },
@@ -77,13 +77,11 @@
       "type": "node",
       "request": "launch",
       "program": "${workspaceRoot}/bin/stryker",
-      "preLaunchTask": "build",
+      // "preLaunchTask": "build",
       "stopOnEntry": false,
       "args": [
         "--configFile",
-        "stryker.conf.js",
-        "--logLevel",
-        "info"
+        "stryker.conf.js"
       ],
       "cwd": "${workspaceRoot}",
       "runtimeExecutable": null,
@@ -93,7 +91,7 @@
       "env": {
         "NODE_ENV": "development"
       },
-      "externalConsole": false,
+      "console": "internalConsole",
       "sourceMaps": true,
       "outDir": "${workspaceRoot}"
     },
@@ -115,7 +113,7 @@
       "env": {
         "NODE_ENV": "development"
       },
-      "externalConsole": false,
+      "console": "internalConsole",
       "sourceMaps": true,
       "outDir": "${workspaceRoot}"
     }

--- a/src/Stryker.ts
+++ b/src/Stryker.ts
@@ -1,22 +1,23 @@
 'use strict';
 
 import * as _ from 'lodash';
-import {normalize} from './utils/fileUtils';
+import { normalize } from './utils/fileUtils';
 import MutatorOrchestrator from './MutatorOrchestrator';
 import Mutant from './Mutant';
-import {Config, ConfigWriterFactory} from 'stryker-api/config';
-import {StrykerOptions} from 'stryker-api/core';
-import {Reporter, MutantResult} from 'stryker-api/report';
+import { Config, ConfigWriterFactory } from 'stryker-api/config';
+import { StrykerOptions, InputFile } from 'stryker-api/core';
+import { Reporter, MutantResult } from 'stryker-api/report';
+import { TestSelector } from 'stryker-api/test_selector';
 import TestRunnerOrchestrator from './TestRunnerOrchestrator';
 import ReporterOrchestrator from './ReporterOrchestrator';
 import './jasmine_test_selector/JasmineTestSelector';
-import {RunResult, TestResult} from 'stryker-api/test_runner';
+import { RunResult, TestResult } from 'stryker-api/test_runner';
 import TestSelectorOrchestrator from './TestSelectorOrchestrator';
 import MutantRunResultMatcher from './MutantRunResultMatcher';
 import InputFileResolver from './InputFileResolver';
 import ConfigReader from './ConfigReader';
 import PluginLoader from './PluginLoader';
-import {freezeRecursively, isPromise} from './utils/objectUtils';
+import { freezeRecursively, isPromise } from './utils/objectUtils';
 import StrykerTempFolder from './utils/StrykerTempFolder';
 import * as log4js from 'log4js';
 
@@ -25,6 +26,8 @@ const log = log4js.getLogger('Stryker');
 export default class Stryker {
 
   config: Config;
+  private reporter: Reporter;
+  private testSelector: TestSelector;
 
   /**
    * The Stryker mutation tester.
@@ -41,6 +44,8 @@ export default class Stryker {
     this.applyConfigWriters();
     this.setGlobalLogLevel(); // loglevel could be changed
     this.freezeConfig();
+    this.reporter = new ReporterOrchestrator(this.config).createBroadcastReporter();
+    this.testSelector = new TestSelectorOrchestrator(this.config).determineTestSelector();
   }
 
   /**
@@ -48,52 +53,59 @@ export default class Stryker {
    * @function
    */
   runMutationTest(): Promise<MutantResult[]> {
-    let reporter = new ReporterOrchestrator(this.config).createBroadcastReporter();
-    let testSelector = new TestSelectorOrchestrator(this.config).determineTestSelector();
-
     return new InputFileResolver(this.config.mutate, this.config.files).resolve()
-      .then(inputFiles => {
-        let testRunnerOrchestrator = new TestRunnerOrchestrator(this.config, inputFiles, testSelector, reporter);
-        return testRunnerOrchestrator.initialRun().then(runResults => ({ runResults, inputFiles, testRunnerOrchestrator }));
-      })
-      .then(tuple => {
-        let runResults = tuple.runResults;
-        let inputFiles = tuple.inputFiles;
-        let testRunnerOrchestrator = tuple.testRunnerOrchestrator;
-        let unsuccessfulTests = this.filterOutUnsuccesfulResults(runResults);
-        if (unsuccessfulTests.length === 0) {
-          this.logInitialTestRunSucceeded(runResults);
-          let mutatorOrchestrator = new MutatorOrchestrator(reporter);
-          let mutants = mutatorOrchestrator.generateMutants(inputFiles
-            .filter(inputFile => inputFile.mutated)
-            .map(file => file.path));
-          log.info(`${mutants.length} Mutant(s) generated`);
-
-          let mutantRunResultMatcher = new MutantRunResultMatcher(mutants, runResults);
-          mutantRunResultMatcher.matchWithMutants();
-
+      .then((inputFiles) => this.initialTestRun(inputFiles))
+      .then(({runResults, inputFiles, testRunnerOrchestrator}) => {
+        let mutants = this.generateMutants(inputFiles, runResults);
           return testRunnerOrchestrator.runMutations(mutants);
-        } else {
-          this.logFailedTests(unsuccessfulTests);
-          throw new Error('There were failed tests in the initial test run');
-        }
-      }).then(mutantResults => {
-        let maybePromise = reporter.wrapUp();
-        if (isPromise(maybePromise)) {
-          return maybePromise.then(() => mutantResults);
-        } else {
-          return mutantResults;
-        }
-      }).then(mutantResults => StrykerTempFolder.clean().then(() => mutantResults));
+      })
+      .then(mutantResults => this.wrapUpReporter()
+        .then(StrykerTempFolder.clean)
+        .then(() => mutantResults));
   }
 
-  filterOutUnsuccesfulResults(runResults: RunResult[]) {
+  private filterOutUnsuccesfulResults(runResults: RunResult[]) {
     return runResults.filter((runResult: RunResult) => !(!runResult.failed && runResult.result === TestResult.Complete));
   }
 
   private loadPlugins() {
     if (this.config.plugins) {
       new PluginLoader(this.config.plugins).load();
+    }
+  }
+
+  private initialTestRun(inputFiles: InputFile[]) {
+    let testRunnerOrchestrator = new TestRunnerOrchestrator(this.config, inputFiles, this.testSelector, this.reporter);
+    return testRunnerOrchestrator.initialRun()
+      .then(runResults => {
+        let unsuccessfulTests = this.filterOutUnsuccesfulResults(runResults);
+        if (unsuccessfulTests.length) {
+          this.logFailedTests(unsuccessfulTests);
+          throw new Error('There were failed tests in the initial test run');
+        } else {
+          this.logInitialTestRunSucceeded(runResults);
+          return { runResults, inputFiles, testRunnerOrchestrator };
+        }
+      });
+  }
+
+  private generateMutants(inputFiles: InputFile[], runResults: RunResult[]) {
+    let mutatorOrchestrator = new MutatorOrchestrator(this.reporter);
+    let mutants = mutatorOrchestrator.generateMutants(inputFiles
+      .filter(inputFile => inputFile.mutated)
+      .map(file => file.path));
+    log.info(`${mutants.length} Mutant(s) generated`);
+    let mutantRunResultMatcher = new MutantRunResultMatcher(mutants, runResults);
+    mutantRunResultMatcher.matchWithMutants();
+    return mutants;
+  }
+
+  private wrapUpReporter(): Promise<void> {
+    let maybePromise = this.reporter.wrapUp();
+    if (isPromise(maybePromise)) {
+      return maybePromise;
+    } else {
+      return Promise.resolve<void>();
     }
   }
 

--- a/src/utils/StrykerTempFolder.ts
+++ b/src/utils/StrykerTempFolder.ts
@@ -94,7 +94,7 @@ function copyFile(fromFilename: string, toFilename: string): Promise<void> {
  * Deletes the Stryker-temp folder
  */
 function clean() {
-  log.info(`Cleaning stryker temp folder ${baseTempFolder}`);
+  log.debug(`Cleaning stryker temp folder ${baseTempFolder}`);
   return fileUtils.deleteDir(baseTempFolder);
 }
 

--- a/test/unit/StrykerSpec.ts
+++ b/test/unit/StrykerSpec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import Stryker from '../../src/Stryker';
 import {InputFile} from 'stryker-api/core';
 import {MutantResult, Reporter} from 'stryker-api/report';
@@ -76,7 +74,7 @@ describe('Stryker', function () {
     });
   }
 
-  describe('constructor', () => {
+  describe('when constructed', () => {
     beforeEach(() => {
       ConfigWriterFactory.instance().register('FakeConfigWriter', FakeConfigWriter);
       config.plugins = ['plugin1'];

--- a/test/unit/StrykerSpec.ts
+++ b/test/unit/StrykerSpec.ts
@@ -1,16 +1,18 @@
 import Stryker from '../../src/Stryker';
-import {InputFile} from 'stryker-api/core';
-import {MutantResult, Reporter} from 'stryker-api/report';
-import {Config, ConfigWriterFactory, ConfigWriter} from 'stryker-api/config';
-import {RunResult, TestResult} from 'stryker-api/test_runner';
-import {TestSelector} from 'stryker-api/test_selector';
-import {expect} from 'chai';
+import { InputFile } from 'stryker-api/core';
+import { MutantResult, Reporter } from 'stryker-api/report';
+import { Config, ConfigWriterFactory, ConfigWriter } from 'stryker-api/config';
+import { RunResult, TestResult } from 'stryker-api/test_runner';
+import { TestSelector } from 'stryker-api/test_selector';
+import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as inputFileResolver from '../../src/InputFileResolver';
 import * as configReader from '../../src/ConfigReader';
 import * as testSelectorOrchestrator from '../../src/TestSelectorOrchestrator';
 import * as testRunnerOrchestrator from '../../src/TestRunnerOrchestrator';
 import * as reporterOrchestrator from '../../src/ReporterOrchestrator';
+import * as mutatorOrchestrator from '../../src/MutatorOrchestrator';
+import * as mutantRunResultMatcher from '../../src/MutantRunResultMatcher';
 import * as pluginLoader from '../../src/PluginLoader';
 import StrykerTempFolder from '../../src/utils/StrykerTempFolder';
 import log from '../helpers/log4jsMock';
@@ -32,6 +34,7 @@ describe('Stryker', function () {
   let inputFiles: InputFile[];
   let initialRunResults: RunResult[];
   let config: any;
+  let mutants: any[];
   let reporter: Reporter, configReaderMock: any, pluginLoaderMock: any;
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -52,6 +55,13 @@ describe('Stryker', function () {
     let reporterOrchestratorMock = {
       createBroadcastReporter: () => reporter
     };
+    let mutatorOrchestratorMock = {
+      generateMutants: () => mutants
+    };
+    let mutantRunResultMatcherMock = {
+      matchWithMutants: () => { }
+    }
+    mutants = [];
     testSelector = 'some test selector';
     testSelectorOrchestratorStub = {
       determineTestSelector: sandbox.stub().returns(testSelector)
@@ -59,6 +69,8 @@ describe('Stryker', function () {
 
     sandbox.stub(testSelectorOrchestrator, 'default').returns(testSelectorOrchestratorStub);
     sandbox.stub(reporterOrchestrator, 'default').returns(reporterOrchestratorMock);
+    sandbox.stub(mutatorOrchestrator, 'default').returns(mutatorOrchestratorMock);
+    sandbox.stub(mutantRunResultMatcher, 'default').returns(mutantRunResultMatcherMock);
     sandbox.stub(configReader, 'default').returns(configReaderMock);
     sandbox.stub(pluginLoader, 'default').returns(pluginLoaderMock);
     sandbox.stub(StrykerTempFolder, 'clean').returns(Promise.resolve());
@@ -92,6 +104,12 @@ describe('Stryker', function () {
     it('should load plugins', () => {
       expect(pluginLoader.default).to.have.been.calledWith(config.plugins);
       expect(pluginLoaderMock.load).to.have.been.calledWith();
+    });
+
+    it('should determine the testSelector', () => {
+      expect(testSelectorOrchestrator.default).to.have.been.calledWithNew;
+      expect(testSelectorOrchestrator.default).to.have.been.calledWith(config);
+      expect(testSelectorOrchestratorStub.determineTestSelector).to.have.been.called;
     });
   });
 
@@ -168,67 +186,84 @@ describe('Stryker', function () {
             initialRunResults.push({ result: TestResult.Complete, succeeded: 5 });
             initialRunResults.push({ result: TestResult.Complete, succeeded: 1 });
             strykerPromiseResolved = false;
-            strykerPromise = sut.runMutationTest().then(() => strykerPromiseResolved = true);
           });
 
-          it('should determine the testSelector', () => {
-            expect(testSelectorOrchestrator.default).to.have.been.calledWithNew;
-            expect(testSelectorOrchestrator.default).to.have.been.calledWith(config);
-            expect(testSelectorOrchestratorStub.determineTestSelector).to.have.been.called;
-          });
-
-          it('should not directly resolve the stryker promise', (done) => {
-            setTimeout(() => {
-              expect(strykerPromiseResolved).to.be.eq(false);
-              done();
-            }, 100);
-          });
-
-          describe('and running of mutators was successfull while reporter.wrapUp() results in void', () => {
+          let beforeEachRunMutationTest = () => {
             beforeEach(() => {
-              runMutationsPromiseResolve();
-              return strykerPromise;
+              strykerPromise = sut.runMutationTest().then(() => strykerPromiseResolved = true);
             });
-            it('should resolve the stryker promise', () => strykerPromise);
+          };
 
-            it('should have logged the amount of tests ran', () => {
-              expect(log.info).to.have.been.calledWith('Initial test run succeeded. Ran %s tests.', 6);
+          describe('but the mutator does not create any mutants', () => {
+            beforeEachRunMutationTest();
+
+            // wait for Stryker to finish
+            beforeEach(() => strykerPromise);
+
+            it('should log to have quite early', () => {
+              expect(log.info).to.have.been.calledWith('It\'s a mutant-free world, nothing to test.');
             });
 
-            it('should clean the stryker temp folder', () => expect(StrykerTempFolder.clean).to.have.been.called);
+            it('should not have ran mutations', () => {
+              expect(testRunnerOrchestratorStub.runMutations).not.to.have.been.called;
+            });
           });
 
-          describe('and running of mutators was successfull while reporter.wrapUp() results in a promise', () => {
-            let wrapUpDoneFn: Function;
-            beforeEach((done) => {
-              (<sinon.SinonStub>reporter.wrapUp).returns(new Promise((wrapUpDone) => wrapUpDoneFn = wrapUpDone));
-              runMutationsPromiseResolve();
-              setTimeout(done, 1); // give the wrapup promise some time to resolve and go to the next step (i don't know of any other way)
+          describe('and the mutator creates mutants', () => {
+            beforeEach(() => mutants.push({ a: 'mutant' }));
+            beforeEachRunMutationTest();
+            it('should not directly resolve the stryker promise', (done) => {
+              setTimeout(() => {
+                expect(strykerPromiseResolved).to.be.eq(false);
+                done();
+              }, 100);
             });
 
-            it('should let the reporters wrapUp any async tasks', () => {
-              expect(reporter.wrapUp).to.have.been.called;
-            });
-
-            it('should not yet have resolved the stryker promise', () => {
-              expect(strykerPromiseResolved).to.be.eq(false);
-            });
-
-            describe('and the reporter has wrapped up', () => {
-
+            describe('and running of mutators was successfull while reporter.wrapUp() results in void', () => {
               beforeEach(() => {
-                wrapUpDoneFn();
+                runMutationsPromiseResolve();
                 return strykerPromise;
               });
-
               it('should resolve the stryker promise', () => strykerPromise);
 
+              it('should have logged the amount of tests ran', () => {
+                expect(log.info).to.have.been.calledWith('Initial test run succeeded. Ran %s tests.', 6);
+              });
+
               it('should clean the stryker temp folder', () => expect(StrykerTempFolder.clean).to.have.been.called);
+            });
+
+            describe('and running of mutators was successfull while reporter.wrapUp() results in a promise', () => {
+              let wrapUpDoneFn: Function;
+              beforeEach((done) => {
+                (<sinon.SinonStub>reporter.wrapUp).returns(new Promise((wrapUpDone) => wrapUpDoneFn = wrapUpDone));
+                runMutationsPromiseResolve();
+                setTimeout(done, 1); // give the wrapup promise some time to resolve and go to the next step (i don't know of any other way)
+              });
+
+              it('should let the reporters wrapUp any async tasks', () => {
+                expect(reporter.wrapUp).to.have.been.called;
+              });
+
+              it('should not yet have resolved the stryker promise', () => {
+                expect(strykerPromiseResolved).to.be.eq(false);
+              });
+
+              describe('and the reporter has wrapped up', () => {
+
+                beforeEach(() => {
+                  wrapUpDoneFn();
+                  return strykerPromise;
+                });
+
+                it('should resolve the stryker promise', () => strykerPromise);
+
+                it('should clean the stryker temp folder', () => expect(StrykerTempFolder.clean).to.have.been.called);
+              });
             });
           });
         });
       });
-
     });
   });
 

--- a/test/unit/StrykerSpec.ts
+++ b/test/unit/StrykerSpec.ts
@@ -60,7 +60,7 @@ describe('Stryker', function () {
     };
     let mutantRunResultMatcherMock = {
       matchWithMutants: () => { }
-    }
+    };
     mutants = [];
     testSelector = 'some test selector';
     testSelectorOrchestratorStub = {


### PR DESCRIPTION
* Refactor stryker to now stop running where there are no mutants
* Make the main `runMutationTest()` method much clearer to understand by moving all details into seperate methods
* Make use of (parameter context matching)[http://es6-features.org/#ParameterContextMatching]