### PR TITLE
feat(sandbox): Change cwd in `Sandbox`es

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "sinon-chai": "^2.8.0",
     "stryker-api": "^0.4.0",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.2"
+    "typescript": "~2.0.2"
   },
   "peerDependencies": {
     "stryker-api": "^0.4.0"

--- a/src/Sandbox.ts
+++ b/src/Sandbox.ts
@@ -1,12 +1,13 @@
 import * as path from 'path';
 import * as log4js from 'log4js';
 import * as _ from 'lodash';
-import { RunnerOptions, RunResult, StatementMap } from 'stryker-api/test_runner';
+import { RunResult, StatementMap } from 'stryker-api/test_runner';
 import { InputFile, StrykerOptions } from 'stryker-api/core';
 import { TestFramework } from 'stryker-api/test_framework';
 import { wrapInClosure } from './utils/objectUtils';
 import IsolatedTestRunnerAdapterFactory from './isolated-runner/IsolatedTestRunnerAdapterFactory';
 import IsolatedTestRunnerAdapter from './isolated-runner/IsolatedTestRunnerAdapter';
+import IsolatedRunnerOptions from './isolated-runner/IsolatedRunnerOptions';
 import StrykerTempFolder from './utils/StrykerTempFolder';
 import Mutant from './Mutant';
 import CoverageInstrumenter from './coverage/CoverageInstrumenter';
@@ -76,10 +77,11 @@ export default class Sandbox {
   private initializeTestRunner(): void | Promise<any> {
     let files = this.files.map(originalFile => <InputFile>_.assign(_.cloneDeep(originalFile), { path: this.fileMap[originalFile.path] }));
     files.unshift({ path: this.testHooksFile, mutated: false, included: true });
-    let settings: RunnerOptions = {
+    let settings: IsolatedRunnerOptions = {
       files,
       strykerOptions: this.options,
-      port: this.options.port + this.index
+      port: this.options.port + this.index,
+      sandboxWorkingFolder: this.workingFolder
     };
     log.debug(`Creating test runner %s using settings {port: %s}`, this.index, settings.port);
     this.testRunner = IsolatedTestRunnerAdapterFactory.create(settings);

--- a/src/isolated-runner/IsolatedRunnerOptions.ts
+++ b/src/isolated-runner/IsolatedRunnerOptions.ts
@@ -1,0 +1,7 @@
+import { RunnerOptions } from 'stryker-api/test_runner';
+
+interface IsolatedRunnerOptions extends RunnerOptions {
+  sandboxWorkingFolder: string;
+}
+
+export default IsolatedRunnerOptions;

--- a/src/isolated-runner/IsolatedTestRunnerAdapter.ts
+++ b/src/isolated-runner/IsolatedTestRunnerAdapter.ts
@@ -1,11 +1,12 @@
-import { TestRunner, RunResult, RunOptions, RunnerOptions, TestResult, RunStatus } from 'stryker-api/test_runner';
-import { StrykerOptions } from 'stryker-api/core';
-import { fork, ChildProcess } from 'child_process';
-import { AdapterMessage, WorkerMessage } from './MessageProtocol';
-import * as _ from 'lodash';
-import * as log4js from 'log4js';
 import { EventEmitter } from 'events';
+import * as log4js from 'log4js';
+import * as _ from 'lodash';
+import { fork, ChildProcess } from 'child_process';
+import { TestRunner, RunResult, RunOptions, TestResult, RunStatus } from 'stryker-api/test_runner';
+import { StrykerOptions } from 'stryker-api/core';
 import { serialize } from '../utils/objectUtils';
+import { AdapterMessage, WorkerMessage } from './MessageProtocol';
+import IsolatedRunnerOptions from './IsolatedRunnerOptions';
 
 const log = log4js.getLogger('IsolatedTestRunnerAdapter');
 const MAX_WAIT_FOR_DISPOSE = 2000;
@@ -27,7 +28,7 @@ export default class TestRunnerChildProcessAdapter extends EventEmitter implemen
   private currentRunStartedTimestamp: Date;
   private isDisposing: boolean;
 
-  constructor(private realTestRunnerName: string, private options: RunnerOptions) {
+  constructor(private realTestRunnerName: string, private options: IsolatedRunnerOptions) {
     super();
     this.startWorker();
   }

--- a/src/isolated-runner/IsolatedTestRunnerAdapterFactory.ts
+++ b/src/isolated-runner/IsolatedTestRunnerAdapterFactory.ts
@@ -1,8 +1,11 @@
-import { TestRunnerFactory, TestRunner, RunnerOptions } from 'stryker-api/test_runner';
+import { TestRunnerFactory, TestRunner } from 'stryker-api/test_runner';
 import IsolatedTestRunnerAdapter from './IsolatedTestRunnerAdapter';
+import IsolatedRunnerOptions from './IsolatedRunnerOptions';
+
+
 
 export default {
-  create(settings: RunnerOptions): IsolatedTestRunnerAdapter {
+  create(settings: IsolatedRunnerOptions): IsolatedTestRunnerAdapter {
     return new IsolatedTestRunnerAdapter(settings.strykerOptions.testRunner, settings);
   }
 };

--- a/src/isolated-runner/IsolatedTestRunnerAdapterWorker.ts
+++ b/src/isolated-runner/IsolatedTestRunnerAdapterWorker.ts
@@ -1,5 +1,5 @@
 import { AdapterMessage, RunMessage, StartMessage, ResultMessage, EmptyWorkerMessage, WorkerMessage } from './MessageProtocol';
-import { RunnerOptions, TestRunner, RunStatus, TestRunnerFactory, RunResult } from 'stryker-api/test_runner';
+import { TestRunner, RunStatus, TestRunnerFactory, RunResult } from 'stryker-api/test_runner';
 import PluginLoader from '../PluginLoader';
 import * as log4js from 'log4js';
 import { isPromise, deserialize } from '../utils/objectUtils';
@@ -42,6 +42,8 @@ class IsolatedTestRunnerAdapterWorker {
 
   start(message: StartMessage) {
     this.loadPlugins(message.runnerOptions.strykerOptions.plugins);
+    log.debug(`Changing current working directory for this process to ${message.runnerOptions.sandboxWorkingFolder}`);
+    process.chdir(message.runnerOptions.sandboxWorkingFolder);
     this.underlyingTestRunner = TestRunnerFactory.instance().create(message.runnerName, message.runnerOptions);
   }
 

--- a/src/isolated-runner/MessageProtocol.ts
+++ b/src/isolated-runner/MessageProtocol.ts
@@ -1,5 +1,6 @@
 import { RunResult, RunnerOptions } from 'stryker-api/test_runner';
 import { RunOptions } from 'stryker-api/test_runner';
+import IsolatedRunnerOptions from './IsolatedRunnerOptions';
 
 export type AdapterMessage = RunMessage | StartMessage | EmptyAdapterMessage;
 export type WorkerMessage = ResultMessage | EmptyWorkerMessage;
@@ -17,7 +18,7 @@ export interface RunMessage {
 export interface StartMessage {
   kind: 'start';
   runnerName: string;
-  runnerOptions: RunnerOptions;
+  runnerOptions: IsolatedRunnerOptions;
 }
 
 export interface EmptyAdapterMessage {

--- a/test/integration/isolated-runner/VerifyWorkingFolderTestRunner.ts
+++ b/test/integration/isolated-runner/VerifyWorkingFolderTestRunner.ts
@@ -1,0 +1,16 @@
+import { EventEmitter } from 'events';
+import { RunResult, RunStatus, RunOptions, TestRunner, TestRunnerFactory } from 'stryker-api/test_runner';
+class VerifyWorkingFolderTestRunner extends EventEmitter implements TestRunner {
+
+  runResult: RunResult = { status: RunStatus.Complete, tests: [] };
+
+  run(options: RunOptions) {
+   if (process.cwd() === __dirname) {
+      return Promise.resolve(this.runResult);
+    } else {
+      return Promise.reject(new Error(`Expected ${process.cwd()} to be ${__dirname}`));
+    }
+  }
+}
+
+TestRunnerFactory.instance().register('verify-working-folder', VerifyWorkingFolderTestRunner);

--- a/test/unit/SandboxSpec.ts
+++ b/test/unit/SandboxSpec.ts
@@ -1,14 +1,15 @@
-import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as path from 'path';
 import * as os from 'os';
+import { expect } from 'chai';
 import { StrykerOptions, InputFile } from 'stryker-api/core';
-import { RunnerOptions, RunResult } from 'stryker-api/test_runner';
+import { RunResult } from 'stryker-api/test_runner';
+import { wrapInClosure } from '../../src/utils/objectUtils';
 import CoverageInstrumenter from '../../src/coverage/CoverageInstrumenter';
 import Sandbox from '../../src/Sandbox';
 import StrykerTempFolder from '../../src/utils/StrykerTempFolder';
-import { wrapInClosure } from '../../src/utils/objectUtils';
 import IsolatedTestRunnerAdapterFactory from '../../src/isolated-runner/IsolatedTestRunnerAdapterFactory';
+import IsolatedRunnerOptions from '../../src/isolated-runner/IsolatedRunnerOptions';
 
 describe('Sandbox', () => {
   let sut: Sandbox;
@@ -87,14 +88,15 @@ describe('Sandbox', () => {
         .and.calledWith(files[1].path, path.join(workingFolder, 'file2')));
 
       it('should have created the isolated test runner inc framework hook', () => {
-        const expectedSettings: RunnerOptions = {
+        const expectedSettings: IsolatedRunnerOptions = {
           files: [
             { path: expectedTestFrameworkHooksFile, mutated: false, included: true },
             { path: expectedTargetFileToMutate, mutated: true, included: true },
             { path: path.join(workingFolder, 'file2'), mutated: false, included: false }
           ],
           port: 46,
-          strykerOptions: options
+          strykerOptions: options,
+          sandboxWorkingFolder: workingFolder
         };
         expect(IsolatedTestRunnerAdapterFactory.create).to.have.been.calledWith(expectedSettings);
       });
@@ -149,14 +151,15 @@ describe('Sandbox', () => {
       beforeEach(() => sut.initialize());
 
       it('should have created the isolated test runner', () => {
-        const expectedSettings: RunnerOptions = {
+        const expectedSettings: IsolatedRunnerOptions = {
           files: [
             { path: path.join(workingFolder, '___testHooksForStryker.js'), mutated: false, included: true },
             { path: path.join(workingFolder, 'file1'), mutated: true, included: true },
             { path: path.join(workingFolder, 'file2'), mutated: false, included: false }
           ],
           port: 46,
-          strykerOptions: options
+          strykerOptions: options,
+          sandboxWorkingFolder: workingFolder 
         };
         expect(IsolatedTestRunnerAdapterFactory.create).to.have.been.calledWith(expectedSettings);
       });

--- a/test/unit/isolated-runner/IsolatedTestRunnerAdapterSpec.ts
+++ b/test/unit/isolated-runner/IsolatedTestRunnerAdapterSpec.ts
@@ -1,7 +1,8 @@
 import * as child_process from 'child_process';
 import * as sinon from 'sinon';
-import { RunnerOptions, RunOptions, RunResult, RunStatus } from 'stryker-api/test_runner';
+import { RunOptions, RunResult, RunStatus } from 'stryker-api/test_runner';
 import IsolatedTestRunnerAdapter from '../../../src/isolated-runner/IsolatedTestRunnerAdapter';
+import IsolatedRunnerOptions from '../../../src/isolated-runner/IsolatedRunnerOptions';
 import { WorkerMessage, AdapterMessage, RunMessage, ResultMessage } from '../../../src/isolated-runner/MessageProtocol';
 import { serialize } from '../../../src/utils/objectUtils';
 import { expect } from 'chai';
@@ -13,12 +14,13 @@ describe('IsolatedTestRunnerAdapter', () => {
   let sinonSandbox: sinon.SinonSandbox;
   let clock: sinon.SinonFakeTimers;
   let fakeChildProcess: any;
-  let runnerOptions: RunnerOptions;
+  let runnerOptions: IsolatedRunnerOptions;
 
   beforeEach(() => {
     runnerOptions = {
       port: 42,
       files: [],
+      sandboxWorkingFolder: 'a working directory',
       strykerOptions: null
     };
     sinonSandbox = sinon.sandbox.create();


### PR DESCRIPTION
Change the current working directory for all isolated sandboxes. This is needed to remove unwanted side effects during test runs. For example RequireJS wasn't able to find files in combination with karma.

* Add new interface `IsolatedRunnerOptions`, which extends `RunnerOptions` with the addition of `SandboxWorkingFolder`
* Change working directory as soon as the IsoltatedTestRunnerAdapterWorker has loaded the plugins as they can be relative to the parent working directory.