### PR TITLE
test(typescript): remove ts2.4 from build

### DIFF
--- a/packages/stryker-typescript/package.json
+++ b/packages/stryker-typescript/package.json
@@ -10,9 +10,7 @@
     "prebuild": "npm run clean",
     "build": "tsc -p .",
     "postbuild": "tslint -p tsconfig.json",
-    "test": "npm run test:ts2.4 && npm run test:current",
-    "test:current": "nyc --reporter=html --report-dir=reports/coverage --check-coverage --lines 85 --functions 90 --branches 65 mocha \"test/helpers/**/*.js\" \"test/unit/**/*.js\" \"test/integration/**/*.js\"",
-    "test:ts2.4": "npm i --no-save typescript@~2.4 && npm run bootstrap && npm run test:current && npm uninstall typescript && npm run bootstrap "
+    "test": "nyc --reporter=html --report-dir=reports/coverage --check-coverage --lines 85 --functions 90 --branches 65 mocha \"test/helpers/**/*.js\" \"test/unit/**/*.js\" \"test/integration/**/*.js\""
   },
   "repository": {
     "type": "git",

--- a/packages/stryker-typescript/test/integration/ownDogFoodSpec.ts
+++ b/packages/stryker-typescript/test/integration/ownDogFoodSpec.ts
@@ -9,7 +9,7 @@ import { textFile } from '../helpers/producers';
 import { setGlobalLogLevel } from 'log4js';
 
 describe('stryker-typescript', function () {
-  this.timeout(10000);
+  this.timeout(20000);
 
   let config: Config;
   let inputFiles: TextFile[];


### PR DESCRIPTION
The ts 2.4 specific tests in stryker-typescript has some problems running on node 9.5 npm 5.6, removing it from the build.