### PR TITLE
refactor(stryker task): Move stryker require inside stryker task (#362)

### DIFF
--- a/packages/grunt-stryker/tasks/stryker.js
+++ b/packages/grunt-stryker/tasks/stryker.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var Stryker = require('stryker').default;
-
 module.exports = function (grunt) {
 
   grunt.registerMultiTask('stryker', 'The extendable JavaScript mutation testing framework.', function () {
+    var Stryker = require('stryker').default;
     var target = this.name + "." + this.target + ".";
     var filesProperty = target + 'files';
     var mutateProperty = target + 'mutate';


### PR DESCRIPTION
Only running the Stryker grunt task should cause 'stryker' to be required. Also guards against upstream tasks clearing require cache.