### PR TITLE
refactor(sinon): Use createSandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/progress": "^1.1.28",
     "@types/rimraf": "0.0.28",
     "@types/sinon": "^4.0.0",
-    "@types/sinon-chai": "^2.7.27",
+    "@types/sinon-chai": "^2.7.29",
     "browserify": "^14.3.0",
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
@@ -36,7 +36,7 @@
     "protractor": "^5.1.2",
     "rimraf": "^2.6.1",
     "sinon": "^4.0.0",
-    "sinon-chai": "^2.10.0",
+    "sinon-chai": "^2.14.0",
     "source-map-support": "^0.4.16",
     "tslint": "^5.6.0",
     "typescript": "^2.6.1"

--- a/packages/stryker-html-reporter/test/unit/HtmlReporter.spec.ts
+++ b/packages/stryker-html-reporter/test/unit/HtmlReporter.spec.ts
@@ -15,7 +15,7 @@ describe('HtmlReporter', () => {
   let sut: HtmlReporter;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     copyFolderStub = sandbox.stub(util, 'copyFolder');
     writeFileStub = sandbox.stub(util, 'writeFile');
     deleteDirStub = sandbox.stub(util, 'deleteDir');

--- a/packages/stryker-jasmine/test/unit/index.spec.ts
+++ b/packages/stryker-jasmine/test/unit/index.spec.ts
@@ -11,7 +11,7 @@ describe('index', () => {
   let testFrameworkFactoryMock: any;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     testFrameworkFactoryMock = mockFactory();
 
     sandbox.stub(TestFrameworkFactory, 'instance').returns(testFrameworkFactoryMock);

--- a/packages/stryker-javascript-mutator/test/helpers/initSinon.ts
+++ b/packages/stryker-javascript-mutator/test/helpers/initSinon.ts
@@ -3,7 +3,7 @@ import * as log4js from 'log4js';
 import LogMock from './LogMock';
 
 beforeEach(() => {
-  global.sandbox = sinon.sandbox.create();
+  global.sandbox = sinon.createSandbox();
   global.logMock = new LogMock();
   global.sandbox.stub(log4js, 'getLogger').returns(global.logMock);
 });

--- a/packages/stryker-karma-runner/test/unit/KarmaConfigEditorSpec.ts
+++ b/packages/stryker-karma-runner/test/unit/KarmaConfigEditorSpec.ts
@@ -12,7 +12,7 @@ describe('KarmaConfigEditor', () => {
 
   beforeEach(() => {
     sut = new KarmaConfigEditor();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     karmaConfigReader = { read: sandbox.stub() };
     sandbox.stub(karmaConfigReaderModule, 'default').returns(karmaConfigReader);
     config = new Config();

--- a/packages/stryker-karma-runner/test/unit/KarmaConfigReaderSpec.ts
+++ b/packages/stryker-karma-runner/test/unit/KarmaConfigReaderSpec.ts
@@ -15,7 +15,7 @@ describe('KarmaConfigReader', () => {
 
   beforeEach(() => {
     log = new LoggerStub();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     karmaConfigModule = sandbox.stub();
     sandbox.stub(utils, 'requireModule').returns(karmaConfigModule);
     sandbox.stub(cfg, 'parseConfig');

--- a/packages/stryker-karma-runner/test/unit/KarmaTestRunnerSpec.ts
+++ b/packages/stryker-karma-runner/test/unit/KarmaTestRunnerSpec.ts
@@ -18,7 +18,7 @@ describe('KarmaTestRunner', () => {
       port: 0,
       strykerOptions: {}
     };
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(karma.stopper, 'stop');
     sandbox.stub(karma, 'Server').returns({ on: sandbox.stub(), start: sandbox.stub() });
   });

--- a/packages/stryker-mocha-framework/test/unit/MochaConfigWriterSpec.ts
+++ b/packages/stryker-mocha-framework/test/unit/MochaConfigWriterSpec.ts
@@ -12,7 +12,7 @@ describe('MochaConfigEditor', () => {
   let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     log = {
       warn: sandbox.stub()
     };

--- a/packages/stryker-mocha-runner/test/helpers/initSinon.ts
+++ b/packages/stryker-mocha-runner/test/helpers/initSinon.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 
 beforeEach(() => {
-  global.sandbox = sinon.sandbox.create();
+  global.sandbox = sinon.createSandbox();
 });
 
 afterEach(() => {

--- a/packages/stryker-typescript/test/helpers/initSinon.ts
+++ b/packages/stryker-typescript/test/helpers/initSinon.ts
@@ -3,7 +3,7 @@ import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 beforeEach(() => {
-  global.sandbox = sinon.sandbox.create();
+  global.sandbox = sinon.createSandbox();
 });
 afterEach(() => {
   global.sandbox.restore();

--- a/packages/stryker/test/helpers/initSinon.ts
+++ b/packages/stryker/test/helpers/initSinon.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 
 beforeEach(() => {
-  global.sandbox = sinon.sandbox.create();
+  global.sandbox = sinon.createSandbox();
 });
 
 afterEach(() => {

--- a/packages/stryker/test/integration/utils/fileUtilsSpec.ts
+++ b/packages/stryker/test/integration/utils/fileUtilsSpec.ts
@@ -7,7 +7,7 @@ describe('fileUtils', () => {
   let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => sandbox.restore());

--- a/packages/stryker/test/unit/ConfigValidatorSpec.ts
+++ b/packages/stryker/test/unit/ConfigValidatorSpec.ts
@@ -17,7 +17,7 @@ describe('ConfigValidator', () => {
   beforeEach(() => {
     log = currentLogMock();
     config = new Config();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     exitStub = sandbox.stub(process, 'exit');
   });
 

--- a/packages/stryker/test/unit/PluginLoaderSpec.ts
+++ b/packages/stryker/test/unit/PluginLoaderSpec.ts
@@ -18,7 +18,7 @@ describe('PluginLoader', () => {
 
   beforeEach(() => {
     log = currentLogMock();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     importModuleStub = sandbox.stub(fileUtils, 'importModule');
     pluginDirectoryReadMock = sandbox.stub(fs, 'readdirSync');
   });

--- a/packages/stryker/test/unit/ReporterOrchestratorSpec.ts
+++ b/packages/stryker/test/unit/ReporterOrchestratorSpec.ts
@@ -11,7 +11,7 @@ describe('ReporterOrchestrator', () => {
   let broadcastReporterMock: sinon.SinonStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     broadcastReporterMock = sandbox.stub(broadcastReporter, 'default');
     captureTTY();
   });

--- a/packages/stryker/test/unit/ScoreResultCalculatorSpec.ts
+++ b/packages/stryker/test/unit/ScoreResultCalculatorSpec.ts
@@ -166,7 +166,7 @@ describe('ScoreResult', () => {
     let setExitCodeStub: sinon.SinonStub;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       setExitCodeStub = sandbox.stub(objectUtils, 'setExitCode');
     });
 

--- a/packages/stryker/test/unit/TestFrameworkOrchestratorSpec.ts
+++ b/packages/stryker/test/unit/TestFrameworkOrchestratorSpec.ts
@@ -42,7 +42,7 @@ describe('TestFrameworkOrchestrator', () => {
 
   beforeEach(() => {
     options = { coverageAnalysis: 'perTest' };
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(TestFrameworkFactory.instance(), 'create').returns(testFramework);
     sandbox.stub(TestFrameworkFactory.instance(), 'knownNames').returns(['awesomeFramework', 'unusedTestFramework']);
   });

--- a/packages/stryker/test/unit/initializer/StrykerInitializerSpec.ts
+++ b/packages/stryker/test/unit/initializer/StrykerInitializerSpec.ts
@@ -23,7 +23,7 @@ describe('StrykerInitializer', () => {
 
   beforeEach(() => {
     log = currentLogMock();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     out = sandbox.stub();
     inquirerPrompt = sandbox.stub(inquirer, 'prompt');
     childExecSync = sandbox.stub(child, 'execSync');

--- a/packages/stryker/test/unit/isolated-runner/IsolatedTestRunnerAdapterSpec.ts
+++ b/packages/stryker/test/unit/isolated-runner/IsolatedTestRunnerAdapterSpec.ts
@@ -28,7 +28,7 @@ describe('IsolatedTestRunnerAdapter', () => {
       sandboxWorkingFolder: 'a working directory',
       strykerOptions: {}
     };
-    sinonSandbox = sinon.sandbox.create();
+    sinonSandbox = sinon.createSandbox();
     fakeChildProcess = {
       kill: sinon.stub(),
       send: sinon.stub(),

--- a/packages/stryker/test/unit/isolated-runner/TimeoutDecoratorSpec.ts
+++ b/packages/stryker/test/unit/isolated-runner/TimeoutDecoratorSpec.ts
@@ -14,7 +14,7 @@ describe('TimeoutDecorator', () => {
   let availableTestRunners: TestRunnerMock[];
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     clock = sandbox.useFakeTimers();
     testRunner1 = new TestRunnerMock();
     testRunner2 = new TestRunnerMock();

--- a/packages/stryker/test/unit/reporters/ClearTextReporterSpec.ts
+++ b/packages/stryker/test/unit/reporters/ClearTextReporterSpec.ts
@@ -13,7 +13,7 @@ describe('ClearTextReporter', () => {
   let stdoutStub: sinon.SinonStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     stdoutStub = sandbox.stub(process.stdout, 'write');
   });
 

--- a/packages/stryker/test/unit/reporters/DotsReporterSpec.ts
+++ b/packages/stryker/test/unit/reporters/DotsReporterSpec.ts
@@ -12,7 +12,7 @@ describe('DotsReporter', () => {
 
   beforeEach(() => {
     sut = new DotsReporter();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(process.stdout, 'write');
   });
 

--- a/packages/stryker/test/unit/reporters/EventRecorderReporterSpec.ts
+++ b/packages/stryker/test/unit/reporters/EventRecorderReporterSpec.ts
@@ -16,7 +16,7 @@ describe('EventRecorderReporter', () => {
   let writeFileStub: sinon.SinonStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     cleanFolderStub = sandbox.stub(fileUtils, 'cleanFolder');
     writeFileStub = sandbox.stub(fs, 'writeFile');
   });

--- a/packages/stryker/test/unit/reporters/ProgressAppendOnlyReporterSpec.ts
+++ b/packages/stryker/test/unit/reporters/ProgressAppendOnlyReporterSpec.ts
@@ -11,7 +11,7 @@ describe('ProgressAppendOnlyReporter', () => {
 
   beforeEach(() => {
     sut = new ProgressAppendOnlyReporter();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.useFakeTimers();
     sandbox.stub(process.stdout, 'write');
   });

--- a/packages/stryker/test/unit/reporters/ProgressReporterSpec.ts
+++ b/packages/stryker/test/unit/reporters/ProgressReporterSpec.ts
@@ -17,7 +17,7 @@ describe('ProgressReporter', () => {
 
   beforeEach(() => {
     sut = new ProgressReporter();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     progressBar = mock(ProgressBar);
     sandbox.stub(progressBarModule, 'default').returns(progressBar);
   });

--- a/packages/stryker/test/unit/utils/TempFolderSpec.ts
+++ b/packages/stryker/test/unit/utils/TempFolderSpec.ts
@@ -13,7 +13,7 @@ describe('TempFolder', () => {
   const mockCwd = '/x/y/z/some/dir';
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     sandbox.stub(mkdirp, 'sync');
     sandbox.stub(fs, 'writeFile');


### PR DESCRIPTION
sinon.createSandbox maps to sinon.sandbox.create but all documentation now refers to sinon.createSandbox.