### PR TITLE
feat(append-only-progress): Implement new reporter

### DIFF
--- a/src/reporters/ProgressAppendOnlyReporter.ts
+++ b/src/reporters/ProgressAppendOnlyReporter.ts
@@ -1,0 +1,43 @@
+import { MatchedMutant, MutantResult, MutantStatus } from 'stryker-api/report';
+import * as chalk from 'chalk';
+import * as os from 'os';
+import ProgressKeeper from './ProgressKeeper';
+import Timer from '../utils/Timer';
+
+export default class ProgressAppendOnlyReporter extends ProgressKeeper {
+  private intervalReference: NodeJS.Timer;
+  private timer: Timer;
+
+  onAllMutantsMatchedWithTests(matchedMutants: ReadonlyArray<MatchedMutant>): void {
+    super.onAllMutantsMatchedWithTests(matchedMutants);
+    this.timer = new Timer();
+    this.intervalReference = setInterval(() => this.render(), 10000);
+  }
+
+  onAllMutantsTested(): void {
+    clearInterval(this.intervalReference);
+  }
+
+  private render() {
+    process.stdout.write(`Mutation testing ${this.procent()} (ETC ${this.etc()}) ` +
+      `[${this.progress.killed} ${this.progress.killedLabel}] ` +
+      `[${this.progress.survived} ${this.progress.survivedLabel}] ` +
+      `[${this.progress.noCoverage} ${this.progress.noCoverageLabel}] ` +
+      `[${this.progress.timeout} ${this.progress.timeoutLabel}] ` +
+      `[${this.progress.error} ${this.progress.errorLabel}]` +
+      os.EOL);
+  }
+
+  private procent() {
+    return Math.floor(this.progress.testedCount / this.progress.totalCount * 100) + '%';
+  }
+
+  private etc() {
+    const etcSeconds = Math.floor(this.timer.elapsedSeconds() / this.progress.testedCount * (this.progress.totalCount - this.progress.testedCount));
+    if (isFinite(etcSeconds)) {
+      return etcSeconds + 's';
+    } else {
+      return 'n/a';
+    }
+  }
+}

--- a/src/reporters/ProgressKeeper.ts
+++ b/src/reporters/ProgressKeeper.ts
@@ -1,0 +1,49 @@
+import * as chalk from 'chalk';
+import { MatchedMutant, Reporter, MutantResult, MutantStatus } from 'stryker-api/report';
+
+abstract class ProgressKeeper implements Reporter {
+
+  // progress contains Labels, because on initation of the ProgressBar the width is determined based on the amount of characters of the progressBarContent inclusive ASCII-codes for colors
+  protected progress = {
+    error: 0,
+    survived: 0,
+    killed: 0,
+    timeout: 0,
+    noCoverage: 0,
+    testedCount: 0,
+    totalCount: 0,
+    killedLabel: chalk.green.bold('killed'),
+    survivedLabel: chalk.red.bold('survived'),
+    noCoverageLabel: chalk.red.bold('no coverage'),
+    timeoutLabel: chalk.yellow.bold('timeout'),
+    errorLabel: chalk.yellow.bold('error')
+  };
+
+  onAllMutantsMatchedWithTests(matchedMutants: ReadonlyArray<MatchedMutant>): void {
+    this.progress.totalCount = matchedMutants.filter(m => m.scopedTestIds.length > 0).length;
+  }
+  
+  onMutantTested(result: MutantResult): void {
+    this.progress.testedCount++;
+    switch (result.status) {
+      case MutantStatus.NoCoverage:
+        this.progress.testedCount--; // correct for not tested, because no coverage
+        this.progress.noCoverage++;
+        break;
+      case MutantStatus.Killed:
+        this.progress.killed++;
+        break;
+      case MutantStatus.Survived:
+        this.progress.survived++;
+        break;
+      case MutantStatus.TimedOut:
+        this.progress.timeout++;
+        break;
+      case MutantStatus.Error:
+        this.progress.error++;
+        break;
+    }
+  }
+
+}
+export default ProgressKeeper;

--- a/src/reporters/ProgressReporter.ts
+++ b/src/reporters/ProgressReporter.ts
@@ -1,28 +1,14 @@
-import { Reporter, MatchedMutant, MutantResult, MutantStatus } from 'stryker-api/report';
+import { MatchedMutant, MutantResult, MutantStatus } from 'stryker-api/report';
+import ProgressKeeper from './ProgressKeeper';
 import ProgressBar from './ProgressBar';
 import * as chalk from 'chalk';
 
-export default class ProgressReporter implements Reporter {
+export default class ProgressBarReporter extends ProgressKeeper {
   private progressBar: ProgressBar;
 
-  // tickValues contains Labels, because on initation of the ProgressBar the width is determined based on the amount of characters of the progressBarContent inclusive ASCII-codes for colors
-  private tickValues = {
-    error: 0,
-    survived: 0,
-    killed: 0,
-    timeout: 0,
-    noCoverage: 0,
-    killedLabel: chalk.green.bold('killed'),
-    survivedLabel: chalk.red.bold('survived'),
-    noCoverageLabel: chalk.red.bold('no coverage'),
-    timeoutLabel: chalk.yellow.bold('timeout'),
-    errorLabel: chalk.yellow.bold('error')
-  };
-
   onAllMutantsMatchedWithTests(matchedMutants: ReadonlyArray<MatchedMutant>): void {
-    let progressBarContent: string;
-
-    progressBarContent =
+    super.onAllMutantsMatchedWithTests(matchedMutants);
+    const progressBarContent =
       `Mutation testing  [:bar] :percent (ETC :etas)` +
       `[:killed :killedLabel] ` +
       `[:survived :survivedLabel] ` +
@@ -34,36 +20,26 @@ export default class ProgressReporter implements Reporter {
       width: 50,
       complete: '=',
       incomplete: ' ',
-      total: matchedMutants.filter(m => m.scopedTestIds.length > 0).length
+      stream: process.stdout,
+      total: this.progress.totalCount
     });
   }
 
   onMutantTested(result: MutantResult): void {
-    switch (result.status) {
-      case MutantStatus.NoCoverage:
-        this.tickValues.noCoverage++;
-        this.progressBar.render(this.tickValues);
-        break;
-      case MutantStatus.Killed:
-        this.tickValues.killed++;
-        this.tick();
-        break;
-      case MutantStatus.Survived:
-        this.tickValues.survived++;
-        this.tick();
-        break;
-      case MutantStatus.TimedOut:
-        this.tickValues.timeout++;
-        this.tick();
-        break;
-      case MutantStatus.Error:
-        this.tickValues.error++;
-        this.tick();
-        break;
+    const ticksBefore = this.progress.testedCount;
+    super.onMutantTested(result);
+    if (ticksBefore < this.progress.testedCount) {
+      this.tick();
+    } else {
+      this.render();
     }
   }
 
-  tick(): void {
-    this.progressBar.tick(this.tickValues);
+  private tick(): void {
+    this.progressBar.tick(this.progress);
+  }
+
+  private render(): void {
+    this.progressBar.render(this.progress);
   }
 }

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -11,9 +11,13 @@ export default class Timer {
   }
 
   humanReadableElapsed() {
-    const elapsedMs = new Date().getTime() - this.start.getTime();
-    const elapsedSeconds = Math.floor(elapsedMs / 1000);
+    const elapsedSeconds = this.elapsedSeconds();
     return Timer.humanReadableElapsedMinutes(elapsedSeconds) + Timer.humanReadableElapsedSeconds(elapsedSeconds);
+  }
+
+  elapsedSeconds() {
+    const elapsedMs = new Date().getTime() - this.start.getTime();
+    return Math.floor(elapsedMs / 1000);
   }
 
   private static humanReadableElapsedSeconds(elapsedSeconds: number) {

--- a/test/helpers/producers.ts
+++ b/test/helpers/producers.ts
@@ -1,0 +1,29 @@
+import { MutantStatus, MatchedMutant, MutantResult } from 'stryker-api/report';
+
+export function mutantResult(status: MutantStatus): MutantResult {
+  return {
+    location: null,
+    mutatedLines: null,
+    mutatorName: null,
+    originalLines: null,
+    replacement: null,
+    sourceFilePath: null,
+    testsRan: null,
+    status,
+    range: null
+  };
+}
+
+export function matchedMutant(numberOfTests: number): MatchedMutant {
+  let scopedTestIds: number[] = [];
+  for (let i = 0; i < numberOfTests; i++) {
+    scopedTestIds.push(1);
+  }
+  return {
+    mutatorName: null,
+    scopedTestIds: scopedTestIds,
+    timeSpentScopedTests: null,
+    filename: null,
+    replacement: null
+  };
+}

--- a/test/unit/ReporterOrchestratorSpec.ts
+++ b/test/unit/ReporterOrchestratorSpec.ts
@@ -1,0 +1,60 @@
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import * as broadcastReporter from '../../src/reporters/BroadcastReporter';
+import ReporterOrchestrator from '../../src/ReporterOrchestrator';
+import { ReporterFactory } from 'stryker-api/report';
+
+describe('ReporterOrchestrator', () => {
+  let sandbox: sinon.SinonSandbox;
+  let sut: ReporterOrchestrator;
+  let isTTY: boolean;
+  let broadcastReporterMock: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    broadcastReporterMock = sandbox.stub(broadcastReporter, 'default');
+    captureTTY();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    restoreTTY();
+  });
+
+  it('should register default reporters', () => {
+    expect(ReporterFactory.instance().knownNames()).to.have.lengthOf(5);
+  });
+
+  describe('createBroadcastReporter()', () => {
+
+    // https://github.com/stryker-mutator/stryker/issues/212
+    it('should create "progress-append-only" instead of "progress" reporter if process.stdout is not a tty', () => {
+      setTTY(false);
+      sut = new ReporterOrchestrator({ reporter: 'progress' });
+      sut.createBroadcastReporter();
+      expect(broadcastReporterMock).to.have.been.calledWithNew;
+      expect(broadcastReporterMock).to.have.been.calledWith(sinon.match(
+        (reporters: broadcastReporter.NamedReporter[]) => reporters[0].name === 'progress-append-only'));
+    });
+
+    it('should create the correct reporters', () => {
+      setTTY(true);
+      sut = new ReporterOrchestrator({ reporter: ['progress', 'progress-append-only'] });
+      sut.createBroadcastReporter();
+      expect(broadcastReporterMock).to.have.been.calledWith(sinon.match(
+        (reporters: broadcastReporter.NamedReporter[]) => reporters[0].name === 'progress' && reporters[1].name === 'progress-append-only'));
+    });
+  });
+
+  function captureTTY() {
+    isTTY = (process.stdout as any)['isTTY'];
+  }
+
+  function restoreTTY() {
+    (process.stdout as any)['isTTY'] = isTTY;
+  }
+
+  function setTTY(val: boolean) {
+    (process.stdout as any)['isTTY'] = val;
+  }
+});

--- a/test/unit/reporters/ProgressAppendOnlyReporter.ts
+++ b/test/unit/reporters/ProgressAppendOnlyReporter.ts
@@ -4,6 +4,7 @@ import * as chalk from 'chalk';
 import { expect } from 'chai';
 import { MatchedMutant, MutantResult, MutantStatus } from 'stryker-api/report';
 import ProgressAppendOnlyReporter from '../../../src/reporters/ProgressAppendOnlyReporter';
+import { matchedMutant, mutantResult } from '../../helpers/producers';
 
 describe('ProgressAppendOnlyReporter', () => {
   let sut: ProgressAppendOnlyReporter;
@@ -51,29 +52,3 @@ describe('ProgressAppendOnlyReporter', () => {
     });
   });
 });
-function matchedMutant(numberOfTests: number): MatchedMutant {
-  let scopedTestIds: number[] = [];
-  for (let i = 0; i < numberOfTests; i++) {
-    scopedTestIds.push(1);
-  }
-  return {
-    mutatorName: null,
-    scopedTestIds: scopedTestIds,
-    timeSpentScopedTests: null,
-    filename: null,
-    replacement: null
-  };
-}
-function mutantResult(status: MutantStatus): MutantResult {
-  return {
-    location: null,
-    mutatedLines: null,
-    mutatorName: null,
-    originalLines: null,
-    replacement: null,
-    sourceFilePath: null,
-    testsRan: null,
-    status,
-    range: null
-  };
-}

--- a/test/unit/reporters/ProgressAppendOnlyReporter.ts
+++ b/test/unit/reporters/ProgressAppendOnlyReporter.ts
@@ -1,0 +1,79 @@
+import * as os from 'os';
+import * as sinon from 'sinon';
+import * as chalk from 'chalk';
+import { expect } from 'chai';
+import { MatchedMutant, MutantResult, MutantStatus } from 'stryker-api/report';
+import ProgressAppendOnlyReporter from '../../../src/reporters/ProgressAppendOnlyReporter';
+
+describe('ProgressAppendOnlyReporter', () => {
+  let sut: ProgressAppendOnlyReporter;
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sut = new ProgressAppendOnlyReporter();
+    sandbox = sinon.sandbox.create();
+    sandbox.useFakeTimers();
+    sandbox.stub(process.stdout, 'write');
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('onAllMutantsMatchedWithTests() with 2 mutant to test', () => {
+
+    beforeEach(() => {
+      sut.onAllMutantsMatchedWithTests([matchedMutant(1), matchedMutant(1)]);
+    });
+
+    it('should not show show progress directly', () => {
+      expect(process.stdout.write).to.not.have.been.called;
+    });
+
+    it('should log zero first progress after 10s without completed tests', () => {
+      sandbox.clock.tick(10000);
+      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 0% (ETC n/a) ` +
+        `[0 ${chalk.green.bold('killed')}] ` +
+        `[0 ${chalk.red.bold('survived')}] ` +
+        `[0 ${chalk.red.bold('no coverage')}] ` +
+        `[0 ${chalk.yellow.bold('timeout')}] ` +
+        `[0 ${chalk.yellow.bold('error')}]${os.EOL}`);
+    });
+
+    it('should should log 50% with 10s ETC after 10s with 1 completed test', () => {
+      sut.onMutantTested(mutantResult(MutantStatus.Killed));
+      expect(process.stdout.write).to.not.have.been.called;
+      sandbox.clock.tick(10000);
+      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 50% (ETC 10s) ` +
+        `[1 ${chalk.green.bold('killed')}] ` +
+        `[0 ${chalk.red.bold('survived')}] ` +
+        `[0 ${chalk.red.bold('no coverage')}] ` +
+        `[0 ${chalk.yellow.bold('timeout')}] ` +
+        `[0 ${chalk.yellow.bold('error')}]${os.EOL}`);
+    });
+  });
+});
+function matchedMutant(numberOfTests: number): MatchedMutant {
+  let scopedTestIds: number[] = [];
+  for (let i = 0; i < numberOfTests; i++) {
+    scopedTestIds.push(1);
+  }
+  return {
+    mutatorName: null,
+    scopedTestIds: scopedTestIds,
+    timeSpentScopedTests: null,
+    filename: null,
+    replacement: null
+  };
+}
+function mutantResult(status: MutantStatus): MutantResult {
+  return {
+    location: null,
+    mutatedLines: null,
+    mutatorName: null,
+    originalLines: null,
+    replacement: null,
+    sourceFilePath: null,
+    testsRan: null,
+    status,
+    range: null
+  };
+}

--- a/test/unit/reporters/ProgressReporterSpec.ts
+++ b/test/unit/reporters/ProgressReporterSpec.ts
@@ -1,9 +1,10 @@
-import ProgressReporter from '../../../src/reporters/ProgressReporter';
-import * as progressBarModule from '../../../src/reporters/ProgressBar';
-import { MutantStatus, MutantResult, MatchedMutant } from 'stryker-api/report';
-import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as chalk from 'chalk';
+import { expect } from 'chai';
+import { MutantStatus, MutantResult, MatchedMutant } from 'stryker-api/report';
+import ProgressReporter from '../../../src/reporters/ProgressReporter';
+import * as progressBarModule from '../../../src/reporters/ProgressBar';
+import { matchedMutant, mutantResult } from '../../helpers/producers';
 
 describe('ProgressReporter', () => {
 
@@ -129,31 +130,3 @@ describe('ProgressReporter', () => {
     });
   });
 });
-
-function mutantResult(status: MutantStatus): MutantResult {
-  return {
-    location: null,
-    mutatedLines: null,
-    mutatorName: null,
-    originalLines: null,
-    replacement: null,
-    sourceFilePath: null,
-    testsRan: null,
-    status,
-    range: null
-  };
-}
-
-function matchedMutant(numberOfTests: number): MatchedMutant {
-  let scopedTestIds: number[] = [];
-  for (let i = 0; i < numberOfTests; i++) {
-    scopedTestIds.push(1);
-  }
-  return {
-    mutatorName: null,
-    scopedTestIds: scopedTestIds,
-    timeSpentScopedTests: null,
-    filename: null,
-    replacement: null
-  };
-}


### PR DESCRIPTION
* Create a new progress reporter, one which only appends. It prints progress every 10 seconds.
* When the "progress" reporter is not used when the console does not support it.

fixes #212 