### PR TITLE
fix(coverage-analysis): make sure to not erase sourceMappingURL comment

### DIFF
--- a/packages/stryker/package.json
+++ b/packages/stryker/package.json
@@ -59,7 +59,7 @@
     "esprima": "^2.7.0",
     "glob": "^7.0.3",
     "inquirer": "^3.0.6",
-    "istanbul-lib-instrument": "^1.9.1",
+    "istanbul-lib-instrument": "^1.9.2",
     "lodash": "^4.17.4",
     "log4js": "^1.1.0",
     "mkdirp": "^0.5.1",

--- a/packages/stryker/src/transpiler/CoverageInstrumenterTranspiler.ts
+++ b/packages/stryker/src/transpiler/CoverageInstrumenterTranspiler.ts
@@ -24,7 +24,7 @@ export default class CoverageInstrumenterTranspiler implements Transpiler {
   private log: Logger;
 
   constructor(private settings: TranspilerOptions, private testFramework: TestFramework | null) {
-    this.instrumenter = createInstrumenter({ coverageVariable: this.coverageVariable });
+    this.instrumenter = createInstrumenter({ coverageVariable: this.coverageVariable, preserveComments: true });
     this.log = getLogger(CoverageInstrumenterTranspiler.name);
   }
 

--- a/packages/stryker/test/unit/transpiler/CoverageInstrumenterTranspilerSpec.ts
+++ b/packages/stryker/test/unit/transpiler/CoverageInstrumenterTranspilerSpec.ts
@@ -44,6 +44,16 @@ describe('CoverageInstrumenterTranspiler', () => {
       expect(instrumentedContent).to.contain('function something(){cov_').and.contain('.f[0]++');
     });
 
+    it('should preserve source map comments', async () => { 
+      const input = [
+        textFile({ mutated: true, content: 'function something() {} // # sourceMappingUrl="something.map.js"' }),
+      ];
+      const output = await sut.transpile(input);
+      expect(output.error).null;
+      const instrumentedContent = (output.outputFiles[0] as TextFile).content;
+      expect(instrumentedContent).to.contain('sourceMappingUrl="something.map.js"');
+    });
+
     it('should create a statement map for mutated files', () => {
       const input = [
         textFile({ name: 'something.js', mutated: true, content: 'function something () {}' }),


### PR DESCRIPTION
The default for `preserveComments` of istanbul-lib-instrumenter was changed (true to false). Make sure it is true so the sourceMappingURL is not overwritten.

Fixes #624 