### PR TITLE
fix(stryker.conf.js) Fix bithound status

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -6,5 +6,8 @@
     "test": [
         "test/**",
         "testResources/**"
-     ]
+     ],
+     "ignore": [
+        "testResources/config-reader/syntax-error.conf.js"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "lodash": "^3.10.1",
     "log4js": "^0.6.33",
     "mkdirp": "^0.5.1",
-    "node-glob": "^1.2.0",
     "serialize-javascript": "^1.3.0"
   },
   "devDependencies": {

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -7,4 +7,4 @@ module.exports = function (config) {
     testSelector: null,
     plugins: ['stryker-mocha-runner', 'stryker-html-reporter']
   });
-}
+};

--- a/testResources/config-reader/valid.conf.js
+++ b/testResources/config-reader/valid.conf.js
@@ -5,4 +5,4 @@ module.exports = function(config){
     'should': 'be',
     'read': true
   });  
-}
+};

--- a/testResources/module/stryker.conf.js
+++ b/testResources/module/stryker.conf.js
@@ -6,4 +6,4 @@ module.exports = function(config){
     testFramework: 'jasmine',
     testRunner: 'karma'
   });
-}
+};

--- a/testResources/sampleProject/stryker.conf.js
+++ b/testResources/sampleProject/stryker.conf.js
@@ -6,4 +6,4 @@ module.exports = function (config) {
     // testSelector: null,
     plugins: ['stryker-karma-runner']
   });
-}
+};


### PR DESCRIPTION
Builds no longer break when we have outdated dependencies. However, the build does break if we have an unused dependency.