### PR TITLE
feat(html reporter): Make report gh-pages compatible

### DIFF
--- a/integrationTest/test/karma-jasmine/verify/verify.ts
+++ b/integrationTest/test/karma-jasmine/verify/verify.ts
@@ -19,12 +19,12 @@ describe('Verify stryker has ran correctly', () => {
 
     it('should copy over the resources', () => {
       return Promise.all([
-        expectFileExists('reports/mutation/html/__resources/stryker.css'),
-        expectFileExists('reports/mutation/html/__resources/stryker.js'),
-        expectFileExists('reports/mutation/html/__resources/stryker-80x80.png'),
-        expectFileExists('reports/mutation/html/__resources/bootstrap/css/bootstrap.min.css'),
-        expectFileExists('reports/mutation/html/__resources/bootstrap/js/bootstrap.min.js'),
-        expectFileExists('reports/mutation/html/__resources/highlightjs/styles/default.css')
+        expectFileExists('reports/mutation/html/strykerResources/stryker.css'),
+        expectFileExists('reports/mutation/html/strykerResources/stryker.js'),
+        expectFileExists('reports/mutation/html/strykerResources/stryker-80x80.png'),
+        expectFileExists('reports/mutation/html/strykerResources/bootstrap/css/bootstrap.min.css'),
+        expectFileExists('reports/mutation/html/strykerResources/bootstrap/js/bootstrap.min.js'),
+        expectFileExists('reports/mutation/html/strykerResources/highlightjs/styles/default.css')
       ]);
     });
   });

--- a/integrationTest/test/mocha-mocha/verify/verify.ts
+++ b/integrationTest/test/mocha-mocha/verify/verify.ts
@@ -19,12 +19,12 @@ describe('Verify stryker has ran correctly', () => {
 
     it('should copy over the resources', () => {
       return Promise.all([
-        expectFileExists('reports/mutation/html/__resources/stryker.css'),
-        expectFileExists('reports/mutation/html/__resources/stryker.js'),
-        expectFileExists('reports/mutation/html/__resources/stryker-80x80.png'),
-        expectFileExists('reports/mutation/html/__resources/bootstrap/css/bootstrap.min.css'),
-        expectFileExists('reports/mutation/html/__resources/bootstrap/css/bootstrap.min.css'),
-        expectFileExists('reports/mutation/html/__resources/highlightjs/styles/default.css')
+        expectFileExists('reports/mutation/html/strykerResources/stryker.css'),
+        expectFileExists('reports/mutation/html/strykerResources/stryker.js'),
+        expectFileExists('reports/mutation/html/strykerResources/stryker-80x80.png'),
+        expectFileExists('reports/mutation/html/strykerResources/bootstrap/css/bootstrap.min.css'),
+        expectFileExists('reports/mutation/html/strykerResources/bootstrap/css/bootstrap.min.css'),
+        expectFileExists('reports/mutation/html/strykerResources/highlightjs/styles/default.css')
       ]);
     });
   });

--- a/integrationTest/test/typescript-transpiling/verify/verify.ts
+++ b/integrationTest/test/typescript-transpiling/verify/verify.ts
@@ -19,12 +19,12 @@ describe('Verify stryker has ran correctly', () => {
 
     it('should copy over the resources', () => {
       return Promise.all([
-        expectFileExists('reports/mutation/html/__resources/stryker.css'),
-        expectFileExists('reports/mutation/html/__resources/stryker.js'),
-        expectFileExists('reports/mutation/html/__resources/stryker-80x80.png'),
-        expectFileExists('reports/mutation/html/__resources/bootstrap/css/bootstrap.min.css'),
-        expectFileExists('reports/mutation/html/__resources/bootstrap/css/bootstrap.min.css'),
-        expectFileExists('reports/mutation/html/__resources/highlightjs/styles/default.css')
+        expectFileExists('reports/mutation/html/strykerResources/stryker.css'),
+        expectFileExists('reports/mutation/html/strykerResources/stryker.js'),
+        expectFileExists('reports/mutation/html/strykerResources/stryker-80x80.png'),
+        expectFileExists('reports/mutation/html/strykerResources/bootstrap/css/bootstrap.min.css'),
+        expectFileExists('reports/mutation/html/strykerResources/bootstrap/css/bootstrap.min.css'),
+        expectFileExists('reports/mutation/html/strykerResources/highlightjs/styles/default.css')
       ]);
     });
   });

--- a/packages/stryker-html-reporter/src/HtmlReporter.ts
+++ b/packages/stryker-html-reporter/src/HtmlReporter.ts
@@ -9,6 +9,7 @@ import Breadcrumb from './Breadcrumb';
 
 const log = log4js.getLogger('HtmlReporter');
 const DEFAULT_BASE_FOLDER = path.normalize('reports/mutation/html');
+export const RESOURCES_DIR_NAME = 'strykerResources';
 
 export default class HtmlReporter implements Reporter {
 
@@ -99,7 +100,7 @@ export default class HtmlReporter implements Reporter {
   }
 
   private get resourcesDir() {
-    return path.join(this.baseDir, '__resources');
+    return path.join(this.baseDir, RESOURCES_DIR_NAME);
   }
 
   private get baseDir() {

--- a/packages/stryker-html-reporter/src/templates/layout.tsx
+++ b/packages/stryker-html-reporter/src/templates/layout.tsx
@@ -1,5 +1,6 @@
 import * as typedHtml from 'typed-html';
 import Breadcrumb from '../Breadcrumb';
+import { RESOURCES_DIR_NAME } from '../HtmlReporter';
 
 function printBreadcrumbLinks(breadcrumb: Breadcrumb | undefined, pageDepth: number): string {
     if (breadcrumb) {
@@ -20,7 +21,7 @@ function printBreadcrumb(breadcrumb: Breadcrumb) {
 }
 
 export function layout(breadcrumb: Breadcrumb, content: string) {
-    const urlPrefix = Array(breadcrumb.depth + 1).join('../') + '__resources/';
+    const urlPrefix = Array(breadcrumb.depth + 1).join('../') + RESOURCES_DIR_NAME + '/';
     return '<!DOCTYPE html>\n' + <html>
         <head>
             <title>{breadcrumb.title} - Stryker report</title>

--- a/packages/stryker-html-reporter/test/integration/StrykerReportSpec.ts
+++ b/packages/stryker-html-reporter/test/integration/StrykerReportSpec.ts
@@ -36,7 +36,7 @@ describe('Html report of stryker', function () {
       'Stryker.js.html': 'Stryker.js.html',
       'stryker-cli.js.html': 'stryker-cli.js.html',
       'TestFrameworkOrchestrator.js.html': 'TestFrameworkOrchestrator.js.html',
-      '__resources': {
+      'strykerResources': {
         'popper.js': {
           'dist': {
             'umd': {

--- a/packages/stryker-html-reporter/test/integration/singleFileInFolderSpec.ts
+++ b/packages/stryker-html-reporter/test/integration/singleFileInFolderSpec.ts
@@ -29,6 +29,6 @@ describe('HtmlReporter single file in a folder', () => {
     expect(dir.math).deep.eq({
       'Add.js.html': 'Add.js.html'
     });
-    expect(fs.readFileSync(path.resolve(REPORT_DIR, 'math', 'Add.js.html'), 'utf8')).contains('"../__resources/bootstrap/css/bootstrap.min.css"');
+    expect(fs.readFileSync(path.resolve(REPORT_DIR, 'math', 'Add.js.html'), 'utf8')).contains('"../strykerResources/bootstrap/css/bootstrap.min.css"');
   });
 });

--- a/packages/stryker-html-reporter/test/unit/HtmlReporter.spec.ts
+++ b/packages/stryker-html-reporter/test/unit/HtmlReporter.spec.ts
@@ -39,8 +39,8 @@ describe('HtmlReporter', () => {
       sut.onAllMutantsTested([]);
       sut.onScoreCalculated(scoreResult());
       await sut.wrapUp();
-      expect(copyFolderStub).calledWith(join(__dirname, '..', '..', 'src', 'resources', 'stryker'), normalize('reports/mutation/html/__resources'));
-      expect(copyFolderStub).calledWith(join(__dirname, '..', '..', 'resources'), normalize('reports/mutation/html/__resources'));
+      expect(copyFolderStub).calledWith(join(__dirname, '..', '..', 'src', 'resources', 'stryker'), normalize('reports/mutation/html/strykerResources'));
+      expect(copyFolderStub).calledWith(join(__dirname, '..', '..', 'resources'), normalize('reports/mutation/html/strykerResources'));
     });
 
     it('should write an html report', async () => {
@@ -57,7 +57,7 @@ describe('HtmlReporter', () => {
         sinon.match(normalize('reports/mutation/html/a.js.html')),
         sinon.match('10.67%')
           .and(sinon.match('<span class="badge badge-info stryker-mutant-replacement" hidden="hidden" data-mutant="0">{}</span>'))
-          .and(sinon.match('<link rel="stylesheet" href="__resources/bootstrap/css/bootstrap.min.css">')));
+          .and(sinon.match('<link rel="stylesheet" href="strykerResources/bootstrap/css/bootstrap.min.css">')));
       expect(writeFileStub).calledWithMatch(
         sinon.match(normalize('reports/mutation/html/b.js.html')),
         sinon.match('10.67%'));
@@ -84,8 +84,8 @@ describe('HtmlReporter', () => {
       await sut.wrapUp();
       expect(writeFileStub).calledWith(
         normalize('reports/mutation/html/a/b/c.js.html'),
-        sinon.match('<link rel="stylesheet" href="../../__resources/bootstrap/css/bootstrap.min.css">')
-          .and(sinon.match('<script src="../../__resources/stryker.js" defer="defer"></script>')));
+        sinon.match('<link rel="stylesheet" href="../../strykerResources/bootstrap/css/bootstrap.min.css">')
+          .and(sinon.match('<script src="../../strykerResources/stryker.js" defer="defer"></script>')));
     });
 
     it('should not fail when input files are missing', async () => {


### PR DESCRIPTION
Rename `__resources` to `strykerResources` as folders starting with `_` are not served by github by default.

closes #420 