### PR TITLE
fix(init stryker typescript): Add init section

### DIFF
--- a/packages/stryker-karma-runner/package.json
+++ b/packages/stryker-karma-runner/package.json
@@ -53,9 +53,6 @@
   ],
   "initStrykerConfig": {
     "karmaConfigFile": "karma.conf.js",
-    "files": [],
-    "mutate": [
-      "src/**/*.js"
-    ]
+    "files": []
   }
 }

--- a/packages/stryker-typescript/package.json
+++ b/packages/stryker-typescript/package.json
@@ -56,9 +56,6 @@
     "tsconfigFile": "tsconfig.json",
     "files": [],
     "coverageAnalysis": "off",
-    "transpilers": [
-      "typescript"
-    ],
     "mutate": [
       "src/**/*.ts"
     ]

--- a/packages/stryker-typescript/package.json
+++ b/packages/stryker-typescript/package.json
@@ -56,7 +56,6 @@
     "tsconfigFile": "tsconfig.json",
     "files": [],
     "coverageAnalysis": "off",
-    "mutator": "typescript",
     "transpilers": [
       "typescript"
     ],

--- a/packages/stryker-typescript/package.json
+++ b/packages/stryker-typescript/package.json
@@ -51,5 +51,17 @@
   "peerDependencies": {
     "stryker-api": "^0.11.0",
     "typescript": "^2.5.0"
+  },
+  "initStrykerConfig": {
+    "tsconfigFile": "tsconfig.json",
+    "files": [],
+    "coverageAnalysis": "off",
+    "mutator": "typescript",
+    "transpilers": [
+      "typescript"
+    ],
+    "mutate": [
+      "src/**/*.ts"
+    ]
   }
 }


### PR DESCRIPTION
* Add a `initStrykerConfig` section to the stryker-typescript package.json file. 
* Remove `mutate` section from `stryker-karma-runner`. A test runner shouldn't force mutation of certain files.

Closes #454