### PR TITLE
fix(StringLiteralMutator): Don't mutate string literals in types

### DIFF
--- a/packages/stryker-mutator-specification/src/StringLiteralMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/StringLiteralMutatorSpec.ts
@@ -42,5 +42,10 @@ export default function StringLiteralMutatorSpec(name: string, expectMutation: E
       expectMutation('import foo from "foo";');
       expectMutation('import "foo";');
     });
+
+    it('should not mutate type declarations', () => {
+      expectMutation('const a: "hello" = "hello";', 'const a: "hello" = "";');
+      expectMutation('const a: Record<"id", number> = { id: 10 }');
+    });
   });
 }

--- a/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
+++ b/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
@@ -18,8 +18,13 @@ export default class StringLiteralMutator extends NodeMutator<AllStringLiterals>
       || node.kind === ts.SyntaxKind.FirstTemplateToken;
   }
 
+  private isInvalidParentNode(node: ts.Node): boolean {
+    return node.kind === ts.SyntaxKind.ImportDeclaration ||
+      node.kind === ts.SyntaxKind.LastTypeNode;
+  }
+
   protected identifyReplacements(str: AllStringLiterals, sourceFile: ts.SourceFile): NodeReplacement[] {
-    if (str.parent && str.parent.kind === ts.SyntaxKind.ImportDeclaration) {
+    if (str.parent && this.isInvalidParentNode(str.parent)) {
       return [];
     }
 


### PR DESCRIPTION
Fixes #563 .

Removes the ability to mutate the `StringLiterals` inside type definitions.