### PR TITLE
refactor(mocha-sinon): Remove integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "karma-phantomjs-launcher": "^1.0.1",
     "load-grunt-tasks": "^3.5.0",
     "mocha": "^2.3.3",
-    "mocha-sinon": "^1.1.4",
     "sinon": "^1.17.2",
     "sinon-as-promised": "^4.0.2",
     "sinon-chai": "^2.8.0",

--- a/test/unit/utils/parserUtilsSpec.ts
+++ b/test/unit/utils/parserUtilsSpec.ts
@@ -2,7 +2,6 @@
 
 import { expect } from 'chai';
 import * as parserUtils from '../../../src/utils/parserUtils';
-require('mocha-sinon');
 
 describe('parserUtils', () => {
 


### PR DESCRIPTION
* Remove `mocha-sinon` integration layer. We don't use it anymore. Instead we use sinon sandboxes directly.