### PR TITLE
feat(ClearTextReporter): Limit the tests that the ClearTextReporter shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ These reporters can be used out of the box: `clear-text`, `progress` and `event-
 By default `clear-text` and `progress` are active if no reporter is configured.
 You can load additional plugins to get more reporters. See [stryker-mutator.github.io](http://stryker-mutator.github.io)
 for an up-to-date list of supported reporter plugins and a description on each reporter.
+
+The `clear-text` reporter supports an additional config option to show more tests that were executed to kill a mutant. The config for your config file is: `clearTextReporter: { maxTestsToLog: 3 },`
   
 #### Plugins
 **Command line:** `--plugins stryker-html-reporter,stryker-karma-runner`  

--- a/src/reporters/ClearTextReporter.ts
+++ b/src/reporters/ClearTextReporter.ts
@@ -98,13 +98,35 @@ export default class ClearTextReporter implements Reporter {
     });
     logImplementation('');
     if (this.options.coverageAnalysis === 'perTest') {
-      if (result.testsRan && result.testsRan.length > 0) {
-        logImplementation('Tests ran: ');
-        result.testsRan.forEach(spec => logImplementation('    ' + spec));
-        logImplementation('');
-      }
+      this.logExecutedTests(result, logImplementation);
     } else if (result.testsRan && result.testsRan.length > 0) {
       logImplementation('Ran all tests for this mutant.');
+    }
+  }
+
+  private logExecutedTests(result: MutantResult, logImplementation: (input: string) => void) {
+    const clearTextReporterConfig = this.options['clearTextReporter'];
+
+    if (result.testsRan && result.testsRan.length > 0) {
+      let testsToLog = 3;
+      if (clearTextReporterConfig && typeof clearTextReporterConfig.maxTestsToLog === 'number') {
+        testsToLog = clearTextReporterConfig.maxTestsToLog;
+      }
+
+      if (testsToLog > 0) {
+        logImplementation('Tests ran: ');
+        for (let i = 0; i < testsToLog; i++) {
+          if (i > result.testsRan.length - 1) {
+            break;
+          }
+
+          logImplementation('    ' + result.testsRan[i]);
+        }
+        if (testsToLog < result.testsRan.length) {
+          logImplementation(`  and ${result.testsRan.length - testsToLog} more tests!`);
+        }
+        logImplementation('');
+      }
     }
   }
 

--- a/test/unit/reporters/ClearTextReporterSpec.ts
+++ b/test/unit/reporters/ClearTextReporterSpec.ts
@@ -21,7 +21,7 @@ describe('ClearTextReporter', function () {
       beforeEach(() => {
         sut.onAllMutantsTested(mutantResults(MutantStatus.Killed, MutantStatus.Survived, MutantStatus.TimedOut, MutantStatus.NoCoverage));
       });
-      it('should not report the error', () => {        
+      it('should not report the error', () => {
         expect(process.stdout.write).to.not.have.been.calledWithMatch(sinon.match(/error/));
       });
     });
@@ -60,15 +60,68 @@ describe('ClearTextReporter', function () {
 
     describe('onAllMutantsTested()', () => {
 
-      beforeEach(() => {
-        sut.onAllMutantsTested(mutantResults(MutantStatus.Killed, MutantStatus.Survived, MutantStatus.TimedOut, MutantStatus.NoCoverage));
-      });
-
       it('should log individual ran tests', () => {
+        sut.onAllMutantsTested(mutantResults(MutantStatus.Killed, MutantStatus.Survived, MutantStatus.TimedOut, MutantStatus.NoCoverage));
         expect(process.stdout.write).to.have.been.calledWith('Tests ran: \n');
         expect(process.stdout.write).to.have.been.calledWith('    a test\n');
         expect(process.stdout.write).to.have.been.calledWith('    a second test\n');
+        expect(process.stdout.write).to.have.been.calledWith('    a third test\n');
         expect(process.stdout.write).to.not.have.been.calledWith('Ran all tests for this mutant.\n');
+      });
+
+      describe('with less tests that may be logged', () => {
+        it('should log less tests', () => {
+          sut = new ClearTextReporter({ coverageAnalysis: 'perTest', clearTextReporter: { maxTestsToLog: 1} });
+
+          sut.onAllMutantsTested(mutantResults(MutantStatus.Killed, MutantStatus.Survived, MutantStatus.TimedOut, MutantStatus.NoCoverage));
+
+          expect(process.stdout.write).to.have.been.calledWith('Tests ran: \n');
+          expect(process.stdout.write).to.have.been.calledWith('    a test\n');
+          expect(process.stdout.write).to.have.been.calledWith('  and 2 more tests!\n');
+          expect(process.stdout.write).to.not.have.been.calledWith('Ran all tests for this mutant.\n');
+        });
+      });
+
+      describe('with more tests that may be logged', () => {
+        it('should log all tests', () => {
+          sut = new ClearTextReporter({ coverageAnalysis: 'perTest', clearTextReporter: { maxTestsToLog: 10} });
+
+          sut.onAllMutantsTested(mutantResults(MutantStatus.Killed, MutantStatus.Survived, MutantStatus.TimedOut, MutantStatus.NoCoverage));
+
+          expect(process.stdout.write).to.have.been.calledWith('Tests ran: \n');
+          expect(process.stdout.write).to.have.been.calledWith('    a test\n');
+          expect(process.stdout.write).to.have.been.calledWith('    a second test\n');
+          expect(process.stdout.write).to.have.been.calledWith('    a third test\n');
+          expect(process.stdout.write).to.not.have.been.calledWith('Ran all tests for this mutant.\n');
+        });
+      });
+
+      describe('with the default amount of tests that may be logged', () => {
+        it('should log all tests', () => {
+          sut = new ClearTextReporter({ coverageAnalysis: 'perTest', clearTextReporter: { maxTestsToLog: 3} });
+
+          sut.onAllMutantsTested(mutantResults(MutantStatus.Killed, MutantStatus.Survived, MutantStatus.TimedOut, MutantStatus.NoCoverage));
+
+          expect(process.stdout.write).to.have.been.calledWith('Tests ran: \n');
+          expect(process.stdout.write).to.have.been.calledWith('    a test\n');
+          expect(process.stdout.write).to.have.been.calledWith('    a second test\n');
+          expect(process.stdout.write).to.have.been.calledWith('    a third test\n');
+          expect(process.stdout.write).to.not.have.been.calledWith('Ran all tests for this mutant.\n');
+        });
+      });
+
+      describe('with no tests that may be logged', () => {
+        it('should not log a test', () => {
+          sut = new ClearTextReporter({ coverageAnalysis: 'perTest', clearTextReporter: { maxTestsToLog: 0} });
+
+          sut.onAllMutantsTested(mutantResults(MutantStatus.Killed, MutantStatus.Survived, MutantStatus.TimedOut, MutantStatus.NoCoverage));
+
+          expect(process.stdout.write).to.not.have.been.calledWith('Tests ran: \n');
+          expect(process.stdout.write).to.not.have.been.calledWith('    a test\n');
+          expect(process.stdout.write).to.not.have.been.calledWith('    a second test\n');
+          expect(process.stdout.write).to.not.have.been.calledWith('    a third test\n');
+          expect(process.stdout.write).to.not.have.been.calledWith('Ran all tests for this mutant.\n');
+        });
       });
     });
   });
@@ -91,7 +144,7 @@ describe('ClearTextReporter', function () {
         expect(process.stdout.write).to.have.been.calledWith(`Mutation score based on covered code: n/a\n`));
 
       it('should report the average amount of tests ran', () =>
-        expect(process.stdout.write).to.have.been.calledWith(`Ran 2.00 tests per mutant on average.\n`));
+        expect(process.stdout.write).to.have.been.calledWith(`Ran 3.00 tests per mutant on average.\n`));
     });
   });
 
@@ -106,7 +159,7 @@ describe('ClearTextReporter', function () {
         originalLines: 'original line',
         replacement: '',
         sourceFilePath: '',
-        testsRan: ['a test', 'a second test'],
+        testsRan: ['a test', 'a second test', 'a third test'],
         status
       };
     });


### PR DESCRIPTION
Fixes #196 by limiting the amount of tests that are shown to 3. You can override this using the config file.