### PR TITLE
Add Node.js 6 & 7 to the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "7"
+  - "6"
   - "5"
   - "4"
   - "0.12"


### PR DESCRIPTION
Hi Y'all,

Node.js is [releasing quite fast](https://nodejs.org/en/download/releases/) nowadays. It would be cool if you could also test this against the last two versions (especially since 6 has a LTS release).  Since this was a quick implementation, I went ahead an just added the PR instead of discussing this in an issue first. If that's a problem feel free to close the PR anyway.

Some additional remarks:
- What about `node` as a version? this will install the latest stable release.
- I was going to add the lowest LTS versions of node here (`4.20` and `6.9.0`) but since Node.js is now semver updating shouldn't be a problem if users are experiencing a problem. Let me know if you would like to add `4.2.0` and `6.9.0` anyway.