### PR TITLE
test(ReporterOrchestrator): Make test less strict

### DIFF
--- a/test/unit/ReporterOrchestratorSpec.ts
+++ b/test/unit/ReporterOrchestratorSpec.ts
@@ -21,7 +21,7 @@ describe('ReporterOrchestrator', () => {
     restoreTTY();
   });
 
-  it('should register default reporters', () => {
+  it('should at least register the 5 default reporters', () => {
     expect(ReporterFactory.instance().knownNames()).length.to.be.above(4);
   });
 

--- a/test/unit/ReporterOrchestratorSpec.ts
+++ b/test/unit/ReporterOrchestratorSpec.ts
@@ -22,7 +22,7 @@ describe('ReporterOrchestrator', () => {
   });
 
   it('should register default reporters', () => {
-    expect(ReporterFactory.instance().knownNames()).to.have.lengthOf(5);
+    expect(ReporterFactory.instance().knownNames()).length.to.be.above(4);
   });
 
   describe('createBroadcastReporter()', () => {


### PR DESCRIPTION
Test would break when adding the html reporter. Use global state for now, instead of mocking the dependency away.