### PR TITLE
feat(typescript-mutator): Implement new ArrowFunctionMutator

### DIFF
--- a/packages/stryker-typescript/src/TypescriptMutator.ts
+++ b/packages/stryker-typescript/src/TypescriptMutator.ts
@@ -17,6 +17,7 @@ import ForStatementMutator from './mutator/ForStatementMutator';
 import DoStatementMutator from './mutator/DoStatementMutator';
 import ConditionalExpressionMutator from './mutator/ConditionalExpressionMutator';
 import PrefixUnaryExpressionMutator from './mutator/PrefixUnaryExpressionMutator';
+import ArrowFunctionMutator from './mutator/ArrowFunctionMutator';
 
 export default class TypescriptMutator {
 
@@ -27,6 +28,7 @@ export default class TypescriptMutator {
     new ArrayLiteralMutator(),
     new ArrayNewExpressionMutator(),
     new BlockMutator(),
+    new ArrowFunctionMutator(),
     new IfStatementMutator(),
     new WhileStatementMutator(),
     new ForStatementMutator(),

--- a/packages/stryker-typescript/src/mutator/ArrowFunctionMutator.ts
+++ b/packages/stryker-typescript/src/mutator/ArrowFunctionMutator.ts
@@ -1,0 +1,20 @@
+import * as ts from 'typescript';
+import NodeMutator, { NodeReplacement } from './NodeMutator';
+
+export default class ArrowFunctionMutator extends NodeMutator<ts.ArrowFunction> {
+  name = 'ArrowFunction';
+
+  guard(node: ts.Node): node is ts.ArrowFunction {
+    return node.kind === ts.SyntaxKind.ArrowFunction;
+  }
+
+  protected identifyReplacements(fn: ts.ArrowFunction, sourceFile: ts.SourceFile): NodeReplacement[] {
+    if (fn.body.kind === ts.SyntaxKind.Block) {
+      // This case is already handled by the BlockMutator.
+      return [];
+    }
+
+    return [{ node: fn, replacement: '() => undefined' }];
+  }
+
+}

--- a/packages/stryker-typescript/test/unit/mutator/ArrowFunctionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ArrowFunctionMutatorSpec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { expectMutation } from './mutatorAssertions';
+import ArrowFunctionMutator from '../../../src/mutator/ArrowFunctionMutator';
+
+describe('ArrowFunctionMutator', () => {
+
+  let sut: ArrowFunctionMutator;
+
+  beforeEach(() => {
+    sut = new ArrowFunctionMutator();
+  });
+
+  it('should have name "ArrowFunction"', () => {
+    expect(sut.name).eq('ArrowFunction');
+  });
+
+  it('should mutate an anonymous function with an inline return', () => {
+    expectMutation(sut, 'const b = () => 4;', 'const b = () => undefined;');
+  });
+
+  it('should not mutate an anonymous function with a block as a body', () => {
+    expectMutation(sut, 'const b = () => { return 4; }');
+  });
+
+});

--- a/packages/stryker-typescript/test/unit/mutator/BlockMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/BlockMutatorSpec.ts
@@ -26,5 +26,12 @@ describe('BlockMutator', () => {
     expectMutation(sut, 'function() {  }');
   });
 
-  
+  it('should mutate the body of an anonymous function if defined as a block', () => {
+    expectMutation(sut, 'const b = () => { return 4; }', 'const b = () => {}');
+  });
+
+  it('should not mutate the body of an anonymous function if not defined as a block', () => {
+    expectMutation(sut, 'const b = () => 4;');
+  });
+
 });


### PR DESCRIPTION
The current implementation of BlockMutator doesn't catch anonymous
functions that use the shorthard return value syntax such as:

```
const lengthOf = (s: string) => s.length
```

Closes #456 