### PR TITLE
refactor(typescript): Set parent nodes

### DIFF
--- a/packages/stryker-typescript/src/TypescriptMutator.ts
+++ b/packages/stryker-typescript/src/TypescriptMutator.ts
@@ -3,7 +3,7 @@ import flatMap = require('lodash.flatmap');
 import { File } from 'stryker-api/core';
 import { Mutant } from 'stryker-api/mutant';
 import { Config } from 'stryker-api/config';
-import { filterOutTypescriptFiles, parseFile, getTSConfig } from './helpers/tsHelpers';
+import { filterTypescriptFiles, parseFile, getTSConfig } from './helpers/tsHelpers';
 import NodeMutator from './mutator/NodeMutator';
 import BinaryExpressionMutator from './mutator/BinaryExpressionMutator';
 import BooleanSubstitutionMutator from './mutator/BooleanSubstitutionMutator';
@@ -38,7 +38,7 @@ export default class TypescriptMutator {
   ]) { }
 
   mutate(inputFiles: File[]): Mutant[] {
-    const mutatedInputFiles = filterOutTypescriptFiles(inputFiles)
+    const mutatedInputFiles = filterTypescriptFiles(inputFiles)
       .filter(inputFile => inputFile.mutated);
     const compilerOptions = getTSConfig(this.config);
     const mutants = flatMap(mutatedInputFiles, inputFile => {

--- a/packages/stryker-typescript/src/TypescriptMutator.ts
+++ b/packages/stryker-typescript/src/TypescriptMutator.ts
@@ -3,7 +3,7 @@ import flatMap = require('lodash.flatmap');
 import { File } from 'stryker-api/core';
 import { Mutant } from 'stryker-api/mutant';
 import { Config } from 'stryker-api/config';
-import { createProgram } from './helpers/tsHelpers';
+import { filterOutTypescriptFiles, parseFile, getTSConfig } from './helpers/tsHelpers';
 import NodeMutator from './mutator/NodeMutator';
 import BinaryExpressionMutator from './mutator/BinaryExpressionMutator';
 import BooleanSubstitutionMutator from './mutator/BooleanSubstitutionMutator';
@@ -38,10 +38,11 @@ export default class TypescriptMutator {
   ]) { }
 
   mutate(inputFiles: File[]): Mutant[] {
-    const program = createProgram(inputFiles, this.config);
-    const mutatedInputFiles = inputFiles.filter(inputFile => inputFile.mutated);
+    const mutatedInputFiles = filterOutTypescriptFiles(inputFiles)
+      .filter(inputFile => inputFile.mutated);
+    const compilerOptions = getTSConfig(this.config);
     const mutants = flatMap(mutatedInputFiles, inputFile => {
-      const sourceFile = program.getSourceFile(inputFile.name);
+      const sourceFile = parseFile(inputFile, compilerOptions && compilerOptions.target);
       return this.mutateForNode(sourceFile, sourceFile);
     });
     return mutants;

--- a/packages/stryker-typescript/src/TypescriptTranspiler.ts
+++ b/packages/stryker-typescript/src/TypescriptTranspiler.ts
@@ -1,7 +1,7 @@
 import { Config } from 'stryker-api/config';
 import { Transpiler, TranspileResult, TranspilerOptions, FileLocation } from 'stryker-api/transpile';
 import { File } from 'stryker-api/core';
-import { filterOutTypescriptFiles, getCompilerOptions, getProjectDirectory, filterEmpty, isHeaderFile, guardTypescriptVersion, isTypescriptFile } from './helpers/tsHelpers';
+import { filterTypescriptFiles, getCompilerOptions, getProjectDirectory, filterNotEmpty, isHeaderFile, guardTypescriptVersion, isTypescriptFile } from './helpers/tsHelpers';
 import TranspilingLanguageService from './transpiler/TranspilingLanguageService';
 import { setGlobalLogLevel } from 'log4js';
 
@@ -19,7 +19,7 @@ export default class TypescriptTranspiler implements Transpiler {
   }
 
   transpile(files: File[]): Promise<TranspileResult> {
-    const typescriptFiles = filterOutTypescriptFiles(files)
+    const typescriptFiles = filterTypescriptFiles(files)
       .filter(file => file.transpiled);
     if (!this.languageService) {
       this.languageService = new TranspilingLanguageService(
@@ -47,7 +47,7 @@ export default class TypescriptTranspiler implements Transpiler {
       const implementationFiles = typescriptFiles.filter(file => !isHeaderFile(file));
       const outputFiles = this.languageService.emit(implementationFiles);
       // Keep original order of the files
-      const resultFiles = filterEmpty(allFiles.map(file => {
+      const resultFiles = filterNotEmpty(allFiles.map(file => {
         if (file.transpiled && isTypescriptFile(file)) {
           return outputFiles[file.name];
         } else {

--- a/packages/stryker-typescript/src/TypescriptTranspiler.ts
+++ b/packages/stryker-typescript/src/TypescriptTranspiler.ts
@@ -1,7 +1,7 @@
 import { Config } from 'stryker-api/config';
 import { Transpiler, TranspileResult, TranspilerOptions, FileLocation } from 'stryker-api/transpile';
 import { File } from 'stryker-api/core';
-import { filterOutTypescriptFiles, getCompilerOptions, getProjectDirectory, isToBeTranspiled, filterEmpty, guardTypescriptVersion } from './helpers/tsHelpers';
+import { filterOutTypescriptFiles, getCompilerOptions, getProjectDirectory, isTypescriptFile, filterEmpty, guardTypescriptVersion } from './helpers/tsHelpers';
 import TranspilingLanguageService from './transpiler/TranspilingLanguageService';
 import { setGlobalLogLevel } from 'log4js';
 
@@ -19,7 +19,8 @@ export default class TypescriptTranspiler implements Transpiler {
   }
 
   transpile(files: File[]): Promise<TranspileResult> {
-    const typescriptFiles = filterOutTypescriptFiles(files);
+    const typescriptFiles = filterOutTypescriptFiles(files)
+      .filter(file => file.transpiled);
     if (!this.languageService) {
       this.languageService = new TranspilingLanguageService(
         getCompilerOptions(this.config), typescriptFiles, getProjectDirectory(this.config), this.keepSourceMaps);
@@ -46,7 +47,7 @@ export default class TypescriptTranspiler implements Transpiler {
       const outputFiles = this.languageService.emit(typescriptFiles);
       // Keep original order of the files
       const resultFiles = filterEmpty(allFiles.map(file => {
-        if (isToBeTranspiled(file)) {
+        if (file.transpiled && isTypescriptFile(file)) {
           return outputFiles[file.name];
         } else {
           return file;

--- a/packages/stryker-typescript/src/helpers/tsHelpers.ts
+++ b/packages/stryker-typescript/src/helpers/tsHelpers.ts
@@ -74,10 +74,16 @@ export function isHeaderFile(file: File) {
   return file.name.endsWith('.d.ts');
 }
 
-export function filterOutTypescriptFiles(files: File[]): TextFile[] {
+/**
+ * Returns all the files that are considered typescript files (text files with *.ts or something like that)
+ */
+export function filterTypescriptFiles(files: File[]): TextFile[] {
   return files.filter(isTypescriptFile) as TextFile[];
 }
 
-export function filterEmpty<T>(input: (T | undefined | null)[]): T[] {
+/**
+ * Returns all items that are NOT undefined or null
+ */
+export function filterNotEmpty<T>(input: (T | undefined | null)[]): T[] {
   return input.filter(item => item !== void 0 && item !== null) as T[];
 }

--- a/packages/stryker-typescript/src/helpers/tsHelpers.ts
+++ b/packages/stryker-typescript/src/helpers/tsHelpers.ts
@@ -12,10 +12,18 @@ export function createProgram(inputFiles: File[], strykerConfig: Config) {
     .map(file => file.name);
   const options = getTSConfig(strykerConfig);
 
-  return ts.createProgram(files, options);
+  return ts.createProgram(files, options || {});
 }
 
-export function getTSConfig(strykerConfig: Config): ts.CompilerOptions {
+export function parseFile(file: TextFile, target: ts.ScriptTarget | undefined) {
+  return ts.createSourceFile(
+    file.name,
+    file.content,
+    target || ts.ScriptTarget.ES5,
+    /*setParentNodes*/ true);
+}
+
+export function getTSConfig(strykerConfig: Config): ts.CompilerOptions | undefined {
   return strykerConfig[CONFIG_KEY_OPTIONS];
 }
 
@@ -54,15 +62,14 @@ export function printNode(node: ts.Node, originalSourceFile: ts.SourceFile): str
 }
 
 const allExtensions: string[] = Object.keys(ts.Extension).map(extension => ts.Extension[extension as any]);
-export function isToBeTranspiled(file: File) {
+export function isTypescriptFile(file: File) {
   return file.kind === FileKind.Text &&
-    file.transpiled &&
     allExtensions.some(extension => file.name.endsWith(extension)) && !file.name.endsWith('.d.ts');
 }
 
 
 export function filterOutTypescriptFiles(files: File[]): TextFile[] {
-  return files.filter(isToBeTranspiled) as TextFile[];
+  return files.filter(isTypescriptFile) as TextFile[];
 }
 
 export function filterEmpty<T>(input: (T | undefined | null)[]): T[] {

--- a/packages/stryker-typescript/test/helpers/producers.ts
+++ b/packages/stryker-typescript/test/helpers/producers.ts
@@ -25,7 +25,7 @@ export const binaryFile = factoryMethod<BinaryFile>(() => ({
 }));
 
 export const textFile = factoryMethod<TextFile>(() => ({
-  name: '',
+  name: 'file.ts',
   content: 'c = a^2 + b^2',
   mutated: true,
   included: true,

--- a/packages/stryker-typescript/test/unit/helpers/tsHelpersSpec.ts
+++ b/packages/stryker-typescript/test/unit/helpers/tsHelpersSpec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as tsHelpers from '../../../src/helpers/tsHelpers';
 import * as semver from 'semver';
 import * as ts from 'typescript';
+import { textFile } from '../../helpers/producers';
 
 describe('tsHelpers', () => {
 
@@ -22,6 +23,16 @@ describe('tsHelpers', () => {
     it('should not throw an error if installed version satisfies >=2.5', () => {
       satisfiesStub.returns(true);
       expect(() => tsHelpers.guardTypescriptVersion()).not.throws();
+    });
+  });
+
+  describe('parseFile', () => {
+    it('should also set parent nodes', () => {
+      const input = textFile({ content: 'const b: string = "hello world";' });
+      const actual = tsHelpers.parseFile(input, undefined);
+      ts.forEachChild(actual, node => {
+        expect(node.parent).ok;
+      });
     });
   });
 });

--- a/packages/stryker-typescript/test/unit/mutator/mutatorAssertions.ts
+++ b/packages/stryker-typescript/test/unit/mutator/mutatorAssertions.ts
@@ -1,11 +1,14 @@
 import * as ts from 'typescript';
+import { parseFile } from '../../../src/helpers/tsHelpers';
 import { expect } from 'chai';
 import { Mutant } from 'stryker-api/mutant';
 import NodeMutator from '../../../src/mutator/NodeMutator';
+import { textFile } from '../../helpers/producers';
 
 
 export function expectMutation(mutator: NodeMutator, sourceText: string, ...expectedTexts: string[]) {
-  const sourceFile = ts.createSourceFile('file.ts', sourceText, ts.ScriptTarget.ES5);
+  const tsFile = textFile({ content: sourceText });
+  const sourceFile = parseFile(tsFile, undefined);
   const mutants = mutate(mutator, sourceFile, sourceFile);
   expect(mutants).lengthOf(expectedTexts.length);
   const actualMutantTexts = mutants.map(mutant => mutantToString(mutant, sourceText));


### PR DESCRIPTION
Use a slightly more low level api to parse typescript files so we can force typescript to set parent nodes. This is useful for creating node mutators, as we can use information about the parent to determine what tho mutate.