### PR TITLE
chore(example): Remove `--configFile`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,10 +53,8 @@
       // "preLaunchTask": "build",
       "stopOnEntry": false,
       "args": [
-        "--configFile",
-        "testResources/sampleProject/stryker.conf.js",
-        "--logLevel",
-        "debug"
+        "run",
+        "testResources/sampleProject/stryker.conf.js"
       ],
       "cwd": "${workspaceRoot}",
       "runtimeExecutable": null,


### PR DESCRIPTION
Remove old `--configFile` option from Run stryker example config