### PR TITLE
feat(javascript-mutator): support more plugins by default

### DIFF
--- a/packages/stryker-javascript-mutator/src/helpers/BabelParser.ts
+++ b/packages/stryker-javascript-mutator/src/helpers/BabelParser.ts
@@ -11,7 +11,11 @@ export default class BabelParser {
       sourceType: 'script',
       plugins: [
         'jsx',
-        'flow'
+        'flow',
+        'objectRestSpread',
+        'classProperties',
+        'asyncGenerators',
+        'dynamicImport'
       ]
     };
 

--- a/packages/stryker-javascript-mutator/test/unit/JavaScriptMutatorSpec.ts
+++ b/packages/stryker-javascript-mutator/test/unit/JavaScriptMutatorSpec.ts
@@ -141,6 +141,41 @@ describe('JavaScriptMutator', () => {
     });
   });
 
+  it('should generate mutants for js vnext code', () => {
+    const sut = new JavaScriptMutator(new Config());
+    const files: File[] = [
+      {
+        name: 'testFile.js',
+        included: false,
+        mutated: true,
+        transpiled: false,
+        kind: FileKind.Text,
+        content: `
+          function objectRestSpread(input) {
+            return {
+              ...input,
+              foo: true,
+            };
+          }
+
+          class ClassProperties { b = 1; }
+
+          async function* asyncGenerators(i) {
+            yield i;
+            yield i + 10;
+          }
+
+          function dynamicImport(){
+            import('./guy').then(a)
+          }
+        `
+      }
+    ];
+
+    const mutants = sut.mutate(files);
+    expect(mutants).lengthOf.above(2);
+  });
+
   it('should generate mutants for multiple files', () => {
     let mutator = new JavaScriptMutator(new Config());
     let file: File = {


### PR DESCRIPTION
Add these plugins by default:  `'objectRestSpread', 'classProperties', 'asyncGenerators', 'dynamicImport'`

Fixes #612 