### PR TITLE
fix(babel-transpiler): log babel config on debug

### DIFF
--- a/packages/stryker-babel-transpiler/src/BabelConfigReader.ts
+++ b/packages/stryker-babel-transpiler/src/BabelConfigReader.ts
@@ -8,8 +8,8 @@ export default class BabelConfigReader {
   private readonly log = getLogger(BabelConfigReader.name);
 
   public readConfig(config: Config): babel.TransformOptions {
-    let babelrc = config[CONFIG_KEY_OPTIONS] || this.getConfigFile(config) || {};
-    this.log.trace(`babel config is: ${JSON.stringify(config[CONFIG_KEY_OPTIONS])}`);
+    const babelrc = config[CONFIG_KEY_OPTIONS] || this.getConfigFile(config) || {};
+    this.log.debug(`babel config is: ${JSON.stringify(babelrc, null, 2)}`);
     return babelrc;
   }
 

--- a/packages/stryker-babel-transpiler/test/unit/BabelConfigReaderSpec.ts
+++ b/packages/stryker-babel-transpiler/test/unit/BabelConfigReaderSpec.ts
@@ -11,7 +11,8 @@ describe('BabelConfigReader', () => {
   let logStub: {
     trace: sinon.SinonStub,
     info: sinon.SinonStub,
-    error: sinon.SinonStub
+    error: sinon.SinonStub,
+    debug: sinon.SinonStub
   };
 
   beforeEach(() => {
@@ -19,7 +20,8 @@ describe('BabelConfigReader', () => {
     logStub = {
       trace: sandbox.stub(),
       info: sandbox.stub(),
-      error: sandbox.stub()
+      error: sandbox.stub(),
+      debug: sandbox.stub()
     };
 
     sandbox.stub(log4js, 'getLogger').returns(logStub);
@@ -63,6 +65,17 @@ describe('BabelConfigReader', () => {
       editor.readConfig(config);
 
       expect(logStub.info).calledWith(`Reading .babelrc file from path "${path.resolve(config.babelrcFile)}"`);
+    });
+    
+    it('should log the babel config if read from an babelrc file', () => {
+      const editor = new BabelConfigReader();
+      const config = new Config();
+      config.set({ babelrcFile: '.babelrc' });
+      sandbox.stub(fs, 'readFileSync').returns('{ "presets": ["env"] }');
+      sandbox.stub(fs, 'existsSync').returns(true);
+      editor.readConfig(config);
+
+      expect(logStub.debug).calledWith(`babel config is: ${JSON.stringify({ presets: ['env']}, null, 2)}`);
     });
 
     describe('when reading the file throws an error', () => {


### PR DESCRIPTION
Log babel config on debug. Instead of logging only babel config from the `babelConfig` option, now log the resulting config from `babelrcFile` as well.