### PR TITLE
 chore(dependencies): Upgrade to chalk 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "@types/babel-core": "^6.25.2",
     "@types/chai": "4.0.6",
     "@types/chai-as-promised": "7.1.0",
-    "@types/chalk": "^0.4.28",
     "@types/commander": "^2.9.0",
     "@types/escodegen": "0.0.6",
     "@types/esprima": "^2.1.31",

--- a/packages/stryker/package.json
+++ b/packages/stryker/package.json
@@ -53,7 +53,7 @@
     "stryker": "./bin/stryker"
   },
   "dependencies": {
-    "chalk": "^1.1.1",
+    "chalk": "^2.3.0",
     "commander": "^2.9.0",
     "escodegen": "^1.8.0",
     "esprima": "^2.7.0",

--- a/packages/stryker/src/reporters/ClearTextReporter.ts
+++ b/packages/stryker/src/reporters/ClearTextReporter.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import { getLogger } from 'log4js';
 import { Reporter, MutantResult, MutantStatus, ScoreResult } from 'stryker-api/report';
 import { Config } from 'stryker-api/config';

--- a/packages/stryker/src/reporters/ClearTextScoreTable.ts
+++ b/packages/stryker/src/reporters/ClearTextScoreTable.ts
@@ -2,7 +2,7 @@ import { MutationScoreThresholds } from 'stryker-api/core';
 import { ScoreResult } from 'stryker-api/report';
 import * as os from 'os';
 import * as _ from 'lodash';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 
 const FILES_ROOT_NAME = 'All files';
 

--- a/packages/stryker/src/reporters/DotsReporter.ts
+++ b/packages/stryker/src/reporters/DotsReporter.ts
@@ -1,5 +1,5 @@
 import {Reporter, MutantResult, MutantStatus} from 'stryker-api/report';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as os from 'os';
 
 export default class DotsReporter implements Reporter {

--- a/packages/stryker/test/unit/reporters/ClearTextReporterSpec.ts
+++ b/packages/stryker/test/unit/reporters/ClearTextReporterSpec.ts
@@ -1,7 +1,7 @@
 import * as os from 'os';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as _ from 'lodash';
 import { MutantStatus, MutantResult } from 'stryker-api/report';
 import ClearTextReporter from '../../../src/reporters/ClearTextReporter';

--- a/packages/stryker/test/unit/reporters/DotsReporterSpec.ts
+++ b/packages/stryker/test/unit/reporters/DotsReporterSpec.ts
@@ -2,7 +2,7 @@ import DotsReporter from '../../../src/reporters/DotsReporter';
 import * as sinon from 'sinon';
 import { MutantStatus, MutantResult } from 'stryker-api/report';
 import { expect } from 'chai';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as os from 'os';
 
 describe('DotsReporter', () => {


### PR DESCRIPTION
The types are now included with the release of chalk so they have been removed from the devDependencies.