### PR TITLE
feature(mutator specification): Create the generic mutator specification

### DIFF
--- a/packages/stryker-mutator-specification/.npmignore
+++ b/packages/stryker-mutator-specification/.npmignore
@@ -1,0 +1,6 @@
+**/*
+!bin/**
+!src/**
+!readme.md
+!LICENSE
+!CHANGELOG.md

--- a/packages/stryker-mutator-specification/.vscode/settings.json
+++ b/packages/stryker-mutator-specification/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "typescript.tsdk": "../../node_modules/typescript/lib",
+  "files.exclude": {
+    ".git": true,
+    ".tscache": true,
+    "**/*.js": {
+      "when": "$(basename).ts"
+    },
+    "**/*.d.ts": true,
+    "**/*.map": {
+      "when": "$(basename)"
+    }
+  }
+}

--- a/packages/stryker-mutator-specification/README.md
+++ b/packages/stryker-mutator-specification/README.md
@@ -1,0 +1,12 @@
+[![NPM](https://img.shields.io/npm/dm/stryker-mutator-specification.svg)](https://www.npmjs.com/package/stryker-mutator-specification)
+[![Node version](https://img.shields.io/node/v/stryker-mutator-specification.svg)](https://img.shields.io/node/v/stryker-mutator-specification.svg)
+[![Gitter](https://badges.gitter.im/stryker-mutator/stryker.svg)](https://gitter.im/stryker-mutator/stryker?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+![Stryker](https://github.com/stryker-mutator/stryker/raw/master/stryker-80x80.png)
+
+# Stryker mutator specification
+
+This package contains a specification for mutators for [Stryker](https://stryker-mutator.github.io) - The JavaScript mutation testing framework. 
+
+Stryker is language agnostic, examples of mutators are the [JavaScript mutator](https://github.com/stryker-mutator/stryker/tree/master/packages/stryker-javascript-mutator) and the [TypeScript mutator](https://github.com/stryker-mutator/stryker/tree/master/packages/stryker-typescript). However, they share a common set of mutators specified in this package. So this package defines a common set of specifications to which a mutator *could* conform. 
+
+The specifications are written as mocha tests, so it's easy to run them inside your own build as part of *insert your custom mutator here*. Please take a look at stryker-typescript or stryker-javascript-mutator if you want to know how.

--- a/packages/stryker-mutator-specification/package.json
+++ b/packages/stryker-mutator-specification/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "stryker-mutator-specification",
+  "version": "0.1.0",
+  "description": "A package for maintaining common mutator specifications for Stryker - the JavaScript mutation testing framework",
+  "scripts": {
+    "start": "tsc -w",
+    "clean": "rimraf \"+(test|src)/**/*+(.d.ts|.js|.map)\" reports",
+    "prebuild": "npm run clean",
+    "build": "tsc -p .",
+    "postbuild": "tslint -p tsconfig.json"
+  },
+  "keywords": [
+    "stryker"
+  ],
+  "main": "src/index.js",
+  "typings": "src/index.ts",
+  "author": "Nico Jansen <jansennico@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stryker-mutator/stryker"
+  },
+  "engines": {
+    "node": ">=4"
+  },
+  "homepage": "https://github.com/stryker-mutator/stryker/tree/master/packages/stryker-javascript-mutator#readme",
+  "license": "Apache-2.0"
+}

--- a/packages/stryker-mutator-specification/src/ArrayLiteralMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/ArrayLiteralMutatorSpec.ts
@@ -20,7 +20,7 @@ export default function ArrayLiteralMutatorSpec(name: string, expectMutation: Ex
     });
 
     it('should mutate empty array literals as a filled array', () => {
-      expectMutation('[]', '[[]]');
+      expectMutation('[]', '[\'Stryker was here\']');
     });
   });
 }

--- a/packages/stryker-mutator-specification/src/ArrayLiteralMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/ArrayLiteralMutatorSpec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function ArrayLiteralMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('ArrayLiteralMutator', () => {
+
+    it('should have name "ArrayLiteral"', () => {
+      expect(name).eq('ArrayLiteral');
+    });
+
+    it('should mutate filled array literals as empty arrays', () => {
+      expectMutation('[a, 1 + 1]', '[]');
+      expectMutation(`['val']`, '[]');
+    });
+
+    it('should not mutate array initializers (leave that for ArrayNewExpressionMutator)', () => {
+      expectMutation(`new Array()`);
+      expectMutation(`new Array(1, 2, 3)`);
+    });
+
+    it('should mutate empty array literals as a filled array', () => {
+      expectMutation('[]', '[[]]');
+    });
+  });
+}

--- a/packages/stryker-mutator-specification/src/ArrayNewExpressionMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/ArrayNewExpressionMutatorSpec.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function ArrayNewExpressionMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('ArrayNewExpressionMutator', () => {
+   
+    it('should have name "ArrayNewExpression"', () => {
+      expect(name).eq('ArrayNewExpression');
+    });
+
+    it('should mutate filled array literals as empty arrays', () => {
+      expectMutation('new Array(a, 1 + 1)', 'new Array()');
+      expectMutation(`new Array('val')`, 'new Array()');
+    });
+
+    it('should not mutate array literals (leave that for ArrayLiteralMutator)', () => {
+      expectMutation(`[]`);
+      expectMutation(`[1, 2 ,3]`);
+    });
+
+    it('should not mutate other new expressions', () => {
+      expectMutation('new Object(21, 2)');
+      expectMutation('new Arrays(21, 2)');
+    });
+
+    it('should mutate empty array literals as a filled array', () => {
+      expectMutation('new Array()', 'new Array([])');
+    });
+  });
+}

--- a/packages/stryker-mutator-specification/src/ArrowFunctionMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/ArrowFunctionMutatorSpec.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function ArrowFunctionMutatorSpec(name: string, expectMutation: ExpectMutation) {
+  describe('ArrowFunctionMutator', () => {
+
+    it('should have name "ArrowFunction"', () => {
+      expect(name).eq('ArrowFunction');
+    });
+
+    it('should mutate an anonymous function with an inline return', () => {
+      expectMutation('const b = () => 4;', 'const b = () => undefined;');
+    });
+
+    it('should not mutate an anonymous function with a block as a body', () => {
+      expectMutation('const b = () => { return 4; }');
+    });
+  });
+}

--- a/packages/stryker-mutator-specification/src/BinaryExpressionMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/BinaryExpressionMutatorSpec.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function BinaryExpressionMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('BinaryExpressionMutator', () => {
+
+    it('should have name "BinaryExpression"', () => {
+      expect(name).eq('BinaryExpression');
+    });
+
+    it('should mutate + and -', () => {
+      expectMutation('a + b', 'a - b');
+      expectMutation('a - b', 'a + b');
+    });
+
+    it('should mutate *, % and /', () => {
+      expectMutation('a * b', 'a / b');
+      expectMutation('a / b', 'a * b');
+      expectMutation('a % b', 'a * b');
+    });
+
+    it('should mutate < and >', () => {
+      expectMutation('a < b', 'a >= b', 'a <= b');
+      expectMutation('a > b', 'a <= b', 'a >= b');
+    });
+
+    it('should mutate <= and >=', () => {
+      expectMutation('a <= b', 'a < b', 'a > b');
+      expectMutation('a >= b', 'a < b', 'a > b');
+    });
+
+    it('should mutate == and ===', () => {
+      expectMutation('a == b', 'a != b');
+      expectMutation('a === b', 'a !== b');
+    });
+
+    it('should mutate != and !==', () => {
+      expectMutation('a != b', 'a == b');
+      expectMutation('a !== b', 'a === b');
+    });
+
+    it('should mutate && and ||', () => {
+      expectMutation('a && b', 'a || b');
+      expectMutation('a || b', 'a && b');
+    });
+
+  });
+}

--- a/packages/stryker-mutator-specification/src/BlockMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/BlockMutatorSpec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function BlockMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('BlockMutator', () => {
+
+    it('should have name "Block"', () => {
+      expect(name).eq('Block');
+    });
+
+    it('should mutate the block of a function into an empty block', () => {
+      expectMutation('function() { return 4; }', 'function() {}');
+    });
+
+    it('should mutate a single block', () => {
+      expectMutation('const a = 3; { const b = a; }', 'const a = 3; {}');
+    });
+
+    it('should not mutate an already empty block', () => {
+      expectMutation('function() {  }');
+    });
+
+    it('should mutate the body of an anonymous function if defined as a block', () => {
+      expectMutation('const b = () => { return 4; }', 'const b = () => {}');
+    });
+
+    it('should not mutate the body of an anonymous function if not defined as a block', () => {
+      expectMutation('const b = () => 4;');
+    });
+
+  });
+}

--- a/packages/stryker-mutator-specification/src/BooleanSubstitutionMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/BooleanSubstitutionMutatorSpec.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function BooleanSubstitutionMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('BooleanSubstitutionMutator', () => {
+
+    it('should have name "BooleanSubstitution"', () => {
+      expect(name).eq('BooleanSubstitution');
+    });
+
+    it('should mutate `true` into `false`', () => {
+      expectMutation('true', 'false');
+    });
+
+    it('should mutate `false` into `true`', () => {
+      expectMutation('false', 'true');
+    });
+  });
+}

--- a/packages/stryker-mutator-specification/src/ConditionalExpressionMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/ConditionalExpressionMutatorSpec.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function ConditionalExpressionMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('ConditionalExpressionMutator', () => {
+
+    it('should have name "ConditionalExpression"', () => {
+      expect(name).eq('ConditionalExpression');
+    });
+
+    it('should replace conditional expressions', () => {
+      expectMutation('a < 3? b : c', 'false? b : c');
+    });
+  });
+}

--- a/packages/stryker-mutator-specification/src/DoStatementMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/DoStatementMutatorSpec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function DoStatementMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('DoStatementMutator', () => {
+
+    it('should have name "DoStatement"', () => {
+      expect(name).eq('DoStatement');
+    });
+
+    it('should mutate the expression of a do statement', () => {
+      expectMutation('do { console.log(); } while(a < b);', 'do { console.log(); } while(false);');
+    });
+
+  });
+}

--- a/packages/stryker-mutator-specification/src/ExpectMutation.ts
+++ b/packages/stryker-mutator-specification/src/ExpectMutation.ts
@@ -1,0 +1,3 @@
+export default interface ExpectMutation {
+  (originalCode: string, ...expectedMutations: string[]): void;
+}

--- a/packages/stryker-mutator-specification/src/ForStatementMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/ForStatementMutatorSpec.ts
@@ -1,0 +1,22 @@
+import * as os from 'os';
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function ForStatementMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('ForStatementMutator', () => {
+
+    it('should have name "ForStatement"', () => {
+      expect(name).eq('ForStatement');
+    });
+
+    it('should mutate the condition of a for statement', () => {
+      expectMutation('for(let i=0;i<10; i++) { console.log(); }', 'for(let i=0;false; i++) { console.log(); }');
+    });
+
+    it('should mutate the condition of a for statement without a condition', () => {
+      expectMutation('for(let i=0;; i++) { console.log(); }', `for (let i = 0; false; i++) {${os.EOL}    console.log();${os.EOL}}`);
+    });
+
+  });
+}

--- a/packages/stryker-mutator-specification/src/ForStatementMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/ForStatementMutatorSpec.ts
@@ -1,4 +1,3 @@
-import * as os from 'os';
 import { expect } from 'chai';
 import ExpectMutation from './ExpectMutation';
 
@@ -15,8 +14,7 @@ export default function ForStatementMutatorSpec(name: string, expectMutation: Ex
     });
 
     it('should mutate the condition of a for statement without a condition', () => {
-      expectMutation('for(let i=0;; i++) { console.log(); }', `for (let i = 0; false; i++) {${os.EOL}    console.log();${os.EOL}}`);
+      expectMutation('for(let i=0;; i++) { console.log(); }', `for (let i = 0; false; i++) { console.log(); }`);
     });
-
   });
 }

--- a/packages/stryker-mutator-specification/src/IfStatementMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/IfStatementMutatorSpec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function IfStatementMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('IfStatementMutator', () => {
+
+    it('should have name "IfStatement"', () => {
+      expect(name).eq('IfStatement');
+    });
+
+    it('should mutate an expression to `true` and `false`', () => {
+      expectMutation('if(something){ a++ }', 'if(true){ a++ }', 'if(false){ a++ }');
+    });
+
+  });
+}

--- a/packages/stryker-mutator-specification/src/IfStatementMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/IfStatementMutatorSpec.ts
@@ -10,7 +10,7 @@ export default function IfStatementMutatorSpec(name: string, expectMutation: Exp
     });
 
     it('should mutate an expression to `true` and `false`', () => {
-      expectMutation('if(something){ a++ }', 'if(true){ a++ }', 'if(false){ a++ }');
+      expectMutation('if (something) { a++ }', 'if (true) { a++ }', 'if (false) { a++ }');
     });
 
   });

--- a/packages/stryker-mutator-specification/src/PrefixUnaryExpressionMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/PrefixUnaryExpressionMutatorSpec.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function PrefixUnaryExpressionMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('PrefixUnaryExpressionMutator', () => {
+
+    it('should have name "PrefixUnaryExpression"', () => {
+      expect(name).eq('PrefixUnaryExpression');
+    });
+
+    it('should mutate -a to +a', () => {
+      expectMutation('-a', '+a');
+    });
+
+    it('should mutate +a to -a', () => {
+      expectMutation('+a', '-a');
+    });
+
+    it('should mutate ~a to a', () => {
+      expectMutation('~a', 'a');
+    });
+
+    it('should mutate !a to a', () => {
+      expectMutation('!a', 'a');
+    });
+
+    it('should mutate ++a to --a', () => {
+      expectMutation('++a', '--a');
+    });
+
+    it('should mutate --a to ++a', () => {
+      expectMutation('--a', '++a');
+    });
+
+    it('should not mutate a+a', () => {
+      expectMutation('a+a');
+    });
+
+    it('should not mutate a-a', () => {
+      expectMutation('a-a');
+    });
+  });
+}

--- a/packages/stryker-mutator-specification/src/StringLiteralMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/StringLiteralMutatorSpec.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+
+export default function StringLiteralMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('StringLiteralMutator', () => {
+
+    it('should have name "StringLiteral"', () => {
+      expect(name).eq('StringLiteral');
+    });
+
+    it('should mutate a string literal with double quotes', () => {
+      expectMutation('const b = "Hello world!";', 'const b = "";');
+    });
+
+    it('should mutate a string literal with single quotes', () => {
+      expectMutation('const b = \'Hello world!\';', 'const b = "";');
+    });
+
+    it('should mutate a template string', () => {
+      expectMutation('const b = `Hello world!`;', 'const b = "";');
+    });
+
+    it('should mutate a template string referencing another variable', () => {
+      expectMutation('const a = 10; const b = `${a} mutations`;', 'const a = 10; const b = "";');
+      expectMutation('const a = 10; const b = `mutations: ${a}`;', 'const a = 10; const b = "";');
+      expectMutation('const a = 10; const b = `mutations: ${a} out of 10`;', 'const a = 10; const b = "";');
+    });
+
+    it('should mutate empty strings', () => {
+      expectMutation('const b = "";', 'const b = "Stryker was here!";');
+    });
+
+    it('should mutate empty template strings', () => {
+      expectMutation('const b = ``;', 'const b = "Stryker was here!";');
+    });
+
+    it('should not mutate import statements', () => {
+      expectMutation('import * as foo from "foo";');
+      expectMutation('import { foo } from "foo";');
+      expectMutation('import foo from "foo";');
+      expectMutation('import "foo";');
+    });
+  });
+}

--- a/packages/stryker-mutator-specification/src/UnaryNotMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/UnaryNotMutatorSpec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function UnaryNotMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('UnaryNotMutator', () => {
+
+    it('should have name "UnaryNot"', () => {
+      expect(name).eq('UnaryNot');
+    });
+
+    it('should mutate `!a` into `a`', () => {
+      expectMutation('!a', 'a');
+    });
+
+  });
+}

--- a/packages/stryker-mutator-specification/src/WhileStatementMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/WhileStatementMutatorSpec.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import ExpectMutation from './ExpectMutation';
+
+export default function WhileStatementMutatorSpec(name: string, expectMutation: ExpectMutation) {
+
+  describe('WhileStatementMutator', () => {
+
+    it('should have name "WhileStatement"', () => {
+      expect(name).eq('WhileStatement');
+    });
+
+    it('should mutate the expression of a while statement', () => {
+      expectMutation('while(a < b) { console.log(); }', 'while(false) { console.log(); }');
+    });
+  });
+}

--- a/packages/stryker-mutator-specification/src/index.ts
+++ b/packages/stryker-mutator-specification/src/index.ts
@@ -1,0 +1,14 @@
+
+export { default as ArrayLiteralMutatorSpec } from './ArrayLiteralMutatorSpec';
+export { default as ArrayNewExpressionMutatorSpec } from './ArrayNewExpressionMutatorSpec';
+export { default as ArrowFunctionMutatorSpec } from './ArrowFunctionMutatorSpec';
+export { default as BinaryExpressionMutatorSpec } from './BinaryExpressionMutatorSpec';
+export { default as BlockMutatorSpec } from './BlockMutatorSpec';
+export { default as BooleanSubstitutionMutatorSpec } from './BooleanSubstitutionMutatorSpec';
+export { default as ConditionalExpressionMutatorSpec } from './ConditionalExpressionMutatorSpec';
+export { default as DoStatementMutatorSpec } from './DoStatementMutatorSpec';
+export { default as ForStatementMutatorSpec } from './ForStatementMutatorSpec';
+export { default as IfStatementMutatorSpec } from './IfStatementMutatorSpec';
+export { default as PrefixUnaryExpressionMutatorSpec } from './PrefixUnaryExpressionMutatorSpec';
+export { default as UnaryNotMutatorSpec } from './UnaryNotMutatorSpec';
+export { default as WhileStatementMutatorSpec } from './WhileStatementMutatorSpec';

--- a/packages/stryker-mutator-specification/src/index.ts
+++ b/packages/stryker-mutator-specification/src/index.ts
@@ -12,3 +12,4 @@ export { default as IfStatementMutatorSpec } from './IfStatementMutatorSpec';
 export { default as PrefixUnaryExpressionMutatorSpec } from './PrefixUnaryExpressionMutatorSpec';
 export { default as UnaryNotMutatorSpec } from './UnaryNotMutatorSpec';
 export { default as WhileStatementMutatorSpec } from './WhileStatementMutatorSpec';
+export { default as StringLiteralMutatorSpec } from './StringLiteralMutatorSpec';

--- a/packages/stryker-mutator-specification/tsconfig.json
+++ b/packages/stryker-mutator-specification/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+      "declaration": false
+    },
+    "exclude": [
+        "node_modules",
+        "src/**/*.d.ts",
+        "test/**/*.d.ts",
+        "testResources"
+    ]
+}

--- a/packages/stryker-mutator-specification/tslint.json
+++ b/packages/stryker-mutator-specification/tslint.json
@@ -1,0 +1,58 @@
+{
+    "rules": {
+        "class-name": true,
+        "comment-format": [
+            true,
+            "check-space"
+        ],
+        "indent": [
+            true,
+            "spaces"
+        ],
+        "no-duplicate-variable": true,
+        "no-eval": true,
+        "no-internal-module": true,
+        "no-trailing-whitespace": false,
+        "no-unsafe-finally": true,
+        "no-var-keyword": true,
+        "one-line": [
+            true,
+            "check-open-brace",
+            "check-whitespace"
+        ],
+        "quotemark": [
+            true,
+            "single"
+        ],
+        "semicolon": [
+            true,
+            "always"
+        ],
+        "triple-equals": [
+            true,
+            "allow-null-check"
+        ],
+        "typedef-whitespace": [
+            true,
+            {
+                "call-signature": "nospace",
+                "index-signature": "nospace",
+                "parameter": "nospace",
+                "property-declaration": "nospace",
+                "variable-declaration": "nospace"
+            }
+        ],
+        "variable-name": [
+            true,
+            "ban-keywords"
+        ],
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type"
+        ]
+    }
+}

--- a/packages/stryker-typescript/package.json
+++ b/packages/stryker-typescript/package.json
@@ -46,7 +46,8 @@
     "@types/lodash.flatmap": "^4.5.3",
     "@types/semver": "^5.4.0",
     "@types/source-map": "^0.5.1",
-    "stryker-api": "^0.11.0"
+    "stryker-api": "^0.11.0",
+    "stryker-mutator-specification": "file:../stryker-mutator-specification"
   },
   "peerDependencies": {
     "stryker-api": "^0.11.0",

--- a/packages/stryker-typescript/package.json
+++ b/packages/stryker-typescript/package.json
@@ -47,7 +47,7 @@
     "@types/semver": "^5.4.0",
     "@types/source-map": "^0.5.1",
     "stryker-api": "^0.11.0",
-    "stryker-mutator-specification": "file:../stryker-mutator-specification"
+    "stryker-mutator-specification": "^0.1.0"
   },
   "peerDependencies": {
     "stryker-api": "^0.11.0",

--- a/packages/stryker-typescript/src/mutator/ArrayLiteralMutator.ts
+++ b/packages/stryker-typescript/src/mutator/ArrayLiteralMutator.ts
@@ -12,7 +12,7 @@ export default class ArrayLiteralMutator extends NodeMutator<ts.ArrayLiteralExpr
     if (node.elements.length) {
       return [{ node, replacement: '[]' }];
     } else {
-      return [{ node, replacement: '[[]]' }];
+      return [{ node, replacement: '[\'Stryker was here\']' }];
     }
   }
 }

--- a/packages/stryker-typescript/test/unit/mutator/ArrayLiteralMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ArrayLiteralMutatorSpec.ts
@@ -1,5 +1,5 @@
 import ArrayLiteralMutator from '../../../src/mutator/ArrayLiteralMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import { ArrayLiteralMutatorSpec } from 'stryker-mutator-specification';
 
-ArrayLiteralMutatorSpec(new ArrayLiteralMutator().name, expectMutation(new ArrayLiteralMutator()));
+verifySpecification(ArrayLiteralMutatorSpec, ArrayLiteralMutator);

--- a/packages/stryker-typescript/test/unit/mutator/ArrayLiteralMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ArrayLiteralMutatorSpec.ts
@@ -1,30 +1,5 @@
-import { expect } from 'chai';
 import ArrayLiteralMutator from '../../../src/mutator/ArrayLiteralMutator';
 import { expectMutation } from './mutatorAssertions';
+import { ArrayLiteralMutatorSpec } from 'stryker-mutator-specification';
 
-
-describe('ArrayLiteralMutator', () => {
-  let sut: ArrayLiteralMutator;
-
-  beforeEach(() => {
-    sut = new ArrayLiteralMutator();
-  });
-
-  it('should have name "ArrayLiteral"', () => {
-    expect(sut.name).eq('ArrayLiteral');
-  });
-
-  it('should mutate filled array literals as empty arrays', () => {
-    expectMutation(sut, '[a, 1 + 1]', '[]');
-    expectMutation(sut, `['val']`, '[]');
-  });
-
-  it('should not mutate array initializers (leave that for ArrayNewExpressionMutator)', () => {
-    expectMutation(sut, `new Array()`);
-    expectMutation(sut, `new Array(1, 2, 3)`);
-  });
-
-  it('should mutate empty array literals as a filled array', () => {
-    expectMutation(sut, '[]', '[[]]');
-  });
-});
+ArrayLiteralMutatorSpec(new ArrayLiteralMutator().name, expectMutation(new ArrayLiteralMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/ArrayNewExpressionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ArrayNewExpressionMutatorSpec.ts
@@ -1,35 +1,5 @@
-import { expect } from 'chai';
-import { expectMutation } from './mutatorAssertions';
 import ArrayNewExpressionMutator from '../../../src/mutator/ArrayNewExpressionMutator';
+import { expectMutation } from './mutatorAssertions';
+import { ArrayNewExpressionMutatorSpec } from 'stryker-mutator-specification/src/index';
 
-
-describe('ArrayNewExpressionMutator', () => {
-  let sut: ArrayNewExpressionMutator;
-
-  beforeEach(() => {
-    sut = new ArrayNewExpressionMutator();
-  });
-
-  it('should have name "ArrayNewExpression"', () => {
-    expect(sut.name).eq('ArrayNewExpression');
-  });
-
-  it('should mutate filled array literals as empty arrays', () => {
-    expectMutation(sut, 'new Array(a, 1 + 1)', 'new Array()');
-    expectMutation(sut, `new Array('val')`, 'new Array()');
-  });
-
-  it('should not mutate array literals (leave that for ArrayLiteralMutator)', () => {
-    expectMutation(sut, `[]`);
-    expectMutation(sut, `[1, 2 ,3]`);
-  });
-
-  it('should not mutate other new expressions', () => {
-    expectMutation(sut, 'new Object(21, 2)');
-    expectMutation(sut, 'new Arrays(21, 2)');
-  });
-
-  it('should mutate empty array literals as a filled array', () => {
-    expectMutation(sut, 'new Array()', 'new Array([])');
-  });
-});
+ArrayNewExpressionMutatorSpec(new ArrayNewExpressionMutator().name, expectMutation(new ArrayNewExpressionMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/ArrayNewExpressionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ArrayNewExpressionMutatorSpec.ts
@@ -1,5 +1,5 @@
 import ArrayNewExpressionMutator from '../../../src/mutator/ArrayNewExpressionMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import { ArrayNewExpressionMutatorSpec } from 'stryker-mutator-specification/src/index';
 
-ArrayNewExpressionMutatorSpec(new ArrayNewExpressionMutator().name, expectMutation(new ArrayNewExpressionMutator()));
+verifySpecification(ArrayNewExpressionMutatorSpec, ArrayNewExpressionMutator);

--- a/packages/stryker-typescript/test/unit/mutator/ArrowFunctionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ArrowFunctionMutatorSpec.ts
@@ -1,5 +1,5 @@
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import ArrowFunctionMutator from '../../../src/mutator/ArrowFunctionMutator';
 import ArrowFunctionMutatorSpec from 'stryker-mutator-specification/src/ArrowFunctionMutatorSpec';
 
-ArrowFunctionMutatorSpec(new ArrowFunctionMutator().name, expectMutation(new ArrowFunctionMutator()));
+verifySpecification(ArrowFunctionMutatorSpec, ArrowFunctionMutator);

--- a/packages/stryker-typescript/test/unit/mutator/ArrowFunctionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ArrowFunctionMutatorSpec.ts
@@ -1,25 +1,5 @@
-import { expect } from 'chai';
 import { expectMutation } from './mutatorAssertions';
 import ArrowFunctionMutator from '../../../src/mutator/ArrowFunctionMutator';
+import ArrowFunctionMutatorSpec from 'stryker-mutator-specification/src/ArrowFunctionMutatorSpec';
 
-describe('ArrowFunctionMutator', () => {
-
-  let sut: ArrowFunctionMutator;
-
-  beforeEach(() => {
-    sut = new ArrowFunctionMutator();
-  });
-
-  it('should have name "ArrowFunction"', () => {
-    expect(sut.name).eq('ArrowFunction');
-  });
-
-  it('should mutate an anonymous function with an inline return', () => {
-    expectMutation(sut, 'const b = () => 4;', 'const b = () => undefined;');
-  });
-
-  it('should not mutate an anonymous function with a block as a body', () => {
-    expectMutation(sut, 'const b = () => { return 4; }');
-  });
-
-});
+ArrowFunctionMutatorSpec(new ArrowFunctionMutator().name, expectMutation(new ArrowFunctionMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/BinaryExpressionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/BinaryExpressionMutatorSpec.ts
@@ -1,5 +1,5 @@
 import BinaryExpressionMutator from '../../../src/mutator/BinaryExpressionMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import BinaryExpressionMutatorSpec from 'stryker-mutator-specification/src/BinaryExpressionMutatorSpec';
 
-BinaryExpressionMutatorSpec(new BinaryExpressionMutator().name, expectMutation(new BinaryExpressionMutator()));
+verifySpecification(BinaryExpressionMutatorSpec, BinaryExpressionMutator);

--- a/packages/stryker-typescript/test/unit/mutator/BinaryExpressionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/BinaryExpressionMutatorSpec.ts
@@ -1,52 +1,5 @@
-import { expect } from 'chai';
 import BinaryExpressionMutator from '../../../src/mutator/BinaryExpressionMutator';
 import { expectMutation } from './mutatorAssertions';
+import BinaryExpressionMutatorSpec from 'stryker-mutator-specification/src/BinaryExpressionMutatorSpec';
 
-describe('BinaryExpressionMutator', () => {
-  let sut: BinaryExpressionMutator;
-
-  beforeEach(() => {
-    sut = new BinaryExpressionMutator();
-  });
-
-  it('should have name "BinaryExpression"', () => {
-    expect(sut.name).eq('BinaryExpression');
-  });
-
-  it('should mutate + and -', () => {
-    expectMutation(sut, 'a + b', 'a - b');
-    expectMutation(sut, 'a - b', 'a + b');
-  });
-
-  it('should mutate *, % and /', () => {
-    expectMutation(sut, 'a * b', 'a / b');
-    expectMutation(sut, 'a / b', 'a * b');
-    expectMutation(sut, 'a % b', 'a * b');
-  });
-
-  it('should mutate < and >', () => {
-    expectMutation(sut, 'a < b', 'a >= b', 'a <= b');
-    expectMutation(sut, 'a > b', 'a <= b', 'a >= b');
-  });
-
-  it('should mutate <= and >=', () => {
-    expectMutation(sut, 'a <= b', 'a < b', 'a > b');
-    expectMutation(sut, 'a >= b', 'a < b', 'a > b');
-  });
-
-  it('should mutate == and ===', () => { 
-    expectMutation(sut, 'a == b', 'a != b');
-    expectMutation(sut, 'a === b', 'a !== b');
-  });
-
-  it('should mutate != and !==', () => { 
-    expectMutation(sut, 'a != b', 'a == b');
-    expectMutation(sut, 'a !== b', 'a === b');
-  });
-
-  it('should mutate && and ||', () => { 
-    expectMutation(sut, 'a && b', 'a || b');
-    expectMutation(sut, 'a || b', 'a && b');
-  });
-
-});
+BinaryExpressionMutatorSpec(new BinaryExpressionMutator().name, expectMutation(new BinaryExpressionMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/BlockMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/BlockMutatorSpec.ts
@@ -1,5 +1,5 @@
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import BlockMutator from '../../../src/mutator/BlockMutator';
 import BlockMutatorSpec from 'stryker-mutator-specification/src/BlockMutatorSpec';
 
-BlockMutatorSpec(new BlockMutator().name, expectMutation(new BlockMutator()));
+verifySpecification(BlockMutatorSpec, BlockMutator);

--- a/packages/stryker-typescript/test/unit/mutator/BlockMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/BlockMutatorSpec.ts
@@ -1,37 +1,5 @@
-import { expect } from 'chai';
 import { expectMutation } from './mutatorAssertions';
 import BlockMutator from '../../../src/mutator/BlockMutator';
+import BlockMutatorSpec from 'stryker-mutator-specification/src/BlockMutatorSpec';
 
-describe('BlockMutator', () => {
-
-  let sut: BlockMutator;
-
-  beforeEach(() => {
-    sut = new BlockMutator();
-  });
-
-  it('should have name "Block"', () => {
-    expect(sut.name).eq('Block');
-  });
-
-  it('should mutate the block of a function into an empty block', () => {
-    expectMutation(sut, 'function() { return 4; }', 'function() {}');
-  });
-
-  it('should mutate a single block', () => {
-    expectMutation(sut, 'const a = 3; { const b = a; }', 'const a = 3; {}');
-  });
-
-  it('should not mutate an already empty block', () => {
-    expectMutation(sut, 'function() {  }');
-  });
-
-  it('should mutate the body of an anonymous function if defined as a block', () => {
-    expectMutation(sut, 'const b = () => { return 4; }', 'const b = () => {}');
-  });
-
-  it('should not mutate the body of an anonymous function if not defined as a block', () => {
-    expectMutation(sut, 'const b = () => 4;');
-  });
-
-});
+BlockMutatorSpec(new BlockMutator().name, expectMutation(new BlockMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/BooleanSubstitutionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/BooleanSubstitutionMutatorSpec.ts
@@ -1,5 +1,5 @@
 import BooleanSubstitutionMutator from '../../../src/mutator/BooleanSubstitutionMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import BooleanSubstitutionMutatorSpec from 'stryker-mutator-specification/src/BooleanSubstitutionMutatorSpec';
 
-BooleanSubstitutionMutatorSpec(new BooleanSubstitutionMutator().name, expectMutation(new BooleanSubstitutionMutator()));
+verifySpecification(BooleanSubstitutionMutatorSpec, BooleanSubstitutionMutator);

--- a/packages/stryker-typescript/test/unit/mutator/BooleanSubstitutionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/BooleanSubstitutionMutatorSpec.ts
@@ -1,23 +1,5 @@
 import BooleanSubstitutionMutator from '../../../src/mutator/BooleanSubstitutionMutator';
-import { expect } from 'chai';
 import { expectMutation } from './mutatorAssertions';
+import BooleanSubstitutionMutatorSpec from 'stryker-mutator-specification/src/BooleanSubstitutionMutatorSpec';
 
-describe('BooleanSubstitutionMutator', () => {
-  let sut: BooleanSubstitutionMutator;
-
-  beforeEach(() => {
-    sut = new BooleanSubstitutionMutator();
-  });
-
-  it('should have name "BooleanSubstitution"', () => {
-    expect(sut.name).eq('BooleanSubstitution');
-  });
-
-  it('should mutate `true` into `false`', () => {
-    expectMutation(sut, 'true', 'false');
-  });
-
-  it('should mutate `false` into `true`', () => {
-    expectMutation(sut, 'false', 'true');
-  });
-});
+BooleanSubstitutionMutatorSpec(new BooleanSubstitutionMutator().name, expectMutation(new BooleanSubstitutionMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/ConditionalExpressionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ConditionalExpressionMutatorSpec.ts
@@ -1,5 +1,5 @@
 import ConditionalExpressionMutator from '../../../src/mutator/ConditionalExpressionMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import ConditionalExpressionMutatorSpec from 'stryker-mutator-specification/src/ConditionalExpressionMutatorSpec';
 
-ConditionalExpressionMutatorSpec(new ConditionalExpressionMutator().name, expectMutation(new ConditionalExpressionMutator()));
+verifySpecification(ConditionalExpressionMutatorSpec, ConditionalExpressionMutator);

--- a/packages/stryker-typescript/test/unit/mutator/ConditionalExpressionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ConditionalExpressionMutatorSpec.ts
@@ -1,20 +1,5 @@
-import { expect } from 'chai';
 import ConditionalExpressionMutator from '../../../src/mutator/ConditionalExpressionMutator';
 import { expectMutation } from './mutatorAssertions';
+import ConditionalExpressionMutatorSpec from 'stryker-mutator-specification/src/ConditionalExpressionMutatorSpec';
 
-describe('ConditionalExpressionMutator', () => {
-
-  let sut: ConditionalExpressionMutator;
-
-  beforeEach(() => {
-    sut = new ConditionalExpressionMutator();
-  });
-
-  it('should have name "ConditionalExpression"', () => {
-    expect(sut.name).eq('ConditionalExpression');
-  });
-
-  it('should replace conditional expressions', () => {
-    expectMutation(sut, 'a < 3? b : c', 'false? b : c');
-  });
-});
+ConditionalExpressionMutatorSpec(new ConditionalExpressionMutator().name, expectMutation(new ConditionalExpressionMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/DoStatementMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/DoStatementMutatorSpec.ts
@@ -1,20 +1,5 @@
-import { expect } from 'chai';
 import DoStatementMutator from '../../../src/mutator/DoStatementMutator';
 import { expectMutation } from './mutatorAssertions';
+import DoStatementMutatorSpec from 'stryker-mutator-specification/src/DoStatementMutatorSpec';
 
-describe('DoStatementMutator', () => {
-  let sut: DoStatementMutator;
-
-  beforeEach(() => {
-    sut = new DoStatementMutator();
-  });
-
-  it('should have name "DoStatement"', () => {
-    expect(sut.name).eq('DoStatement');
-  });
-  
-  it('should mutate the expression of a do statement', () => {
-    expectMutation(sut, 'do { console.log(); } while(a < b);', 'do { console.log(); } while(false);');
-  });
-
-});
+DoStatementMutatorSpec(new DoStatementMutator().name, expectMutation(new DoStatementMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/DoStatementMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/DoStatementMutatorSpec.ts
@@ -1,5 +1,5 @@
 import DoStatementMutator from '../../../src/mutator/DoStatementMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import DoStatementMutatorSpec from 'stryker-mutator-specification/src/DoStatementMutatorSpec';
 
-DoStatementMutatorSpec(new DoStatementMutator().name, expectMutation(new DoStatementMutator()));
+verifySpecification(DoStatementMutatorSpec, DoStatementMutator);

--- a/packages/stryker-typescript/test/unit/mutator/ForStatementMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ForStatementMutatorSpec.ts
@@ -1,25 +1,5 @@
-import * as os from 'os';
-import { expect } from 'chai';
 import ForStatementMutator from '../../../src/mutator/ForStatementMutator';
 import { expectMutation } from './mutatorAssertions';
+import { ForStatementMutatorSpec } from 'stryker-mutator-specification/src/index';
 
-describe('ForStatementMutator', () => {
-  let sut: ForStatementMutator;
-
-  beforeEach(() => {
-    sut = new ForStatementMutator();
-  });
-
-  it('should have name "ForStatement"', () => {
-    expect(sut.name).eq('ForStatement');
-  });
-  
-  it('should mutate the condition of a for statement', () => {
-    expectMutation(sut, 'for(let i=0;i<10; i++) { console.log(); }', 'for(let i=0;false; i++) { console.log(); }');
-  });
-  
-  it('should mutate the condition of a for statement without a condition', () => {
-    expectMutation(sut, 'for(let i=0;; i++) { console.log(); }', `for (let i = 0; false; i++) {${os.EOL}    console.log();${os.EOL}}`);
-  });
-  
-});
+ForStatementMutatorSpec(new ForStatementMutator().name, expectMutation(new ForStatementMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/ForStatementMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/ForStatementMutatorSpec.ts
@@ -1,5 +1,5 @@
 import ForStatementMutator from '../../../src/mutator/ForStatementMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import { ForStatementMutatorSpec } from 'stryker-mutator-specification/src/index';
 
-ForStatementMutatorSpec(new ForStatementMutator().name, expectMutation(new ForStatementMutator()));
+verifySpecification(ForStatementMutatorSpec, ForStatementMutator);

--- a/packages/stryker-typescript/test/unit/mutator/IfStatementMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/IfStatementMutatorSpec.ts
@@ -1,21 +1,5 @@
-import { expect } from 'chai';
 import IfStatementMutator from '../../../src/mutator/IfStatementMutator';
 import { expectMutation } from './mutatorAssertions';
+import IfStatementMutatorSpec from 'stryker-mutator-specification/src/IfStatementMutatorSpec';
 
-describe('IfStatementMutator', () => {
-
-  let sut: IfStatementMutator;
-
-  beforeEach(() => {
-    sut = new IfStatementMutator();
-  });
-
-  it('should have name "IfStatement"', () => {
-    expect(sut.name).eq('IfStatement');
-  });
-
-  it('should mutate an expression to `true` and `false`', () => {
-    expectMutation(sut, 'if(something){ a++ }', 'if(true){ a++ }', 'if(false){ a++ }');
-  });
-
-});
+IfStatementMutatorSpec(new IfStatementMutator().name, expectMutation(new IfStatementMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/IfStatementMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/IfStatementMutatorSpec.ts
@@ -1,5 +1,5 @@
 import IfStatementMutator from '../../../src/mutator/IfStatementMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import IfStatementMutatorSpec from 'stryker-mutator-specification/src/IfStatementMutatorSpec';
 
-IfStatementMutatorSpec(new IfStatementMutator().name, expectMutation(new IfStatementMutator()));
+verifySpecification(IfStatementMutatorSpec, IfStatementMutator);

--- a/packages/stryker-typescript/test/unit/mutator/PrefixUnaryExpressionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/PrefixUnaryExpressionMutatorSpec.ts
@@ -1,5 +1,5 @@
 import PrefixUnaryExpressionMutator from '../../../src/mutator/PrefixUnaryExpressionMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import PrefixUnaryExpressionMutatorSpec from 'stryker-mutator-specification/src/PrefixUnaryExpressionMutatorSpec';
 
-PrefixUnaryExpressionMutatorSpec(new PrefixUnaryExpressionMutator().name, expectMutation(new PrefixUnaryExpressionMutator()));
+verifySpecification(PrefixUnaryExpressionMutatorSpec, PrefixUnaryExpressionMutator);

--- a/packages/stryker-typescript/test/unit/mutator/PrefixUnaryExpressionMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/PrefixUnaryExpressionMutatorSpec.ts
@@ -1,48 +1,5 @@
-import { expect } from 'chai';
 import PrefixUnaryExpressionMutator from '../../../src/mutator/PrefixUnaryExpressionMutator';
 import { expectMutation } from './mutatorAssertions';
+import PrefixUnaryExpressionMutatorSpec from 'stryker-mutator-specification/src/PrefixUnaryExpressionMutatorSpec';
 
-describe('PrefixUnaryExpressionMutator', () => {
-
-  let sut: PrefixUnaryExpressionMutator;
-
-  beforeEach(() => {
-    sut = new PrefixUnaryExpressionMutator();
-  });
-
-  it('should have name "PrefixUnaryExpression"', () => {
-    expect(sut.name).eq('PrefixUnaryExpression');
-  });
-
-  it('should mutate -a to +a', () => {
-    expectMutation(sut, '-a', '+a');
-  });
-
-  it('should mutate +a to -a', () => {
-    expectMutation(sut, '+a', '-a');
-  });
-
-  it('should mutate ~a to a', () => {
-    expectMutation(sut, '~a', 'a');
-  });
-
-  it('should mutate !a to a', () => {
-    expectMutation(sut, '!a', 'a');
-  });
-
-  it('should mutate ++a to --a', () => {
-    expectMutation(sut, '++a', '--a');
-  });
-
-  it('should mutate --a to ++a', () => {
-    expectMutation(sut, '--a', '++a');
-  });
-
-  it('should not mutate a+a', () => {
-    expectMutation(sut, 'a+a');
-  });
-  
-  it('should not mutate a-a', () => {
-    expectMutation(sut, 'a-a');
-  });
-});
+PrefixUnaryExpressionMutatorSpec(new PrefixUnaryExpressionMutator().name, expectMutation(new PrefixUnaryExpressionMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/StringLiteralMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/StringLiteralMutatorSpec.ts
@@ -1,50 +1,5 @@
-import { expect } from 'chai';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import StringLiteralMutator from '../../../src/mutator/StringLiteralMutator';
+import StringLiteralMutatorSpec from 'stryker-mutator-specification/src/StringLiteralMutatorSpec';
 
-describe('StringLiteralMutator', () => {
-
-  let sut: StringLiteralMutator;
-
-  beforeEach(() => {
-    sut = new StringLiteralMutator();
-  });
-
-  it('should have name "StringLiteral"', () => {
-    expect(sut.name).eq('StringLiteral');
-  });
-
-  it('should mutate a string literal with double quotes', () => {
-    expectMutation(sut, 'const b = "Hello world!";', 'const b = "";');
-  });
-
-  it('should mutate a string literal with single quotes', () => {
-    expectMutation(sut, 'const b = \'Hello world!\';', 'const b = "";');
-  });
-
-  it('should mutate a template string', () => {
-    expectMutation(sut, 'const b = `Hello world!`;', 'const b = "";');
-  });
-
-  it('should mutate a template string referencing another variabled', () => {
-    expectMutation(sut, 'const a = 10; const b = `${a} mutations`;', 'const a = 10; const b = "";');
-    expectMutation(sut, 'const a = 10; const b = `mutations: ${a}`;', 'const a = 10; const b = "";');
-    expectMutation(sut, 'const a = 10; const b = `mutations: ${a} out of 10`;', 'const a = 10; const b = "";');
-  });
-
-  it('should mutate empty strings', () => {
-    expectMutation(sut, 'const b = "";', 'const b = "Stryker was here!";');
-  });
-
-  it('should mutate empty template strings', () => {
-    expectMutation(sut, 'const b = ``;', 'const b = "Stryker was here!";');
-  });
-
-  it('should not mutate import statements', () => {
-    expectMutation(sut, 'import * as foo from "foo";');
-    expectMutation(sut, 'import { foo } from "foo";');
-    expectMutation(sut, 'import foo from "foo";');
-    expectMutation(sut, 'import "foo";');
-  });
-
-});
+verifySpecification(StringLiteralMutatorSpec, StringLiteralMutator);

--- a/packages/stryker-typescript/test/unit/mutator/UnaryNotMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/UnaryNotMutatorSpec.ts
@@ -1,5 +1,5 @@
 import UnaryNotMutator from '../../../src/mutator/UnaryNotMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import UnaryNotMutatorSpec from 'stryker-mutator-specification/src/UnaryNotMutatorSpec';
 
-UnaryNotMutatorSpec(new UnaryNotMutator().name, expectMutation(new UnaryNotMutator()));
+verifySpecification(UnaryNotMutatorSpec, UnaryNotMutator);

--- a/packages/stryker-typescript/test/unit/mutator/UnaryNotMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/UnaryNotMutatorSpec.ts
@@ -1,20 +1,5 @@
 import UnaryNotMutator from '../../../src/mutator/UnaryNotMutator';
-import { expect } from 'chai';
 import { expectMutation } from './mutatorAssertions';
+import UnaryNotMutatorSpec from 'stryker-mutator-specification/src/UnaryNotMutatorSpec';
 
-describe('UnaryNotMutator', () => {
-  let sut: UnaryNotMutator;
-
-  beforeEach(() => {
-    sut = new UnaryNotMutator();
-  });
-
-  it('should have name "UnaryNot"', () => {
-    expect(sut.name).eq('UnaryNot');
-  });
-
-  it('should mutate `!a` into `a`', () => {
-    expectMutation(sut, '!a', 'a');
-  });
-
-});
+UnaryNotMutatorSpec(new UnaryNotMutator().name, expectMutation(new UnaryNotMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/WhileStatementMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/WhileStatementMutatorSpec.ts
@@ -1,20 +1,5 @@
-import { expect } from 'chai';
 import WhileStatementMutator from '../../../src/mutator/WhileStatementMutator';
 import { expectMutation } from './mutatorAssertions';
+import { WhileStatementMutatorSpec } from 'stryker-mutator-specification/src/index';
 
-describe('WhileStatementMutator', () => {
-  let sut: WhileStatementMutator;
-
-  beforeEach(() => {
-    sut = new WhileStatementMutator();
-  });
-
-  it('should have name "WhileStatement"', () => {
-    expect(sut.name).eq('WhileStatement');
-  });
-
-  it('should mutate the expression of a while statement', () => {
-    expectMutation(sut, 'while(a < b) { console.log(); }', 'while(false) { console.log(); }');
-  });
-
-});
+WhileStatementMutatorSpec(new WhileStatementMutator().name, expectMutation(new WhileStatementMutator()));

--- a/packages/stryker-typescript/test/unit/mutator/WhileStatementMutatorSpec.ts
+++ b/packages/stryker-typescript/test/unit/mutator/WhileStatementMutatorSpec.ts
@@ -1,5 +1,5 @@
 import WhileStatementMutator from '../../../src/mutator/WhileStatementMutator';
-import { expectMutation } from './mutatorAssertions';
+import { verifySpecification } from './mutatorAssertions';
 import { WhileStatementMutatorSpec } from 'stryker-mutator-specification/src/index';
 
-WhileStatementMutatorSpec(new WhileStatementMutator().name, expectMutation(new WhileStatementMutator()));
+verifySpecification(WhileStatementMutatorSpec, WhileStatementMutator);

--- a/packages/stryker-typescript/test/unit/mutator/mutatorAssertions.ts
+++ b/packages/stryker-typescript/test/unit/mutator/mutatorAssertions.ts
@@ -4,12 +4,14 @@ import { Mutant } from 'stryker-api/mutant';
 import NodeMutator from '../../../src/mutator/NodeMutator';
 
 
-export function expectMutation(mutator: NodeMutator, sourceText: string, ...expectedTexts: string[]) {
-  const sourceFile = ts.createSourceFile('file.ts', sourceText, ts.ScriptTarget.ES5);
-  const mutants = mutate(mutator, sourceFile, sourceFile);
-  expect(mutants).lengthOf(expectedTexts.length);
-  const actualMutantTexts = mutants.map(mutant => mutantToString(mutant, sourceText));
-  expectedTexts.forEach(expected => expect(actualMutantTexts, `was: ${actualMutantTexts.join(',')}`).to.include(expected));
+export function expectMutation(mutator: NodeMutator) {
+  return (sourceText: string, ...expectedTexts: string[]) => {
+    const sourceFile = ts.createSourceFile('file.ts', sourceText, ts.ScriptTarget.ES5);
+    const mutants = mutate(mutator, sourceFile, sourceFile);
+    expect(mutants).lengthOf(expectedTexts.length);
+    const actualMutantTexts = mutants.map(mutant => mutantToString(mutant, sourceText));
+    expectedTexts.forEach(expected => expect(actualMutantTexts, `was: ${actualMutantTexts.join(',')}`).to.include(expected));
+  };
 }
 
 function mutate(mutator: NodeMutator, node: ts.Node, sourceFile: ts.SourceFile): Mutant[] {

--- a/packages/stryker-typescript/test/unit/mutator/mutatorAssertions.ts
+++ b/packages/stryker-typescript/test/unit/mutator/mutatorAssertions.ts
@@ -4,16 +4,32 @@ import { expect } from 'chai';
 import { Mutant } from 'stryker-api/mutant';
 import NodeMutator from '../../../src/mutator/NodeMutator';
 import { textFile } from '../../helpers/producers';
+import ExpectMutation from 'stryker-mutator-specification/src/ExpectMutation';
 
+export interface MutatorConstructor {
+  new(): NodeMutator;
+}
 
-export function expectMutation(mutator: NodeMutator) {
-  return (sourceText: string, ...expectedTexts: string[]) => {
-    const sourceFile = ts.createSourceFile('file.ts', sourceText, ts.ScriptTarget.ES5);
-    const mutants = mutate(mutator, sourceFile, sourceFile);
-    expect(mutants).lengthOf(expectedTexts.length);
-    const actualMutantTexts = mutants.map(mutant => mutantToString(mutant, sourceText));
-    expectedTexts.forEach(expected => expect(actualMutantTexts, `was: ${actualMutantTexts.join(',')}`).to.include(expected));
-  };
+export function verifySpecification(specification: (name: string, expectMutation: ExpectMutation) => void, MutatorClass: MutatorConstructor): void {
+  specification(new MutatorClass().name, (actual: string, ...expected: string[]) => expectMutation(new MutatorClass(), actual, ...expected));
+}
+
+export function expectMutation(mutator: NodeMutator, sourceText: string, ...expectedTexts: string[]) {
+  const tsFile = textFile({ content: sourceText });
+  const sourceFile = parseFile(tsFile, undefined);
+  const mutants = mutate(mutator, sourceFile, sourceFile);
+  expect(mutants).lengthOf(expectedTexts.length);
+  const actualMutantTexts = mutants
+    .map(mutant => mutantToString(mutant, sourceText))
+    .map(format);
+  expectedTexts.forEach(expected => {
+    expect(actualMutantTexts, `was: ${actualMutantTexts.join(',')}`).to.include(format(expected));
+  });
+}
+
+function format(code: string) {
+  const ast = parseFile(textFile({ content: code }), undefined);
+  return ts.createPrinter().printFile(ast);
 }
 
 function mutate(mutator: NodeMutator, node: ts.Node, sourceFile: ts.SourceFile): Mutant[] {


### PR DESCRIPTION
Create a generic mutator specification as a seperate npm package in order to reuse between the javascript-mutator and typescript-mutator (and other mutators in the future).