### PR TITLE
chore(travis): Build against latest LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
 - node
 - 'lts/*'
-- '7'
 - '6'
 - '4'
 install: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - node
+- 'lts/*'
 - '7'
 - '6'
 - '4'


### PR DESCRIPTION
I noticed that Node v8 is missing from the travis builds since 9 was released