### PR TITLE
feat(typescript): Backport to TS2.4

### DIFF
--- a/packages/stryker-typescript/package.json
+++ b/packages/stryker-typescript/package.json
@@ -11,7 +11,7 @@
     "postbuild": "tslint -p tsconfig.json",
     "test": "npm run test:ts2.4 && npm run test:current",
     "test:current": "nyc --reporter=html --report-dir=reports/coverage --check-coverage --lines 85 --functions 90 --branches 65 mocha \"test/helpers/**/*.js\" \"test/unit/**/*.js\" \"test/integration/**/*.js\"",
-    "test:ts2.4": "npm i --no-save typescript@~2.4 && npm run test:current && npm uninstall typescript"
+    "test:ts2.4": "npm i --no-save typescript@~2.4 && npm link ../stryker-api && npm run test:current && npm uninstall typescript && npm link ../stryker-api"
   },
   "repository": {
     "type": "git",

--- a/packages/stryker-typescript/package.json
+++ b/packages/stryker-typescript/package.json
@@ -4,6 +4,7 @@
   "description": "A plugin for TypeScript-based projects using Stryker",
   "main": "src/index.js",
   "scripts": {
+    "bootstrap": "npm link ../stryker-api && npm link ../stryker-mutator-specification",
     "start": "tsc -w",
     "clean": "rimraf \"+(test|src)/**/*+(.d.ts|.js|.map)\" reports",
     "prebuild": "npm run clean",
@@ -11,7 +12,7 @@
     "postbuild": "tslint -p tsconfig.json",
     "test": "npm run test:ts2.4 && npm run test:current",
     "test:current": "nyc --reporter=html --report-dir=reports/coverage --check-coverage --lines 85 --functions 90 --branches 65 mocha \"test/helpers/**/*.js\" \"test/unit/**/*.js\" \"test/integration/**/*.js\"",
-    "test:ts2.4": "npm i --no-save typescript@~2.4 && npm link ../stryker-api && npm run test:current && npm uninstall typescript && npm link ../stryker-api"
+    "test:ts2.4": "npm i --no-save typescript@~2.4 && npm run bootstrap && npm run test:current && npm uninstall typescript && npm run bootstrap "
   },
   "repository": {
     "type": "git",

--- a/packages/stryker-typescript/package.json
+++ b/packages/stryker-typescript/package.json
@@ -9,7 +9,9 @@
     "prebuild": "npm run clean",
     "build": "tsc -p .",
     "postbuild": "tslint -p tsconfig.json",
-    "test": "nyc --reporter=html --report-dir=reports/coverage --check-coverage --lines 85 --functions 90 --branches 65 mocha \"test/helpers/**/*.js\" \"test/unit/**/*.js\" \"test/integration/**/*.js\""
+    "test": "npm run test:ts2.4 && npm run test:current",
+    "test:current": "nyc --reporter=html --report-dir=reports/coverage --check-coverage --lines 85 --functions 90 --branches 65 mocha \"test/helpers/**/*.js\" \"test/unit/**/*.js\" \"test/integration/**/*.js\"",
+    "test:ts2.4": "npm i --no-save typescript@~2.4 && npm run test:current && npm uninstall typescript"
   },
   "repository": {
     "type": "git",
@@ -51,7 +53,7 @@
   },
   "peerDependencies": {
     "stryker-api": "^0.11.0",
-    "typescript": "^2.5.0"
+    "typescript": "^2.4.2"
   },
   "initStrykerConfig": {
     "tsconfigFile": "tsconfig.json",

--- a/packages/stryker-typescript/test/unit/helpers/tsHelpersSpec.ts
+++ b/packages/stryker-typescript/test/unit/helpers/tsHelpersSpec.ts
@@ -6,26 +6,27 @@ import { textFile } from '../../helpers/producers';
 
 describe('tsHelpers', () => {
 
+
   let satisfiesStub: sinon.SinonStub;
-
-  beforeEach(() => {
-    satisfiesStub = sandbox.stub(semver, 'satisfies');
-  });
-
-  describe('guardTypescriptVersion', () => {
-
-    it('should throw an error when installed typescript version does not satisfy >=2.5', () => {
-      satisfiesStub.returns(false);
-      expect(() => tsHelpers.guardTypescriptVersion()).throws(`Installed typescript version ${ts.version} is not supported by stryker-typescript. Please install version 2.5 or higher (\`npm install typescript@^2.5\`).`);
-      expect(satisfiesStub).calledWith(ts.version, '>=2.5');
+  
+    beforeEach(() => {
+      satisfiesStub = sandbox.stub(semver, 'satisfies');
     });
-
-    it('should not throw an error if installed version satisfies >=2.5', () => {
-      satisfiesStub.returns(true);
-      expect(() => tsHelpers.guardTypescriptVersion()).not.throws();
+  
+    describe('guardTypescriptVersion', () => {
+  
+      it('should throw an error when installed typescript version does not satisfy >=2.4', () => {
+        satisfiesStub.returns(false);
+        expect(() => tsHelpers.guardTypescriptVersion()).throws(`Installed typescript version ${ts.version} is not supported by stryker-typescript. Please install version 2.5 or higher (\`npm install typescript@^2.5\`).`);
+        expect(satisfiesStub).calledWith(ts.version, '>=2.4');
+      });
+  
+      it('should not throw an error if installed version satisfies >=2.4', () => {
+        satisfiesStub.returns(true);
+        expect(() => tsHelpers.guardTypescriptVersion()).not.throws();
+      });
     });
-  });
-
+  
   describe('parseFile', () => {
     it('should also set parent nodes', () => {
       const input = textFile({ content: 'const b: string = "hello world";' });


### PR DESCRIPTION
Make stryker-typescript compatible with ts2.4. Note: angular 5 supports ts2.4.

* Update a few tests
* Change the version guard from <=2.5 to <=2.4
* Make sure `npm test` in stryker-typescript runs all tests against version current (2.6) as well as 2.4