### PR TITLE
Add latest node version to the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "node"
   - "7"
   - "6"
   - "5"


### PR DESCRIPTION
HI!

As a quick follow-up of #167 this PR will add `node` to the Travis build matrix to build against the latest stable release of node.js ([according to the docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Available-Versions)). 

Let me know if you need anything changed in this PR.
Cheers!
