### PR TITLE
chore: Update changelogs

### DIFF
--- a/packages/grunt-stryker/CHANGELOG.md
+++ b/packages/grunt-stryker/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.5.2"></a>
+## 0.5.2 (2017-06-02)
+
+
+### Bug Fixes
+
+* **build:** Add npm test as preversion script ([c942b05](https://github.com/stryker-mutator/stryker/commit/c942b05))
+* **deps:** Add accept grunt >= 1.0.0 ([29131a5](https://github.com/stryker-mutator/stryker/commit/29131a5))
+* **deps:** Update stryker version ([04c5c1c](https://github.com/stryker-mutator/stryker/commit/04c5c1c))
+* **package.json:** Use most recent major versions (#296) ([57236d8](https://github.com/stryker-mutator/stryker/commit/57236d8))
+* **stryker:** Display stryker errors on the console instead of hiding them (#9) ([e29e582](https://github.com/stryker-mutator/stryker/commit/e29e582))
+
+
+### Features
+
+* **deps:** Stryker 0.4 upgrade (#4) ([44b2871](https://github.com/stryker-mutator/stryker/commit/44b2871))
+* Update stryker-api dependency to ^0.4.0 ([47dcad3](https://github.com/stryker-mutator/stryker/commit/47dcad3))
+* **lifetime-support:** Remove 0.12 node support ([f2fdd45](https://github.com/stryker-mutator/stryker/commit/f2fdd45))
+* **README:** Add downloads, node version and gitter badges (#8) ([20d7bcb](https://github.com/stryker-mutator/stryker/commit/20d7bcb))
+
+
 <a name="0.5.0"></a>
 # 0.5.0 (2017-04-21)
 

--- a/packages/stryker-api/CHANGELOG.md
+++ b/packages/stryker-api/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.5.1"></a>
+## 0.5.1 (2017-06-02)
+
+### Features
+
+* **report-score-result:** Report score result as tree (#309) ([965c575](https://github.com/stryker-mutator/stryker/commit/965c575))
+
 <a name="0.5.0"></a>
 # 0.5.0 (2017-04-21)
 

--- a/packages/stryker-html-reporter/CHANGELOG.md
+++ b/packages/stryker-html-reporter/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="0.4.2"></a>
+## 0.4.2 (2017-06-05)
+
+### Bug Fixes
+
+* **deps:** Alter stryker-api to be a peerDependency ([340487f](https://github.com/stryker-mutator/stryker/commit/340487f))
+* **deps:** Set version of stryker-api ([cf1f125](https://github.com/stryker-mutator/stryker/commit/cf1f125))
+
 <a name="0.3.0"></a>
 # [0.3.0](https://github.com/stryker-mutator/stryker-html-reporter/compare/v0.2.2...v0.3.0) (2016-11-20)
 

--- a/packages/stryker-jasmine/CHANGELOG.md
+++ b/packages/stryker-jasmine/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.2.2"></a>
+## 0.2.2 (2017-06-02)
+
 <a name="0.2.0"></a>
 # 0.2.0 (2017-04-21)
 

--- a/packages/stryker-karma-runner/CHANGELOG.md
+++ b/packages/stryker-karma-runner/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.4.1"></a>
+## 0.4.1 (2017-06-02)
+
 <a name="0.4.0"></a>
 # 0.4.0 (2017-04-21)
 

--- a/packages/stryker-mocha-framework/CHANGELOG.md
+++ b/packages/stryker-mocha-framework/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+<a name="0.4.0"></a>
+# [0.4.0](https://github.com/stryker-mutator/stryker/compare/stryker-mocha-runner@0.4.0...stryker-mocha-runner@0.4.0) (2017-06-02)
+
+### Bug Fixes
+
+* **deps:** Add stryker-api as peerDependency ([8b01a66](https://github.com/stryker-mutator/stryker/commit/8b01a66))
+* **deps:** Add typings as dev-dependency ([4ee866a](https://github.com/stryker-mutator/stryker/commit/4ee866a))
+* **deps:** Fix peer dependency version for mocha ([780ca90](https://github.com/stryker-mutator/stryker/commit/780ca90))
+* **deps:** Remove unused dependency ([121a549](https://github.com/stryker-mutator/stryker/commit/121a549))
+* **deps:** Remove unused dependency ([1f6dbba](https://github.com/stryker-mutator/stryker/commit/1f6dbba))
+* **deps:** Set version of stryker api ([49a1384](https://github.com/stryker-mutator/stryker/commit/49a1384))
+* **deps:** Update out dated dependencies ([cc0be9a](https://github.com/stryker-mutator/stryker/commit/cc0be9a))
+* **deps:** Update outdated dependencies ([0fc17be](https://github.com/stryker-mutator/stryker/commit/0fc17be))
+* **deps:** Update version stryker-api ([3a1a36c](https://github.com/stryker-mutator/stryker/commit/3a1a36c))
+* **index:** Add file which loads the TestRunner ([55fd132](https://github.com/stryker-mutator/stryker/commit/55fd132))
+* **package.json:** Use most recent major versions (#296) ([57236d8](https://github.com/stryker-mutator/stryker/commit/57236d8))
+* **TestRunner:** Add try-catch ([0c41fbf](https://github.com/stryker-mutator/stryker/commit/0c41fbf))
+* **tsconfig:** Extend base tsconfig and don't exclude typings folder (#298) ([622170b](https://github.com/stryker-mutator/stryker/commit/622170b))
+* **tslint:** Add linting ([9c360b2](https://github.com/stryker-mutator/stryker/commit/9c360b2))
+
+
+### Features
+
+* **es2015-promise:** Remove dep to es6-promise (#5) ([6f38885](https://github.com/stryker-mutator/stryker/commit/6f38885))
+* **mocha-framework:** Move mocha test framework to seperate package (#308) ([ae0074e](https://github.com/stryker-mutator/stryker/commit/ae0074e))* **one-pass-coverage:** Update test runner (#4) ([6716519](https://github.com/stryker-mutator/stryker/commit/6716519))
+* **ts2:** Migrate to typescript 2 ([0c9a655](https://github.com/stryker-mutator/stryker/commit/0c9a655))
+* **unincluded-files:** Support unincluded files ([80297bc](https://github.com/stryker-mutator/stryker/commit/80297bc))
+
+### BREAKING CHANGES
+
+* **mocha-framework:** Users with `testRunner: "mocha",testFramework: "mocha"` should now also install "stryker-mocha-framework".
+
+<a name="0.1.0"></a>
+# [0.1.0](https://github.com/stryker-mutator/stryker/compare/stryker-mocha-framework@0.1.0...stryker-mocha-framework@0.1.0) (2017-06-02)
+
+
+### Features
+
+* **mocha-framework:** Move mocha test framework to seperate package (#308) ([ae0074e](https://github.com/stryker-mutator/stryker/commit/ae0074e))
+
+
+### BREAKING CHANGES
+
+* **mocha-framework:** Users with `testRunner: "mocha",testFramework: "mocha"` should now also install "stryker-mocha-framework".

--- a/packages/stryker/CHANGELOG.md
+++ b/packages/stryker/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.6.3"></a>
+## 0.6.3 (2017-06-02)
+
+
+### Features
+
+* **Mutators:** Add Boolean substitution mutators (#294) ([a137a97](https://github.com/stryker-mutator/stryker/commit/a137a97))
+* **report-score-result:** Report score result as tree (#309) ([965c575](https://github.com/stryker-mutator/stryker/commit/965c575))
+
 <a name="0.6.0"></a>
 # 0.6.0 (2017-04-21)
 


### PR DESCRIPTION
I've noticed that Lerna did not update our changelogs in a long time. No clue yet why. Here is a manual update.