### PR TITLE
chore(node-8): Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 install: npm install
 before_install: 
   - if [[ `npm -v` = 2* ]]; then npm i -g npm@3; fi
+  - if [[ `npm -v` = 5* ]]; then npm i -g npm@4; fi
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Fix travis build by making sure node 5 is NOT used. It has a bug a.t.m. which makes integration tests fail:

https://github.com/npm/npm/issues/16812