### PR TITLE
feat(typescript-mutation): Add a StringLiteral mutator.

### DIFF
--- a/packages/stryker-typescript/src/TypescriptMutator.ts
+++ b/packages/stryker-typescript/src/TypescriptMutator.ts
@@ -18,6 +18,7 @@ import DoStatementMutator from './mutator/DoStatementMutator';
 import ConditionalExpressionMutator from './mutator/ConditionalExpressionMutator';
 import PrefixUnaryExpressionMutator from './mutator/PrefixUnaryExpressionMutator';
 import ArrowFunctionMutator from './mutator/ArrowFunctionMutator';
+import StringLiteralMutator from './mutator/StringLiteralMutator';
 
 export default class TypescriptMutator {
 
@@ -34,7 +35,8 @@ export default class TypescriptMutator {
     new ForStatementMutator(),
     new DoStatementMutator(),
     new ConditionalExpressionMutator(),
-    new PrefixUnaryExpressionMutator()
+    new PrefixUnaryExpressionMutator(),
+    new StringLiteralMutator(),
   ]) { }
 
   mutate(inputFiles: File[]): Mutant[] {

--- a/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
+++ b/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
@@ -20,7 +20,20 @@ export default class StringLiteralMutator extends NodeMutator<AllStringLiterals>
   }
 
   protected identifyReplacements(str: AllStringLiterals, sourceFile: ts.SourceFile): NodeReplacement[] {
-    return [{ node: str, replacement: '""' }];
+    if (
+      // Check for empty strings first.
+      (str.kind === ts.SyntaxKind.StringLiteral && str.text === '')
+      // Only check for the Token form of template literals. It's impossible to have a TemplateExpression
+      // that is empty as it's only used when there is a value embedded. I haven't found a case where the
+      // cast fails but the worst that can happen is it is undefined and we fall through to the wrong statement.
+      || (str.kind === ts.SyntaxKind.FirstTemplateToken && (str as ts.Node & { text: string }).text === '')
+    ) {
+      console.log(str);
+      return [{ node: str, replacement: '"Stryker was here!"' }];
+    }
+    else {
+      return [{ node: str, replacement: '""' }];
+    }
   }
 
 }

--- a/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
+++ b/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
@@ -11,7 +11,6 @@ export type AllStringLiterals =
 
 export default class StringLiteralMutator extends NodeMutator<AllStringLiterals> {
   name = 'StringLiteral';
-  imports: string[] = [];
 
   guard(node: ts.Node): node is AllStringLiterals {
     return node.kind === ts.SyntaxKind.StringLiteral
@@ -20,6 +19,10 @@ export default class StringLiteralMutator extends NodeMutator<AllStringLiterals>
   }
 
   protected identifyReplacements(str: AllStringLiterals, sourceFile: ts.SourceFile): NodeReplacement[] {
+    if (str.parent && str.parent.kind === ts.SyntaxKind.ImportDeclaration) {
+      return [];
+    }
+
     if (
       // Check for empty strings first.
       (str.kind === ts.SyntaxKind.StringLiteral && str.text === '')
@@ -28,7 +31,6 @@ export default class StringLiteralMutator extends NodeMutator<AllStringLiterals>
       // cast fails but the worst that can happen is it is undefined and we fall through to the wrong statement.
       || (str.kind === ts.SyntaxKind.FirstTemplateToken && (str as ts.Node & { text: string }).text === '')
     ) {
-      console.log(str);
       return [{ node: str, replacement: '"Stryker was here!"' }];
     }
     else {

--- a/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
+++ b/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
@@ -1,0 +1,26 @@
+import * as ts from 'typescript';
+import NodeMutator, { NodeReplacement } from './NodeMutator';
+
+export type AllStringLiterals =
+  // Regular quoted string.
+  | ts.StringLiteral
+  // Templates string with values embedded.
+  | ts.TemplateExpression
+  // A raw token is emitted if the template string has no embeds.
+  | ts.Token<ts.SyntaxKind.FirstTemplateToken>;
+
+export default class StringLiteralMutator extends NodeMutator<AllStringLiterals> {
+  name = 'StringLiteral';
+  imports: string[] = [];
+
+  guard(node: ts.Node): node is AllStringLiterals {
+    return node.kind === ts.SyntaxKind.StringLiteral
+      || node.kind === ts.SyntaxKind.TemplateExpression
+      || node.kind === ts.SyntaxKind.FirstTemplateToken;
+  }
+
+  protected identifyReplacements(str: AllStringLiterals, sourceFile: ts.SourceFile): NodeReplacement[] {
+    return [{ node: str, replacement: '""' }];
+  }
+
+}

--- a/packages/stryker-typescript/test/integration/sampleSpec.ts
+++ b/packages/stryker-typescript/test/integration/sampleSpec.ts
@@ -41,7 +41,7 @@ describe('Sample integration', function () {
     // Generate mutants
     const mutator = new TypescriptMutator(config);
     const mutants = mutator.mutate(inputFiles);
-    expect(mutants.length).to.eq(7);
+    expect(mutants.length).to.eq(5);
   });
 
   it('should be able to transpile source code', async () => {

--- a/packages/stryker-typescript/test/integration/sampleSpec.ts
+++ b/packages/stryker-typescript/test/integration/sampleSpec.ts
@@ -27,7 +27,7 @@ describe('Sample integration', function () {
       name: file as string,
       content: fs.readFileSync(file as string, 'utf8'),
       included: true,
-      mutated: true, 
+      mutated: true,
       transpiled: true,
       kind: FileKind.Text
     }));
@@ -41,7 +41,7 @@ describe('Sample integration', function () {
     // Generate mutants
     const mutator = new TypescriptMutator(config);
     const mutants = mutator.mutate(inputFiles);
-    expect(mutants.length).to.eq(4);
+    expect(mutants.length).to.eq(7);
   });
 
   it('should be able to transpile source code', async () => {
@@ -74,7 +74,7 @@ describe('Sample integration', function () {
       name: file.name,
       content: file.content.slice(0, mutant.range[0]) + mutant.replacement + file.content.slice(mutant.range[1]),
       mutated: true,
-      included: true, 
+      included: true,
       transpiled: true,
       kind: FileKind.Text
     };

--- a/packages/stryker-typescript/test/unit/mutator/StringLiteralMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/StringLiteralMutatorSpec.ts
@@ -26,15 +26,9 @@ describe('StringLiteralMutator', () => {
     expectMutation(sut, 'const b = `Hello world!`;', 'const b = "";');
   });
 
-  it('should mutate a template string referencing another variable (AST 1)', () => {
+  it('should mutate a template string referencing another variabled', () => {
     expectMutation(sut, 'const a = 10; const b = `${a} mutations`;', 'const a = 10; const b = "";');
-  });
-
-  it('should mutate a template string referencing another variable (AST 2)', () => {
     expectMutation(sut, 'const a = 10; const b = `mutations: ${a}`;', 'const a = 10; const b = "";');
-  });
-
-  it('should mutate a template string referencing another variable (AST 3)', () => {
     expectMutation(sut, 'const a = 10; const b = `mutations: ${a} out of 10`;', 'const a = 10; const b = "";');
   });
 
@@ -46,11 +40,11 @@ describe('StringLiteralMutator', () => {
     expectMutation(sut, 'const b = ``;', 'const b = "Stryker was here!";');
   });
 
-  it('should mutate import statements', () => {
-    // It would be best if this wasn't actually the case. Thanks to the lack of context (ie. node.parent) it
-    // doesn't seem possible right now. This will virtually always end up in a compile error so shouldn't
-    // affect throughput.
-    expectMutation(sut, 'import * as foo from "foo";', 'import * as foo from "";');
+  it('should not mutate import statements', () => {
+    expectMutation(sut, 'import * as foo from "foo";');
+    expectMutation(sut, 'import { foo } from "foo";');
+    expectMutation(sut, 'import foo from "foo";');
+    expectMutation(sut, 'import "foo";');
   });
 
 });

--- a/packages/stryker-typescript/test/unit/mutator/StringLiteralMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/StringLiteralMutatorSpec.ts
@@ -26,16 +26,24 @@ describe('StringLiteralMutator', () => {
     expectMutation(sut, 'const b = `Hello world!`;', 'const b = "";');
   });
 
-  it('should mutate a template string referencing another variable', () => {
+  it('should mutate a template string referencing another variable (AST 1)', () => {
     expectMutation(sut, 'const a = 10; const b = `${a} mutations`;', 'const a = 10; const b = "";');
   });
 
-  it('should mutate a template string referencing another variable', () => {
+  it('should mutate a template string referencing another variable (AST 2)', () => {
     expectMutation(sut, 'const a = 10; const b = `mutations: ${a}`;', 'const a = 10; const b = "";');
   });
 
-  it('should mutate a template string referencing another variable', () => {
+  it('should mutate a template string referencing another variable (AST 3)', () => {
     expectMutation(sut, 'const a = 10; const b = `mutations: ${a} out of 10`;', 'const a = 10; const b = "";');
+  });
+
+  it('should mutate empty strings', () => {
+    expectMutation(sut, 'const b = "";', 'const b = "Stryker was here!";');
+  });
+
+  it('should mutate empty template strings', () => {
+    expectMutation(sut, 'const b = ``;', 'const b = "Stryker was here!";');
   });
 
   it('should mutate import statements', () => {

--- a/packages/stryker-typescript/test/unit/mutator/StringLiteralMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/StringLiteralMutatorSpec.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { expectMutation } from './mutatorAssertions';
+import StringLiteralMutator from '../../../src/mutator/StringLiteralMutator';
+
+describe('StringLiteralMutator', () => {
+
+  let sut: StringLiteralMutator;
+
+  beforeEach(() => {
+    sut = new StringLiteralMutator();
+  });
+
+  it('should have name "StringLiteral"', () => {
+    expect(sut.name).eq('StringLiteral');
+  });
+
+  it('should mutate a string literal with double quotes', () => {
+    expectMutation(sut, 'const b = "Hello world!";', 'const b = "";');
+  });
+
+  it('should mutate a string literal with single quotes', () => {
+    expectMutation(sut, 'const b = \'Hello world!\';', 'const b = "";');
+  });
+
+  it('should mutate a template string', () => {
+    expectMutation(sut, 'const b = `Hello world!`;', 'const b = "";');
+  });
+
+  it('should mutate a template string referencing another variable', () => {
+    expectMutation(sut, 'const a = 10; const b = `${a} mutations`;', 'const a = 10; const b = "";');
+  });
+
+  it('should mutate a template string referencing another variable', () => {
+    expectMutation(sut, 'const a = 10; const b = `mutations: ${a}`;', 'const a = 10; const b = "";');
+  });
+
+  it('should mutate a template string referencing another variable', () => {
+    expectMutation(sut, 'const a = 10; const b = `mutations: ${a} out of 10`;', 'const a = 10; const b = "";');
+  });
+
+  it('should mutate import statements', () => {
+    // It would be best if this wasn't actually the case. Thanks to the lack of context (ie. node.parent) it
+    // doesn't seem possible right now. This will virtually always end up in a compile error so shouldn't
+    // affect throughput.
+    expectMutation(sut, 'import * as foo from "foo";', 'import * as foo from "";');
+  });
+
+});


### PR DESCRIPTION
This mutator will empty out string values. Some of them will cause
compilation errors, but others are useful. It ensures error messages and
other such messages are tested.