### PR TITLE
fix(intializer): Remove install of `stryker` itself

### DIFF
--- a/packages/stryker/src/initializer/StrykerInitializer.ts
+++ b/packages/stryker/src/initializer/StrykerInitializer.ts
@@ -106,7 +106,7 @@ export default class StrykerInitializer {
   private installNpmDependencies(dependencies: string[]): void {
     if (dependencies.length > 0) {
       this.out('Installing NPM dependencies...');
-      const cmd = `npm i --save-dev stryker stryker-api ${dependencies.join(' ')}`;
+      const cmd = `npm i --save-dev stryker-api ${dependencies.join(' ')}`;
       this.out(cmd);
       try {
         child.execSync(cmd, { stdio: [0, 1, 2] });

--- a/packages/stryker/test/unit/initializer/StrykerInitializerSpec.ts
+++ b/packages/stryker/test/unit/initializer/StrykerInitializerSpec.ts
@@ -88,7 +88,7 @@ describe('StrykerInitializer', () => {
       inquirerPrompt.resolves({ testFramework: 'awesome', testRunner: 'awesome', reporters: ['dimension', 'mars'] });
       await sut.initialize();
       expect(out).to.have.been.calledWith('Installing NPM dependencies...');
-      expect(childExecSync).to.have.been.calledWith('npm i --save-dev stryker stryker-api stryker-awesome-runner stryker-awesome-framework stryker-dimension-reporter stryker-mars-reporter',
+      expect(childExecSync).to.have.been.calledWith('npm i --save-dev stryker-api stryker-awesome-runner stryker-awesome-framework stryker-dimension-reporter stryker-mars-reporter',
         { stdio: [0, 1, 2] });
     });
 
@@ -154,7 +154,7 @@ describe('StrykerInitializer', () => {
 
       it('should recover', async () => {
         await sut.initialize();
-        expect(out).to.have.been.calledWith('An error occurred during installation, please try it yourself: "npm i --save-dev stryker stryker-api stryker-ghost-runner"');
+        expect(out).to.have.been.calledWith('An error occurred during installation, please try it yourself: "npm i --save-dev stryker-api stryker-ghost-runner"');
         expect(fs.writeFile).to.have.been.called;
       });
     });


### PR DESCRIPTION
Remove the install of `stryker` itself on `stryker init`. This results in:

```bash
npm ERR! Error: EPERM: operation not permitted, open 'C:\Users\nicoj\example\node_modules\.bin\stryker'
```

(at least on windows)

Fixes #316