### PR TITLE
feat(ConfigReader): Add inform about init

### DIFF
--- a/packages/stryker/src/ConfigReader.ts
+++ b/packages/stryker/src/ConfigReader.ts
@@ -47,7 +47,7 @@ export default class ConfigReader {
         } else {
           log.fatal('Invalid config file!\n  ' + e.stack);
         }
-        log.info('Stryker can help you setup a `stryker.conf` file for your project.')
+        log.info('Stryker can help you setup a `stryker.conf` file for your project.');
         log.info('Please execute `stryker init` in your project\'s root directory.');
         process.exit(1);
       }

--- a/packages/stryker/src/ConfigReader.ts
+++ b/packages/stryker/src/ConfigReader.ts
@@ -47,6 +47,8 @@ export default class ConfigReader {
         } else {
           log.fatal('Invalid config file!\n  ' + e.stack);
         }
+        log.info('Stryker can help you setup a `stryker.conf` file for your project.')
+        log.info('Please execute `stryker init` in your project\'s root directory.');
         process.exit(1);
       }
       if (!_.isFunction(configModule)) {


### PR DESCRIPTION
Just some simple info logging to solve #332.

The output is now:
```
$ stryker run
[2017-07-14 19:39:23.916] [INFO] ConfigReader - Using stryker.conf.js in the current working directory.
[2017-07-14 19:39:23.919] [FATAL] ConfigReader - File ~/Development/infosupport/opensource/stryker/stryker-cli-test/stryker.conf.js does not exist!
[2017-07-14 19:39:23.919] [FATAL] ConfigReader - { Error: Cannot find module '~/Development/infosupport/opensource/stryker/stryker-cli-test/stryker.conf.js'
    at Function.Module._resolveFilename (module.js:485:15)
    at Function.Module._load (module.js:437:25)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at ConfigReader.loadConfigModule (~/Development/infosupport/opensource/stryker/stryker/packages/stryker/src/ConfigReader.js:38:32)
    at ConfigReader.loadConfigModule (~/Development/infosupport/opensource/stryker/stryker/packages/stryker/src/ConfigReader.js:60:25)
    at ConfigReader.readConfig (~/Development/infosupport/opensource/stryker/stryker/packages/stryker/src/ConfigReader.js:18:33)
    at new Stryker (~/Development/infosupport/opensource/stryker/stryker/packages/stryker/src/Stryker.js:42:36)
    at Object.run (~/Development/infosupport/opensource/stryker/stryker/packages/stryker/src/stryker-cli.js:56:31)
    at Object.<anonymous> (~/Development/infosupport/opensource/stryker/stryker/packages/stryker/src/stryker-cli.js:59:22) code: 'MODULE_NOT_FOUND' }
[2017-07-14 19:39:23.924] [INFO] ConfigReader - Stryker can help you setup a `stryker.conf` file for your project.
[2017-07-14 19:39:23.924] [INFO] ConfigReader - Please execute `stryker init` in your project's root directory
```