### PR TITLE
chore(build): Make build ts 2.5 compatible

### DIFF
--- a/packages/stryker-html-reporter/.vscode/settings.json
+++ b/packages/stryker-html-reporter/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "typescript.tsdk": "${workspaceRoot}/../../node_modules/typescript/lib",
+  "typescript.tsdk": "${workspaceRoot}/../../../node_modules/typescript/lib",
   "files": {
     "exclude": {
       ".git": "",

--- a/packages/stryker-html-reporter/package.json
+++ b/packages/stryker-html-reporter/package.json
@@ -46,7 +46,6 @@
   "devDependencies": {
     "@types/file-url": "^1.0.28",
     "@types/rimraf": "0.0.28",
-    "@types/selenium-webdriver": "^3.0.3",
     "bootstrap": "3.3.7",
     "highlight.js": "^9.4.0",
     "stryker-api": "^0.8.0"

--- a/packages/stryker-karma-runner/test/integration/KarmaTestRunner.it.ts
+++ b/packages/stryker-karma-runner/test/integration/KarmaTestRunner.it.ts
@@ -75,7 +75,7 @@ describe('KarmaTestRunner', function () {
     });
   });
 
-  describe('when an error occures while running tests', () => {
+  describe('when an error occurs while running tests', () => {
 
     before(() => {
       const testRunnerOptions = {
@@ -100,7 +100,7 @@ describe('KarmaTestRunner', function () {
     });
   });
 
-  describe('when no error occured and no test is performed', () => {
+  describe('when no error occurred and no test is performed', () => {
     before(() => {
       const testRunnerOptions = {
         files: [{ path: 'testResources/sampleProject/src/Add.js', mutated: true, included: true }, { path: 'testResources/sampleProject/test/EmptySpec.js', mutated: true, included: true }],
@@ -164,7 +164,7 @@ describe('KarmaTestRunner', function () {
     it('should report coverage data', () => expect(sut.run()).to.eventually.satisfy((runResult: RunResult) => {
       expect(runResult.coverage).to.be.ok;
       expect(runResult.status).to.be.eq(RunStatus.Complete);
-      const files = Object.keys(runResult.coverage);
+      const files = Object.keys(runResult.coverage || {});
       expect(files).to.have.length(1);
       const coverageResult = (runResult.coverage as CoverageCollection)[files[0]];
       expect(coverageResult.s).to.be.ok;


### PR DESCRIPTION
Make the build [TypeScript 2.5.2](https://github.com/Microsoft/TypeScript/releases/tag/v2.5.2) compatible:

* Make `KarmaTestRunner.ts` compatible with new `Object.keys` signature.
* Remove types of selenium-webdriver. We don't really need them and they are not yet compatible with 2.5