### PR TITLE
 test(own-dogfood): Add stryker-api files in stryker.conf.js

### DIFF
--- a/packages/stryker/stryker.conf.js
+++ b/packages/stryker/stryker.conf.js
@@ -1,10 +1,15 @@
 module.exports = function (config) {
   config.set({
-    files: ['test/helpers/**/*.js', 'test/unit/**/*.js', { pattern: 'src/**/*.js', included: false, mutated: true }],
+    files: [
+      'test/helpers/**/*.js',
+      'test/unit/**/*.js',
+      { pattern: 'src/**/*.js', included: false, mutated: true },
+      { pattern: 'node_modules/stryker-api/*.js', included: false, mutated: false },
+      { pattern: 'node_modules/stryker-api/!(node_modules)/**/*.js', included: false, mutated: false }],
     testFramework: 'mocha',
     testRunner: 'mocha',
     reporter: ['progress', 'clear-text', 'event-recorder'],
-    coverageAnalysis: 'all',
+    coverageAnalysis: 'perTest',
     logLevel: 'info',
     plugins: ['stryker-mocha-runner', 'stryker-mocha-framework']
   });

--- a/packages/stryker/stryker.conf.js
+++ b/packages/stryker/stryker.conf.js
@@ -5,7 +5,7 @@ module.exports = function (config) {
       'test/unit/**/*.js',
       { pattern: 'src/**/*.js', included: false, mutated: true },
       { pattern: 'node_modules/stryker-api/*.js', included: false, mutated: false },
-      { pattern: 'node_modules/stryker-api/!(node_modules)/**/*.js', included: false, mutated: false }],
+      { pattern: 'node_modules/stryker-api/src/**/*.js', included: false, mutated: false }],
     testFramework: 'mocha',
     testRunner: 'mocha',
     reporter: ['progress', 'clear-text', 'event-recorder'],

--- a/packages/stryker/test/helpers/registerSinonPlugins.ts
+++ b/packages/stryker/test/helpers/registerSinonPlugins.ts
@@ -1,1 +1,0 @@
-import 'sinon';

--- a/packages/stryker/test/unit/reporters/EventRecorderReporterSpec.ts
+++ b/packages/stryker/test/unit/reporters/EventRecorderReporterSpec.ts
@@ -74,22 +74,14 @@ describe('EventRecorderReporter', () => {
     describe('and cleanFolder results in a rejection', () => {
       let expectedError: Error;
       beforeEach(() => {
-        expectedError = new Error('Some error');
+        expectedError = new Error('Some error 1');
         cleanFolderStub.rejects(expectedError);
         sut = new EventRecorderReporter({});
       });
 
-      describe('and `wrapUp()` is called', () => {
-        let result: any;
-
-        beforeEach(() => {
-          let promise = <Promise<any>>sut.wrapUp();
-          return promise.then(() => result = true, (error: any) => result = error);
-        });
-
-        it('should reject', () => expect(result).to.be.eq(expectedError));
+      it('should reject when `wrapUp()` is called', () => {
+        expect(sut.wrapUp()).rejectedWith(expectedError);
       });
     });
   });
-
 });


### PR DESCRIPTION
When running stryker on stryker, we didn't include the stryker-api module in the test files. This meant that every sandbox shared the stryker-api files with the `IsolatedtestRunnerAdapterWorker` child process. Since we now have a `MochaConfigWriter`, that one is always added to the `ConfigWriterFactory`. It polluted the tests in the sandbox, resulting in an initial test failure.