### PR TITLE
refactor(build): Add ability to run build steps from a child package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "^2.2.2"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap && link-parent-bin",
+    "postinstall": "lerna bootstrap && link-parent-bin --log-level trace",
     "prebuild": "npm run clean-integration-test",
     "build": "lerna run build",
     "postbuild": "tsc -p integrationTest",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "postinstall": "lerna bootstrap && npm run link",
-    "link": "link-parent-bin --log-level trace",
+    "link": "link-parent-bin --log-level debug",
     "prebuild": "npm run clean-integration-test",
     "build": "lerna run build",
     "postbuild": "tsc -p integrationTest",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chai-as-promised": "^6.0.0",
     "concurrently": "^3.4.0",
     "lerna": "^2.0.0-rc.0",
-    "link-parent-bin": "^0.1.0",
+    "link-parent-bin": "^0.1.1",
     "mocha": "^3.2.0",
     "nyc": "^10.2.0",
     "rimraf": "^2.6.1",
@@ -33,8 +33,7 @@
     "typescript": "^2.2.2"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap && npm run link",
-    "link": "node tasks/link.js",
+    "postinstall": "lerna bootstrap && link-parent-bin",
     "prebuild": "npm run clean-integration-test",
     "build": "lerna run build",
     "postbuild": "tsc -p integrationTest",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "typescript": "^2.2.2"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap && link-parent-bin --log-level trace",
+    "postinstall": "lerna bootstrap && npm run link",
+    "link": "link-parent-bin --log-level trace",
     "prebuild": "npm run clean-integration-test",
     "build": "lerna run build",
     "postbuild": "tsc -p integrationTest",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "postinstall": "lerna bootstrap && npm run link",
-    "link": "link-parent-bin --log-level debug",
+    "link": "node tasks/link.js",
     "prebuild": "npm run clean-integration-test",
     "build": "lerna run build",
     "postbuild": "tsc -p integrationTest",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "chai-as-promised": "^6.0.0",
     "concurrently": "^3.4.0",
     "lerna": "^2.0.0-rc.0",
+    "link-parent-bin": "^0.1.0",
     "mocha": "^3.2.0",
     "nyc": "^10.2.0",
     "rimraf": "^2.6.1",
@@ -32,7 +33,7 @@
     "typescript": "^2.2.2"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna bootstrap && link-parent-bin",
     "prebuild": "npm run clean-integration-test",
     "build": "lerna run build",
     "postbuild": "tsc -p integrationTest",

--- a/tasks/link.js
+++ b/tasks/link.js
@@ -1,5 +1,0 @@
-const ParentBinLinker = require('link-parent-bin').ParentBinLinker;
-const linker = new ParentBinLinker({ childDirectoryRoot: 'packages', linkDevDependencies: true, linkDependencies: false });
-linker.linkBinsToChildren()
-    .then(() => console.log('done'))
-    .catch(err => console.error('Error Linking packages', err));

--- a/tasks/link.js
+++ b/tasks/link.js
@@ -1,0 +1,5 @@
+const ParentBinLinker = require('link-parent-bin').ParentBinLinker;
+const linker = new ParentBinLinker({ childDirectoryRoot: 'packages', linkDevDependencies: true, linkDependencies: false });
+linker.linkBinsToChildren()
+    .then(() => console.log('done'))
+    .catch(err => console.error('Error Linking packages', err));


### PR DESCRIPTION
Add the ability of running build steps from child packages. For example, run `npm test` from /packages/stryker. Done this by creating a plugin outside this repo and using it as dev dependency.