### PR TITLE
fix(ConfigReader): Use CLI options with default config file

### DIFF
--- a/packages/stryker/src/ConfigReader.ts
+++ b/packages/stryker/src/ConfigReader.ts
@@ -2,6 +2,7 @@ import { Config } from 'stryker-api/config';
 import { StrykerOptions } from 'stryker-api/core';
 import * as fs from 'mz/fs';
 import * as log4js from 'log4js';
+import * as path from 'path';
 import * as _ from 'lodash';
 
 const VALID_COVERAGE_ANALYSIS_VALUES = ['perTest', 'all', 'off'];
@@ -42,7 +43,7 @@ export default class ConfigReader {
 
     if (!this.cliOptions.configFile) {
       try {
-        fs.accessSync(`${process.cwd()}/${DEFAULT_CONFIG_FILE}`);
+        fs.accessSync(path.resolve(`./${DEFAULT_CONFIG_FILE}`));
         log.info(`Using ${DEFAULT_CONFIG_FILE} in the current working directory.`);
         this.cliOptions.configFile = DEFAULT_CONFIG_FILE;
       } catch (e) {

--- a/packages/stryker/src/ConfigReader.ts
+++ b/packages/stryker/src/ConfigReader.ts
@@ -48,6 +48,7 @@ export default class ConfigReader {
         this.cliOptions.configFile = DEFAULT_CONFIG_FILE;
       } catch (e) {
         log.info('No config file specified. Running with command line arguments.');
+        log.info('Use `stryker init` command to generate your config file.');
       }
     }
 

--- a/packages/stryker/test/integration/config-reader/ConfigReaderSpec.ts
+++ b/packages/stryker/test/integration/config-reader/ConfigReaderSpec.ts
@@ -49,14 +49,15 @@ describe('ConfigReader', () => {
         });
 
         describe('without a stryker.conf.js in the CWD', () => {
-          it('should report a fatal error', () => {
+          it('should return default config', () => {
             let mockCwd = process.cwd() + '/testResources/config-reader/no-config';
             sandbox.stub(process, 'cwd').returns(mockCwd);
+
             sut = new ConfigReader({});
 
             result = sut.readConfig(); 
 
-            expect(log.fatal).to.have.been.calledWith(`File ${mockCwd}/stryker.conf.js does not exist!`);
+            expect(result).to.deep.equal(new Config());
           });
         });
       });
@@ -77,16 +78,24 @@ describe('ConfigReader', () => {
     });
 
     describe('with config file', () => {
-
-      beforeEach(() => {
-        sut = new ConfigReader({ configFile: 'testResources/config-reader/valid.conf.js' });
-        result = sut.readConfig();
-      });
-
       it('should read config file', () => {
+        sut = new ConfigReader({ configFile: 'testResources/config-reader/valid.conf.js' });
+
+        result = sut.readConfig();
+
         expect(result['valid']).to.be.eq('config');
         expect(result['should']).to.be.eq('be');
         expect(result['read']).to.be.eq(true);
+      });
+
+      describe('with CLI options', () => {
+        it('should give precedence to CLI options', () => {
+          sut = new ConfigReader({ configFile: 'testResources/config-reader/valid.conf.js', read: false });
+
+          result = sut.readConfig();
+
+          expect(result['read']).to.be.eq(false);
+        });
       });
     });
 


### PR DESCRIPTION
Change ConfigReader behavior to always use stryker.conf.js if present. CLI
options override options from the file.

Run does not fail anymore if a CLI option, but no config file is specified.
closes #390