### PR TITLE
fix(sandbox): Prevent hanging child processes

### DIFF
--- a/packages/stryker/src/Sandbox.ts
+++ b/packages/stryker/src/Sandbox.ts
@@ -29,7 +29,7 @@ export default class Sandbox {
   private workingFolder: string;
   private testHooksFile = path.resolve('___testHooksForStryker.js');
 
-  constructor(private options: Config, private index: number, files: ReadonlyArray<File>, private testFramework: TestFramework | null, private coverageInstrumenter: CoverageInstrumenter | null) {
+  private constructor(private options: Config, private index: number, files: ReadonlyArray<File>, private testFramework: TestFramework | null, private coverageInstrumenter: CoverageInstrumenter | null) {
     this.workingFolder = TempFolder.instance().createRandomFolder('sandbox');
     log.debug('Creating a sandbox for files in %s', this.workingFolder);
     this.files = files.slice(); // Create a copy
@@ -46,9 +46,15 @@ export default class Sandbox {
     }
   }
 
-  public async initialize(): Promise<void> {
+  private async initialize(): Promise<void> {
     await this.fillSandbox();
     return this.initializeTestRunner();
+  }
+
+  public static create(options: Config, index: number, files: ReadonlyArray<File>, testFramework: TestFramework | null, coverageInstrumenter: CoverageInstrumenter | null)
+    : Promise<Sandbox> {
+    const sandbox = new Sandbox(options, index, files, testFramework, coverageInstrumenter);
+    return sandbox.initialize().then(() => sandbox);
   }
 
   public run(timeout: number): Promise<RunResult> {

--- a/packages/stryker/src/process/InitialTestExecutor.ts
+++ b/packages/stryker/src/process/InitialTestExecutor.ts
@@ -57,8 +57,7 @@ export default class InitialTestExecutor {
       throw new Error(`Could not transpile input files: ${transpileResult.error}`);
     } else {
       this.logTranspileResult(transpileResult);
-      const sandbox = new Sandbox(this.options, 0, transpileResult.outputFiles, this.testFramework, this.coverageInstrumenter);
-      await sandbox.initialize();
+      const sandbox = await Sandbox.create(this.options, 0, transpileResult.outputFiles, this.testFramework, this.coverageInstrumenter);
       const runResult = await sandbox.run(INITIAL_RUN_TIMEOUT);
       await sandbox.dispose();
       return { runResult, transpiledFiles: transpileResult.outputFiles };

--- a/packages/stryker/src/process/MutationTestExecutor.ts
+++ b/packages/stryker/src/process/MutationTestExecutor.ts
@@ -9,7 +9,7 @@ import TranspiledMutant from '../TranspiledMutant';
 import StrictReporter from '../reporters/StrictReporter';
 import TestableMutant from '../TestableMutant';
 import MutantTranspiler from '../transpiler/MutantTranspiler';
-import SandboxCoordinator from '../SandboxCoordinator';
+import SandboxPool from '../SandboxPool';
 
 export default class MutationTestExecutor {
 
@@ -18,7 +18,7 @@ export default class MutationTestExecutor {
   }
 
   async run(allMutants: TestableMutant[]): Promise<MutantResult[]> {
-    const sandboxPool = new SandboxCoordinator(this.config, this.testFramework, this.transpiledFiles);
+    const sandboxPool = new SandboxPool(this.config, this.testFramework, this.transpiledFiles);
     const mutantTranspiler = new MutantTranspiler(this.config);
     await mutantTranspiler.initialize(this.inputFiles);
     const result = await this.runInsideSandboxes(

--- a/packages/stryker/test/unit/SandboxPoolSpec.ts
+++ b/packages/stryker/test/unit/SandboxPoolSpec.ts
@@ -2,15 +2,14 @@ import { File } from 'stryker-api/core';
 import * as os from 'os';
 import { expect } from 'chai';
 import { Config } from 'stryker-api/config';
-import SandboxCoordinator from '../../src/SandboxCoordinator';
+import SandboxPool from '../../src/SandboxPool';
 import { TestFramework } from 'stryker-api/test_framework';
 import { Mock, mock, testFramework, textFile, config } from '../helpers/producers';
-import * as strykerSandbox from '../../src/Sandbox';
 import Sandbox from '../../src/Sandbox';
 import '../helpers/globals';
 
-describe('SandboxCoordinator', () => {
-  let sut: SandboxCoordinator;
+describe('SandboxPool', () => {
+  let sut: SandboxPool;
   let firstSandbox: Mock<Sandbox>;
   let secondSandbox: Mock<Sandbox>;
   let options: Config;
@@ -23,50 +22,44 @@ describe('SandboxCoordinator', () => {
     expectedTestFramework = testFramework();
     coverageInstrumenter = 'a coverage instrumenter';
     firstSandbox = mock(Sandbox);
-    firstSandbox.initialize.resolves();
     firstSandbox.dispose.resolves();
     secondSandbox = mock(Sandbox);
-    secondSandbox.initialize.resolves();
     secondSandbox.dispose.resolves();
-    const genericSandboxForAllSubsequentCallsToNewSandbox = mock(Sandbox);
-    genericSandboxForAllSubsequentCallsToNewSandbox.initialize.resolves();
+    const genericSandboxForAllSubsequentCallsToNewSandbox = mock<Sandbox>(Sandbox);
     genericSandboxForAllSubsequentCallsToNewSandbox.dispose.resolves();
-    global.sandbox.stub(strykerSandbox, 'default')
-      .returns(genericSandboxForAllSubsequentCallsToNewSandbox)
-      .onCall(0).returns(firstSandbox)
-      .onCall(1).returns(secondSandbox);
+    global.sandbox.stub(Sandbox, 'create')
+      .resolves(genericSandboxForAllSubsequentCallsToNewSandbox)
+      .onCall(0).resolves(firstSandbox)
+      .onCall(1).resolves(secondSandbox);
 
     expectedInputFiles = [textFile()];
-    sut = new SandboxCoordinator(options, expectedTestFramework, expectedInputFiles);
+    sut = new SandboxPool(options, expectedTestFramework, expectedInputFiles);
   });
 
   describe('streamSandboxes', () => {
     it('should use maxConcurrentTestRunners when set', async () => {
       options.maxConcurrentTestRunners = 1;
       await sut.streamSandboxes().toArray().toPromise();
-      expect(strykerSandbox.default).calledWithNew;
-      expect(strykerSandbox.default).to.have.callCount(1);
-      expect(strykerSandbox.default).calledWith(options, 0, expectedInputFiles, expectedTestFramework, null);
+      expect(Sandbox.create).to.have.callCount(1);
+      expect(Sandbox.create).calledWith(options, 0, expectedInputFiles, expectedTestFramework, null);
     });
 
     it('should use cpuCount when maxConcurrentTestRunners is set too high', async () => {
       global.sandbox.stub(os, 'cpus').returns([1, 2, 3]); // stub 3 cpus
       options.maxConcurrentTestRunners = 100;
       const actual = await sut.streamSandboxes().toArray().toPromise();
-      expect(strykerSandbox.default).calledWithNew;
       expect(actual).lengthOf(3);
-      expect(strykerSandbox.default).to.have.callCount(3);
-      expect(strykerSandbox.default).calledWith(options, 0, expectedInputFiles, expectedTestFramework, null);
+      expect(Sandbox.create).to.have.callCount(3);
+      expect(Sandbox.create).calledWith(options, 0, expectedInputFiles, expectedTestFramework, null);
     });
 
     it('should use the cpuCount when maxConcurrentTestRunners is <= 0', async () => {
       global.sandbox.stub(os, 'cpus').returns([1, 2, 3]); // stub 3 cpus
       options.maxConcurrentTestRunners = 0;
       const actual = await sut.streamSandboxes().toArray().toPromise();
-      expect(strykerSandbox.default).calledWithNew;
-      expect(strykerSandbox.default).to.have.callCount(3);
+      expect(Sandbox.create).to.have.callCount(3);
       expect(actual).lengthOf(3);
-      expect(strykerSandbox.default).calledWith(options, 0, expectedInputFiles, expectedTestFramework, null);
+      expect(Sandbox.create).calledWith(options, 0, expectedInputFiles, expectedTestFramework, null);
     });
 
     it('should use the cpuCount - 1 when a transpiler is configured', async () => {
@@ -74,8 +67,16 @@ describe('SandboxCoordinator', () => {
       options.maxConcurrentTestRunners = 2;
       global.sandbox.stub(os, 'cpus').returns([1, 2]); // stub 2 cpus
       const actual = await sut.streamSandboxes().toArray().toPromise();
-      expect(strykerSandbox.default).to.have.callCount(1);
+      expect(Sandbox.create).to.have.callCount(1);
       expect(actual).lengthOf(1);
+    });
+
+    // see https://github.com/stryker-mutator/stryker/issues/396
+    it('should dispose the newly created sandboxes if the sandbox pool is already disposed', async () => {
+      await sut.disposeAll();
+      const actualSandboxes = await sut.streamSandboxes().toArray().toPromise();
+      actualSandboxes.forEach(actual => expect(actual.dispose).called);
+      expect(actualSandboxes).to.have.length.greaterThan(0);
     });
   });
   describe('dispose', () => {

--- a/packages/stryker/test/unit/process/InitialTestExecutorSpec.ts
+++ b/packages/stryker/test/unit/process/InitialTestExecutorSpec.ts
@@ -1,6 +1,5 @@
 import { EOL } from 'os';
 import { expect } from 'chai';
-import * as strykerSandbox from '../../../src/Sandbox';
 import { default as StrykerSandbox } from '../../../src/Sandbox';
 import InitialTestExecutor, { InitialTestRunResult } from '../../../src/process/InitialTestExecutor';
 import { File } from 'stryker-api/core';
@@ -29,7 +28,7 @@ describe('InitialTestExecutor run', () => {
   beforeEach(() => {
     strykerSandboxMock = producers.mock(StrykerSandbox);
     transpilerFacadeMock = producers.mock(TranspilerFacade);
-    sandbox.stub(strykerSandbox, 'default').returns(strykerSandboxMock);
+    sandbox.stub(StrykerSandbox, 'create').resolves(strykerSandboxMock);
     sandbox.stub(transpilerFacade, 'default').returns(transpilerFacadeMock);
     testFrameworkMock = producers.testFramework();
     coverageInstrumenter = new CoverageInstrumenter('off', testFrameworkMock);
@@ -66,13 +65,11 @@ describe('InitialTestExecutor run', () => {
 
     it('should create a sandbox with correct arguments', async () => {
       await sut.run();
-      expect(strykerSandbox.default).calledWith(options, 0, transpileResultMock.outputFiles, testFrameworkMock, coverageInstrumenter);
-      expect(strykerSandbox.default).calledWithNew;
+      expect(StrykerSandbox.create).calledWith(options, 0, transpileResultMock.outputFiles, testFrameworkMock, coverageInstrumenter);
     });
 
     it('should initialize, run and dispose the sandbox', async () => {
       await sut.run();
-      expect(strykerSandboxMock.initialize).to.have.been.called;
       expect(strykerSandboxMock.run).to.have.been.calledWith(60 * 1000 * 5);
       expect(strykerSandboxMock.dispose).to.have.been.called;
     });


### PR DESCRIPTION
* Rename `SandboxCoordinator` -> `SandboxPool`
* Make sure newly created sandboxes are also disposed if the SandboxPool is already disposed

fixes #396