### PR TITLE
chore(pkg): Update keywords in package.json

### DIFF
--- a/packages/stryker-html-reporter/package.json
+++ b/packages/stryker-html-reporter/package.json
@@ -18,6 +18,7 @@
   "keywords": [
     "stryker",
     "stryker-plugin",
+    "stryker-reporter",
     "html",
     "report",
     "mutation",

--- a/packages/stryker-jasmine/package.json
+++ b/packages/stryker-jasmine/package.json
@@ -18,7 +18,8 @@
     "stryker",
     "jasmine",
     "stryker-plugin",
-    "stryker-test-framework"
+    "stryker-test-framework",
+    "stryker-karma-runner"
   ],
   "author": "nicojs",
   "license": "Apache-2.0",

--- a/packages/stryker-mocha-runner/package.json
+++ b/packages/stryker-mocha-runner/package.json
@@ -21,8 +21,7 @@
     "stryker",
     "stryker-plugin",
     "mocha",
-    "stryker-test-runner",
-    "stryker-mocha-runner"
+    "stryker-test-runner"
   ],
   "author": "Simon de Lang <simon.delang@infosupport.com>",
   "contributors": [

--- a/packages/stryker-mocha-runner/package.json
+++ b/packages/stryker-mocha-runner/package.json
@@ -21,11 +21,8 @@
     "stryker",
     "stryker-plugin",
     "mocha",
-    "test",
-    "runner",
-    "testrunner",
-    "mutation",
-    "testing"
+    "stryker-test-runner",
+    "stryker-mocha-runner"
   ],
   "author": "Simon de Lang <simon.delang@infosupport.com>",
   "contributors": [


### PR DESCRIPTION
Update keywords in package.json of the packages to specify if it is a
test runner, test framework or a reporter. This is useful to dynamically
query in `stryker init` command.