### PR TITLE
feat(stryker): Add excludedMutations as a config option (#13)

### DIFF
--- a/packages/stryker-api/core.ts
+++ b/packages/stryker-api/core.ts
@@ -5,4 +5,5 @@ export { default as Position } from './src/core/Position';
 export { default as Location } from './src/core/Location';
 export { default as Range } from './src/core/Range';
 export { default as InputFileDescriptor } from './src/core/InputFileDescriptor';
+export { default as MutatorDescriptor } from './src/core/MutatorDescriptor';
 export { default as MutationScoreThresholds } from './src/core/MutationScoreThresholds';

--- a/packages/stryker-api/src/config/Config.ts
+++ b/packages/stryker-api/src/config/Config.ts
@@ -17,6 +17,7 @@ export default class Config implements StrykerOptions {
   testRunner: string;
   testFramework: string;
   mutator: string = 'es5';
+  excludedMutations: string[] = [];
   transpilers: string[] = [];
   maxConcurrentTestRunners: number = Infinity;
   thresholds: MutationScoreThresholds = {

--- a/packages/stryker-api/src/config/Config.ts
+++ b/packages/stryker-api/src/config/Config.ts
@@ -1,4 +1,4 @@
-import { StrykerOptions, InputFileDescriptor, MutationScoreThresholds } from '../../core';
+import { StrykerOptions, InputFileDescriptor, MutatorDescriptor, MutationScoreThresholds } from '../../core';
 
 export default class Config implements StrykerOptions {
 
@@ -16,8 +16,7 @@ export default class Config implements StrykerOptions {
   coverageAnalysis: 'perTest' | 'all' | 'off' = 'perTest';
   testRunner: string;
   testFramework: string;
-  mutator: string = 'es5';
-  excludedMutations: string[] = [];
+  mutator: string | MutatorDescriptor = 'es5';
   transpilers: string[] = [];
   maxConcurrentTestRunners: number = Infinity;
   thresholds: MutationScoreThresholds = {

--- a/packages/stryker-api/src/core/MutatorDescriptor.ts
+++ b/packages/stryker-api/src/core/MutatorDescriptor.ts
@@ -1,0 +1,7 @@
+
+interface MutatorDescriptor {
+  name: string;
+  excludedMutations: Array<string>;
+}
+
+export default MutatorDescriptor;

--- a/packages/stryker-api/src/core/StrykerOptions.ts
+++ b/packages/stryker-api/src/core/StrykerOptions.ts
@@ -54,10 +54,10 @@ interface StrykerOptions {
    * This is often dependent on the language of your source files.
    *
    * This value can be either a string, or an object with 2 properties:
-   * * `string`: The name of the mutant generator to use. For example: 'es5', 'typescript'
+   * * `string`: The name of the mutant generator to use. For example: 'javascript', 'typescript'
    * * { name: 'name', excludedMutations: ['mutationType1', 'mutationType2'] }:
    *    * The `name` property is mandatory and contains the name of the mutant generator to use.
-   *    * For example: 'es5', 'typescript'
+   *    * For example: 'javascript', 'typescript'
    *    * The `excludedMutations` property is mandatory and contains the names of the specific mutation types to exclude from testing.
    *    * The values must match the given names of the mutations. For example: 'BinaryExpression', 'BooleanSubstitution', etc.
    */

--- a/packages/stryker-api/src/core/StrykerOptions.ts
+++ b/packages/stryker-api/src/core/StrykerOptions.ts
@@ -56,6 +56,13 @@ interface StrykerOptions {
   mutator?: string;
 
   /**
+   * The names of the specific mutation types to exclude from testing.
+   * The names must match the given names of the mutations.
+   * For example: 'BinaryExpression', 'BooleanSubstitution', etc.
+   */
+  excludedMutations?: string[];
+
+  /**
    * The names of the transpilers to use (in order). Default: [].
    * A transpiler in this context is a plugin that can transform input files (source code)
    * before testing.

--- a/packages/stryker-api/src/core/StrykerOptions.ts
+++ b/packages/stryker-api/src/core/StrykerOptions.ts
@@ -1,5 +1,6 @@
 import InputFileDescriptor from './InputFileDescriptor';
 import MutationScoreThresholds from './MutationScoreThresholds';
+import MutatorDescriptor from './MutatorDescriptor';
 
 interface StrykerOptions {
   // this ensures that custom config for for example 'karma' can be added under the 'karma' key
@@ -49,18 +50,18 @@ interface StrykerOptions {
   testRunner?: string;
 
   /**
-   * The name of the mutant generator to use to generate mutants based on your input file. 
+   * The mutant generator to use to generate mutants based on your input file.
    * This is often dependent on the language of your source files.
-   * For example: 'es5', 'typescript'
+   *
+   * This value can be either a string, or an object with 2 properties:
+   * * `string`: The name of the mutant generator to use. For example: 'es5', 'typescript'
+   * * { name: 'name', excludedMutations: ['mutationType1', 'mutationType2'] }:
+   *    * The `name` property is mandatory and contains the name of the mutant generator to use.
+   *    * For example: 'es5', 'typescript'
+   *    * The `excludedMutations` property is mandatory and contains the names of the specific mutation types to exclude from testing.
+   *    * The values must match the given names of the mutations. For example: 'BinaryExpression', 'BooleanSubstitution', etc.
    */
-  mutator?: string;
-
-  /**
-   * The names of the specific mutation types to exclude from testing.
-   * The names must match the given names of the mutations.
-   * For example: 'BinaryExpression', 'BooleanSubstitution', etc.
-   */
-  excludedMutations?: string[];
+  mutator?: string | MutatorDescriptor;
 
   /**
    * The names of the transpilers to use (in order). Default: [].

--- a/packages/stryker/README.md
+++ b/packages/stryker/README.md
@@ -164,19 +164,21 @@ In addition to requiring your test runner to be able to report the code coverage
  (`Mocha` is not yet supported).
 
 #### Mutator 
-**Config file:** `mutator: 'es5'`  
+**Command line:** `--mutator es5`  
+**Config file:** `mutator: { name: 'es5', excludedMutations: ['BooleanSubstitution', 'StringLiteral'] }`  
 **Default value:** `es5`  
 **Mandatory**: no  
 **Description:**  
-With `mutator` you configure which mutator plugin you want to use. This defaults to es5.  
+With `mutator` you configure which mutator plugin you want to use, and optionally, which mutation types to exclude from the test run.  
+The mutator plugin name defaults to `es5` if not specified. The list of excluded mutation types defaults to an empty array, meaning all mutation types will be included in the test.  
+The full list of mutation types varies slightly between mutators (for example, the `es5` mutator will not use the same mutation types as the `typescript` mutator). Mutation type names are case-sensitive, and can be found either in the source code or in a generated Stryker report.  
+ 
+When using the command line, only the mutator name as a string may be provided.  
+When using the config file, you can provide either a string representing the mutator name, or a `MutatorDescriptor` object, like so:  
 
-#### Excluded mutations 
-**Command line:** `--excludedMutations BooleanSubstitution,StringLiteral`  
-**Config file:** `excludedMutations: ['BooleanSubstitution', 'StringLiteral']`  
-**Default value:** `[ ]`  
-**Mandatory**: no  
-**Description:**  
-With `excludedMutations` you configure which types of mutations to exclude from the test run. The full list of mutation types varies slightly between mutators (for example, the `es5` mutator will not use the same mutation types as the `typescript` mutator). Mutation type names are case-sensitive, and can be found either in the source code or in a generated Stryker report. This defaults to an empty array, meaning all mutation types will be included in the test.  
+* `MutatorDescriptor` object: `{ name: 'name', excludedMutations: ['mutationType1', 'mutationType2', ...] }`:  
+   * The `name` property is mandatory and contains the name of the mutator plugin to use.  
+   * The `excludedMutations` property is mandatory and contains the types of mutations to exclude from the test run.  
 
 #### Transpilers  
 **Config file:** `transpilers: '['typescript']'`  

--- a/packages/stryker/README.md
+++ b/packages/stryker/README.md
@@ -170,13 +170,13 @@ In addition to requiring your test runner to be able to report the code coverage
 **Description:**  
 With `mutator` you configure which mutator plugin you want to use. This defaults to es5.  
 
-#### Excluded mutations
-**Command line:** `--excludedMutations BooleanSubstitution,StringLiteral`
-**Config file:** `excludedMutations: ['BooleanSubstitution', 'StringLiteral']`
-**Default value:** `[ ]`
-**Mandatory**: no
-**Description:**
-With `excludedMutations` you configure which types of mutations to exclude from the test run. The full list of mutation types varies slightly between mutators (for example, the `es5` mutator will not use the same mutation types as the `typescript` mutator). Mutation type names are case-sensitive, and can be found either in the source code or in a generated Stryker report. This defaults to an empty array, meaning all mutation types will be included in the test.
+#### Excluded mutations 
+**Command line:** `--excludedMutations BooleanSubstitution,StringLiteral`  
+**Config file:** `excludedMutations: ['BooleanSubstitution', 'StringLiteral']`  
+**Default value:** `[ ]`  
+**Mandatory**: no  
+**Description:**  
+With `excludedMutations` you configure which types of mutations to exclude from the test run. The full list of mutation types varies slightly between mutators (for example, the `es5` mutator will not use the same mutation types as the `typescript` mutator). Mutation type names are case-sensitive, and can be found either in the source code or in a generated Stryker report. This defaults to an empty array, meaning all mutation types will be included in the test.  
 
 #### Transpilers  
 **Config file:** `transpilers: '['typescript']'`  

--- a/packages/stryker/README.md
+++ b/packages/stryker/README.md
@@ -170,6 +170,14 @@ In addition to requiring your test runner to be able to report the code coverage
 **Description:**  
 With `mutator` you configure which mutator plugin you want to use. This defaults to es5.  
 
+#### Excluded mutations
+**Command line:** `--excludedMutations BooleanSubstitution,StringLiteral`
+**Config file:** `excludedMutations: ['BooleanSubstitution', 'StringLiteral']`
+**Default value:** `[ ]`
+**Mandatory**: no
+**Description:**
+With `excludedMutations` you configure which types of mutations to exclude from the test run. The full list of mutation types varies slightly between mutators (for example, the `es5` mutator will not use the same mutation types as the `typescript` mutator). Mutation type names are case-sensitive, and can be found either in the source code or in a generated Stryker report. This defaults to an empty array, meaning all mutation types will be included in the test.
+
 #### Transpilers  
 **Config file:** `transpilers: '['typescript']'`  
 **Default value:** `[ ]`  

--- a/packages/stryker/src/ConfigValidator.ts
+++ b/packages/stryker/src/ConfigValidator.ts
@@ -22,6 +22,7 @@ export default class ConfigValidator {
     this.validateIsStringArray('plugins', this.strykerConfig.plugins);
     this.validateIsStringArray('reporter', this.strykerConfig.reporter);
     this.validateIsStringArray('transpilers', this.strykerConfig.transpilers);
+    this.validateIsStringArray('excludedMutations', this.strykerConfig.excludedMutations);
     this.validateCoverageAnalysis();
     this.validateCoverageAnalysisWithRespectToTranspilers();
     this.crashIfNeeded();

--- a/packages/stryker/src/ConfigValidator.ts
+++ b/packages/stryker/src/ConfigValidator.ts
@@ -1,5 +1,6 @@
+import * as _ from 'lodash';
 import { TestFramework } from 'stryker-api/test_framework';
-import { MutationScoreThresholds } from 'stryker-api/core';
+import { MutatorDescriptor, MutationScoreThresholds } from 'stryker-api/core';
 import { Config } from 'stryker-api/config';
 import { getLogger } from 'log4js';
 
@@ -14,15 +15,14 @@ export default class ConfigValidator {
   validate() {
     this.validateTestFramework();
     this.validateThresholds();
+    this.validateMutator();
     this.validateLogLevel();
     this.validateTimeout();
     this.validateIsNumber('port', this.strykerConfig.port);
     this.validateIsNumber('maxConcurrentTestRunners', this.strykerConfig.maxConcurrentTestRunners);
-    this.validateIsString('mutator', this.strykerConfig.mutator);
     this.validateIsStringArray('plugins', this.strykerConfig.plugins);
     this.validateIsStringArray('reporter', this.strykerConfig.reporter);
     this.validateIsStringArray('transpilers', this.strykerConfig.transpilers);
-    this.validateIsStringArray('excludedMutations', this.strykerConfig.excludedMutations);
     this.validateCoverageAnalysis();
     this.validateCoverageAnalysisWithRespectToTranspilers();
     this.crashIfNeeded();
@@ -31,6 +31,21 @@ export default class ConfigValidator {
   private validateTestFramework() {
     if (this.strykerConfig.coverageAnalysis === 'perTest' && !this.testFramework) {
       this.invalidate('Configured coverage analysis "perTest" requires there to be a testFramework configured. Either configure a testFramework or set coverageAnalysis to "all" or "off".');
+    }
+  }
+
+  private validateMutator() {
+    const mutator = this.strykerConfig.mutator;
+    if (typeof mutator !== 'string' && !_.isObject(mutator)) {
+      // console.log(`***** FAILED at first assertion: Mutator is: ${mutator}`);
+      this.invalidate(`Value "${mutator}" is invalid for \`mutator\`. Expected either a string or an object`);
+    }
+    if (_.isObject(mutator)) {
+      const mutatorDescriptor = mutator as MutatorDescriptor;
+      // console.log(`***** It's an object!: Mutator is: ${mutatorDescriptor}`);
+      // TODO: do I need to add checks for the presence of these fields??
+      this.validateIsString('mutator.name', mutatorDescriptor.name);
+      this.validateIsStringArray('mutator.excludedMutations', mutatorDescriptor.excludedMutations);
     }
   }
 

--- a/packages/stryker/src/ConfigValidator.ts
+++ b/packages/stryker/src/ConfigValidator.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { TestFramework } from 'stryker-api/test_framework';
 import { MutatorDescriptor, MutationScoreThresholds } from 'stryker-api/core';
 import { Config } from 'stryker-api/config';
@@ -36,16 +35,12 @@ export default class ConfigValidator {
 
   private validateMutator() {
     const mutator = this.strykerConfig.mutator;
-    if (typeof mutator !== 'string' && !_.isObject(mutator)) {
-      // console.log(`***** FAILED at first assertion: Mutator is: ${mutator}`);
-      this.invalidate(`Value "${mutator}" is invalid for \`mutator\`. Expected either a string or an object`);
-    }
-    if (_.isObject(mutator)) {
+    if (typeof mutator === 'object') {
       const mutatorDescriptor = mutator as MutatorDescriptor;
-      // console.log(`***** It's an object!: Mutator is: ${mutatorDescriptor}`);
-      // TODO: do I need to add checks for the presence of these fields??
       this.validateIsString('mutator.name', mutatorDescriptor.name);
       this.validateIsStringArray('mutator.excludedMutations', mutatorDescriptor.excludedMutations);
+    } else if (typeof mutator !== 'string') {
+      this.invalidate(`Value "${mutator}" is invalid for \`mutator\`. Expected either a string or an object`);
     }
   }
 

--- a/packages/stryker/src/MutatorFacade.ts
+++ b/packages/stryker/src/MutatorFacade.ts
@@ -1,4 +1,4 @@
-import { File } from 'stryker-api/core';
+import { File, MutatorDescriptor } from 'stryker-api/core';
 import { Config } from 'stryker-api/config';
 import { Mutant, Mutator, MutatorFactory } from 'stryker-api/mutant';
 import ES5Mutator from './mutators/ES5Mutator';
@@ -12,7 +12,15 @@ export default class MutatorFacade implements Mutator {
 
   mutate(inputFiles: File[]): Mutant[] {
     return MutatorFactory.instance()
-      .create(this.config.mutator, this.config)
+      .create(this.getMutatorName(this.config.mutator), this.config)
       .mutate(inputFiles);
+  }
+
+  private getMutatorName(mutator: string | MutatorDescriptor) {
+    if (typeof mutator === 'string') {
+      return mutator;
+    } else {
+      return (mutator as MutatorDescriptor).name;
+    }
   }
 }

--- a/packages/stryker/src/MutatorFacade.ts
+++ b/packages/stryker/src/MutatorFacade.ts
@@ -20,7 +20,7 @@ export default class MutatorFacade implements Mutator {
     if (typeof mutator === 'string') {
       return mutator;
     } else {
-      return (mutator as MutatorDescriptor).name;
+      return mutator.name;
     }
   }
 }

--- a/packages/stryker/src/Stryker.ts
+++ b/packages/stryker/src/Stryker.ts
@@ -71,11 +71,7 @@ export default class Stryker {
     const mutator = new MutatorFacade(this.config);
     const allMutants = mutator.mutate(inputFiles);
     const includedMutants = this.removeExcludedMutants(allMutants);
-    if (includedMutants.length) {
-      this.log.info(`${includedMutants.length} Mutant(s) generated`);
-    } else {
-      this.log.info('It\'s a mutant-free world, nothing to test.');
-    }
+    this.logMutantCount(includedMutants.length, allMutants.length);
     const mutantRunResultMatcher = new MutantTestMatcher(
       includedMutants,
       inputFiles,
@@ -85,6 +81,20 @@ export default class Stryker {
       this.config,
       this.reporter);
     return mutantRunResultMatcher.matchWithMutants();
+  }
+
+  private logMutantCount(includedMutantCount: number, totalMutantCount: number) {
+    let mutantCountMessage;
+    if (includedMutantCount) {
+      mutantCountMessage = `${includedMutantCount} Mutant(s) generated`;
+    } else {
+      mutantCountMessage = `It\'s a mutant-free world, nothing to test.`;
+    }
+    const numberExcluded = totalMutantCount - includedMutantCount;
+    if (numberExcluded) {
+      mutantCountMessage += ` (${numberExcluded} Mutant(s) excluded)`;
+    }
+    this.log.info(mutantCountMessage);
   }
 
   private removeExcludedMutants(mutants: Mutant[]): Mutant[] {

--- a/packages/stryker/src/Stryker.ts
+++ b/packages/stryker/src/Stryker.ts
@@ -1,5 +1,5 @@
 import { Config, ConfigEditorFactory } from 'stryker-api/config';
-import { StrykerOptions, File } from 'stryker-api/core';
+import { StrykerOptions, MutatorDescriptor, File } from 'stryker-api/core';
 import { MutantResult } from 'stryker-api/report';
 import { TestFramework } from 'stryker-api/test_framework';
 import { Mutant } from 'stryker-api/mutant';
@@ -98,7 +98,11 @@ export default class Stryker {
   }
 
   private removeExcludedMutants(mutants: Mutant[]): Mutant[] {
-    return mutants.filter(mutant => this.config.excludedMutations.indexOf(mutant.mutatorName) === -1);
+    if (typeof this.config.mutator === 'string') {
+      return mutants;
+    }
+    const mutatorDescriptor = this.config.mutator as MutatorDescriptor;
+    return mutants.filter(mutant => mutatorDescriptor.excludedMutations.indexOf(mutant.mutatorName) === -1);
   }
 
   private loadPlugins() {

--- a/packages/stryker/src/Stryker.ts
+++ b/packages/stryker/src/Stryker.ts
@@ -100,9 +100,10 @@ export default class Stryker {
   private removeExcludedMutants(mutants: Mutant[]): Mutant[] {
     if (typeof this.config.mutator === 'string') {
       return mutants;
+    } else {
+      const mutatorDescriptor = this.config.mutator as MutatorDescriptor;
+      return mutants.filter(mutant => mutatorDescriptor.excludedMutations.indexOf(mutant.mutatorName) === -1);
     }
-    const mutatorDescriptor = this.config.mutator as MutatorDescriptor;
-    return mutants.filter(mutant => mutatorDescriptor.excludedMutations.indexOf(mutant.mutatorName) === -1);
   }
 
   private loadPlugins() {

--- a/packages/stryker/src/StrykerCli.ts
+++ b/packages/stryker/src/StrykerCli.ts
@@ -39,6 +39,7 @@ export default class StrykerCli {
       .option('--testFramework <name>', `The name of the test framework you want to use.`)
       .option('--testRunner <name>', `The name of the test runner you want to use`)
       .option('--mutator <name>', `The name of the mutant generator you want to use`)
+      .option('--excludedMutations <listOfExcludedMutations>', 'A comma separated list of the mutation types to exclude from the test.', this.list)
       .option('--transpilers <listOfTranspilers>', 'A comma separated list of transpilers to use.', this.list)
       .option('--reporter <name>', 'A comma separated list of the names of the reporter(s) you want to use', this.list)
       .option('--plugins <listOfPlugins>', 'A list of plugins you want stryker to load (`require`).', this.list)

--- a/packages/stryker/src/StrykerCli.ts
+++ b/packages/stryker/src/StrykerCli.ts
@@ -39,7 +39,6 @@ export default class StrykerCli {
       .option('--testFramework <name>', `The name of the test framework you want to use.`)
       .option('--testRunner <name>', `The name of the test runner you want to use`)
       .option('--mutator <name>', `The name of the mutant generator you want to use`)
-      .option('--excludedMutations <listOfExcludedMutations>', 'A comma separated list of the mutation types to exclude from the test.', this.list)
       .option('--transpilers <listOfTranspilers>', 'A comma separated list of transpilers to use.', this.list)
       .option('--reporter <name>', 'A comma separated list of the names of the reporter(s) you want to use', this.list)
       .option('--plugins <listOfPlugins>', 'A list of plugins you want stryker to load (`require`).', this.list)

--- a/packages/stryker/test/helpers/producers.ts
+++ b/packages/stryker/test/helpers/producers.ts
@@ -236,5 +236,14 @@ export const testableMutant = (fileName = 'file') => new TestableMutant('1337', 
   textFile({ name: fileName, content: 'const a = 4 + 5' })
 ));
 
+export const excludedTestableMutant = (fileName = 'file') => new TestableMutant('2448', mutant({
+  mutatorName: 'excludedMutator',
+  range: [12, 13],
+  replacement: '+',
+  fileName
+}), new SourceFile(
+  textFile({ name: fileName, content: 'const a = 5 - 4' })
+));
+
 export const transpiledMutant = (fileName = 'file') =>
   new TranspiledMutant(testableMutant(fileName), transpileResult(), true);

--- a/packages/stryker/test/helpers/producers.ts
+++ b/packages/stryker/test/helpers/producers.ts
@@ -228,21 +228,13 @@ export const transpileResult = factoryMethod<TranspileResult>(() => ({
 
 export const sourceFile = () => new SourceFile(textFile());
 
-export const testableMutant = (fileName = 'file') => new TestableMutant('1337', mutant({
+export const testableMutant = (fileName = 'file', mutatorName = 'foobarMutator') => new TestableMutant('1337', mutant({
+  mutatorName,
   range: [12, 13],
   replacement: '-',
   fileName
 }), new SourceFile(
   textFile({ name: fileName, content: 'const a = 4 + 5' })
-));
-
-export const excludedTestableMutant = (fileName = 'file') => new TestableMutant('2448', mutant({
-  mutatorName: 'excludedMutator',
-  range: [12, 13],
-  replacement: '+',
-  fileName
-}), new SourceFile(
-  textFile({ name: fileName, content: 'const a = 5 - 4' })
 ));
 
 export const transpiledMutant = (fileName = 'file') =>

--- a/packages/stryker/test/unit/ConfigValidatorSpec.ts
+++ b/packages/stryker/test/unit/ConfigValidatorSpec.ts
@@ -103,14 +103,6 @@ describe('ConfigValidator', () => {
     expect(log.fatal).calledWith('Value "break" is invalid for `timeoutFactor`. Expected a number');
   });
 
-  it('should be invalid with non-string mutator', () => {
-    let brokenConfig = breakConfig(config, 'mutator', 0);
-    sut = new ConfigValidator(brokenConfig, testFramework());
-    sut.validate();
-    expect(exitStub).calledWith(1);
-    expect(log.fatal).calledWith('Value "0" is invalid for `mutator`. Expected a string');
-  });
-
   describe('plugins', () => {
     it('should be invalid with non-array plugins', () => {
       let brokenConfig = breakConfig(config, 'plugins', 'stryker-typescript');
@@ -129,21 +121,59 @@ describe('ConfigValidator', () => {
     });
   });
 
-  describe('excluded mutations', () => {
-    it('should be invalid with non-array plugins', () => {
-      let brokenConfig = breakConfig(config, 'excludedMutations', 'BooleanSubstitution');
+  describe('mutator', () => {
+    it('should be invalid with non-string mutator', () => {
+      let brokenConfig = breakConfig(config, 'mutator', 0);
       sut = new ConfigValidator(brokenConfig, testFramework());
       sut.validate();
       expect(exitStub).calledWith(1);
-      expect(log.fatal).calledWith('Value "BooleanSubstitution" is invalid for `excludedMutations`. Expected an array');
+      expect(log.fatal).calledWith('Value "0" is invalid for `mutator`. Expected either a string or an object');
     });
 
-    it('should be invalid with non-string array elements', () => {
-      let brokenConfig = breakConfig(config, 'excludedMutations', ['BooleanSubstitution', 0]);
-      sut = new ConfigValidator(brokenConfig, testFramework());
-      sut.validate();
-      expect(exitStub).calledWith(1);
-      expect(log.fatal).calledWith('Value "0" is an invalid element of `excludedMutations`. Expected a string');
+    describe('as an object', () => {
+      it('should be valid with string mutator name and string array excluded mutations', () => {
+        let validConfig = breakConfig(config, 'mutator', {
+          name: 'es5',
+          excludedMutations: ['BooleanSubstitution']
+        });
+        sut = new ConfigValidator(validConfig, testFramework());
+        sut.validate();
+        expect(exitStub).not.called;
+        expect(log.fatal).not.called;
+      });
+
+      it('should be invalid with non-string mutator name', () => {
+        let brokenConfig = breakConfig(config, 'mutator', {
+          name: 0,
+          excludedMutations: []
+        });
+        sut = new ConfigValidator(brokenConfig, testFramework());
+        sut.validate();
+        expect(exitStub).calledWith(1);
+        expect(log.fatal).calledWith('Value "0" is invalid for `mutator.name`. Expected a string');
+      });
+
+      it('should be invalid with non-array excluded mutations', () => {
+        let brokenConfig = breakConfig(config, 'mutator', {
+          name: 'es5',
+          excludedMutations: 'BooleanSubstitution'
+        });
+        sut = new ConfigValidator(brokenConfig, testFramework());
+        sut.validate();
+        expect(exitStub).calledWith(1);
+        expect(log.fatal).calledWith('Value "BooleanSubstitution" is invalid for `mutator.excludedMutations`. Expected an array');
+      });
+
+      it('should be invalid with non-string excluded mutation array elements', () => {
+        let brokenConfig = breakConfig(config, 'mutator', {
+          name: 'es5',
+          excludedMutations: ['BooleanSubstitution', 0]
+        });
+        sut = new ConfigValidator(brokenConfig, testFramework());
+        sut.validate();
+        expect(exitStub).calledWith(1);
+        expect(log.fatal).calledWith('Value "0" is an invalid element of `mutator.excludedMutations`. Expected a string');
+      });
     });
   });
 

--- a/packages/stryker/test/unit/ConfigValidatorSpec.ts
+++ b/packages/stryker/test/unit/ConfigValidatorSpec.ts
@@ -129,6 +129,24 @@ describe('ConfigValidator', () => {
     });
   });
 
+  describe('excluded mutations', () => {
+    it('should be invalid with non-array plugins', () => {
+      let brokenConfig = breakConfig(config, 'excludedMutations', 'BooleanSubstitution');
+      sut = new ConfigValidator(brokenConfig, testFramework());
+      sut.validate();
+      expect(exitStub).calledWith(1);
+      expect(log.fatal).calledWith('Value "BooleanSubstitution" is invalid for `excludedMutations`. Expected an array');
+    });
+
+    it('should be invalid with non-string array elements', () => {
+      let brokenConfig = breakConfig(config, 'excludedMutations', ['BooleanSubstitution', 0]);
+      sut = new ConfigValidator(brokenConfig, testFramework());
+      sut.validate();
+      expect(exitStub).calledWith(1);
+      expect(log.fatal).calledWith('Value "0" is an invalid element of `excludedMutations`. Expected a string');
+    });
+  });
+
   describe('reporter', () => {
     it('should be invalid with non-array reporter', () => {
       let brokenConfig = breakConfig(config, 'reporter', 'stryker-typescript');

--- a/packages/stryker/test/unit/MutatorFacadeSpec.ts
+++ b/packages/stryker/test/unit/MutatorFacadeSpec.ts
@@ -17,13 +17,26 @@ describe('MutatorFacade', () => {
   });
 
   describe('mutate', () => {
-    it('should create the configured mutant generator', () => {
+    it('should create the configured mutant generator with a string mutator', () => {
       const config = new Config();
       const sut = new MutatorFacade(config);
       const inputFiles = [file()];
       expect(sut.mutate(inputFiles)).deep.eq(['mutant']);
       expect(mutatorMock.mutate).calledWith(inputFiles);
       expect(MutatorFactory.instance().create).calledWith('es5');
+    });
+
+    it('should create the configured mutant generator with an object mutator', () => {
+      const config = new Config();
+      config.mutator = {
+        name: 'javascript',
+        excludedMutations: []
+      };
+      const sut = new MutatorFacade(config);
+      const inputFiles = [file()];
+      expect(sut.mutate(inputFiles)).deep.eq(['mutant']);
+      expect(mutatorMock.mutate).calledWith(inputFiles);
+      expect(MutatorFactory.instance().create).calledWith('javascript');
     });
   });
 });

--- a/packages/stryker/test/unit/StrykerSpec.ts
+++ b/packages/stryker/test/unit/StrykerSpec.ts
@@ -245,21 +245,30 @@ describe('Stryker', function () {
     describe('with excluded mutants', () => {
 
       it('should log the number of mutants generated and excluded', async () => {
-        strykerConfig.excludedMutations = ['fooMutator'];
+        strykerConfig.mutator = {
+          name: 'es5',
+          excludedMutations: ['fooMutator']
+        };
         sut = new Stryker({});
         await sut.runMutationTest();
         expect(currentLogMock().info).to.have.been.calledWith('2 Mutant(s) generated (1 Mutant(s) excluded)');
       });
 
       it('should log the absence of mutants and the excluded number when all mutants are excluded', async () => {
-        strykerConfig.excludedMutations = ['fooMutator', 'barMutator', 'bazMutator'];
+        strykerConfig.mutator = {
+          name: 'es5',
+          excludedMutations: ['fooMutator', 'barMutator', 'bazMutator']
+        };
         sut = new Stryker({});
         await sut.runMutationTest();
         expect(currentLogMock().info).to.have.been.calledWith('It\'s a mutant-free world, nothing to test. (3 Mutant(s) excluded)');
       });
 
       it('should filter out the excluded mutations', async () => {
-        strykerConfig.excludedMutations = ['barMutator', 'bazMutator'];
+        strykerConfig.mutator = {
+          name: 'es5',
+          excludedMutations: ['barMutator', 'bazMutator']
+        };
         sut = new Stryker({});
         await sut.runMutationTest();
         expect(mutantRunResultMatcher.default).calledWithNew;

--- a/packages/stryker/test/unit/StrykerSpec.ts
+++ b/packages/stryker/test/unit/StrykerSpec.ts
@@ -18,7 +18,7 @@ import ScoreResultCalculator, * as scoreResultCalculatorModule from '../../src/S
 import PluginLoader, * as pluginLoader from '../../src/PluginLoader';
 import { TempFolder } from '../../src/utils/TempFolder';
 import currentLogMock from '../helpers/log4jsMock';
-import { mock, Mock, testFramework as testFrameworkMock, textFile, config, runResult, testableMutant, excludedTestableMutant, mutantResult } from '../helpers/producers';
+import { mock, Mock, testFramework as testFrameworkMock, textFile, config, runResult, testableMutant, mutantResult } from '../helpers/producers';
 import BroadcastReporter from '../../src/reporters/BroadcastReporter';
 import TestableMutant from '../../src/TestableMutant';
 import '../helpers/globals';
@@ -120,62 +120,74 @@ describe('Stryker', function () {
     let inputFiles: File[];
     let initialRunResult: RunResult;
     let transpiledFiles: File[];
-    let allMutants: TestableMutant[];
-    let includedMutants: TestableMutant[];
+    let mutants: TestableMutant[];
     let mutantResults: MutantResult[];
 
     beforeEach(() => {
-      includedMutants = [testableMutant()];
-      allMutants = [excludedTestableMutant(), testableMutant()];
+      mutants = [
+        testableMutant('file1', 'fooMutator'),
+        testableMutant('file2', 'barMutator'),
+        testableMutant('file3', 'bazMutator')
+      ];
       mutantResults = [mutantResult()];
-      mutantRunResultMatcherMock.matchWithMutants.returns(includedMutants);
-      mutatorMock.mutate.returns(allMutants);
+      mutantRunResultMatcherMock.matchWithMutants.returns(mutants);
+      mutatorMock.mutate.returns(mutants);
       mutationTestExecutorMock.run.resolves(mutantResults);
       inputFiles = [textFile({ name: 'input.ts ' })];
       transpiledFiles = [textFile({ name: 'output.js' })];
       inputFileResolverMock.resolve.resolves(inputFiles);
       initialRunResult = runResult();
       initialTestExecutorMock.run.resolves({ runResult: initialRunResult, transpiledFiles });
-      strykerConfig.excludedMutations = ['excludedMutator'];
-      sut = new Stryker({});
     });
 
-    it('should reject when input file globbing results in a rejection', async () => {
-      const expectedError = Error('expected error');
-      inputFileResolverMock.resolve.rejects(expectedError);
-      await expect(sut.runMutationTest()).rejectedWith(expectedError);
-    });
+    describe('sad flow', () => {
 
-    it('should reject when initial test run rejects', async () => {
-      const expectedError = Error('expected error');
-      initialTestExecutorMock.run.rejects(expectedError);
-      await expect(sut.runMutationTest()).rejectedWith(expectedError);
-    });
+      beforeEach(() => {
+        sut = new Stryker({});
+      });
 
-    it('should reject when mutation tester rejects', async () => {
-      const expectedError = Error('expected error');
-      mutationTestExecutorMock.run.rejects(expectedError);
-      await expect(sut.runMutationTest()).rejectedWith(expectedError);
-    });
+      it('should reject when input file globbing results in a rejection', async () => {
+        const expectedError = Error('expected error');
+        inputFileResolverMock.resolve.rejects(expectedError);
+        await expect(sut.runMutationTest()).rejectedWith(expectedError);
+      });
 
-    it('should quit early if no tests were executed in initial test run', async () => {
-      while (initialRunResult.tests.pop());
-      const actualResults = await sut.runMutationTest();
-      expect(mutationTestExecutorMock.run).not.called;
-      expect(actualResults).lengthOf(0);
-    });
+      it('should reject when initial test run rejects', async () => {
+        const expectedError = Error('expected error');
+        initialTestExecutorMock.run.rejects(expectedError);
+        await expect(sut.runMutationTest()).rejectedWith(expectedError);
+      });
 
-    it('should log to have quit early if no mutants were generated', async () => {
-      while (allMutants.pop()); // clear all mutants, for the log assertion
-      while (includedMutants.pop()); // clear all mutants, for the run assertion
-      await sut.runMutationTest();
-      expect(currentLogMock().info).to.have.been.calledWith('It\'s a mutant-free world, nothing to test.');
-      expect(mutationTestExecutorMock.run).not.called;
+      it('should reject when mutation tester rejects', async () => {
+        const expectedError = Error('expected error');
+        mutationTestExecutorMock.run.rejects(expectedError);
+        await expect(sut.runMutationTest()).rejectedWith(expectedError);
+      });
+
+      it('should quit early if no tests were executed in initial test run', async () => {
+        while (initialRunResult.tests.pop());
+        const actualResults = await sut.runMutationTest();
+        expect(mutationTestExecutorMock.run).not.called;
+        expect(actualResults).lengthOf(0);
+      });
+
+      it('should quit early if no mutants were generated', async () => {
+        while (mutants.pop()); // clear all mutants
+        await sut.runMutationTest();
+        expect(mutationTestExecutorMock.run).not.called;
+      });
+
+      it('should log the absence of mutants if no mutants were generated', async () => {
+        while (mutants.pop()); // clear all mutants
+        await sut.runMutationTest();
+        expect(currentLogMock().info).to.have.been.calledWith('It\'s a mutant-free world, nothing to test.');
+      });
     });
 
     describe('happy flow', () => {
 
       beforeEach(() => {
+        sut = new Stryker({});
         return sut.runMutationTest();
       });
 
@@ -214,12 +226,11 @@ describe('Stryker', function () {
       it('should create the mutation test executor', () => {
         expect(mutationTestExecutor.default).calledWithNew;
         expect(mutationTestExecutor.default).calledWith(strykerConfig, inputFiles, testFramework, reporter);
-        expect(mutationTestExecutorMock.run).calledWith(includedMutants);
+        expect(mutationTestExecutorMock.run).calledWith(mutants);
       });
 
-      it('should filter out the excluded mutations', () => {
-        expect(mutantRunResultMatcher.default).calledWithNew;
-        expect(mutantRunResultMatcher.default).calledWith(includedMutants);
+      it('should log the number of mutants generated', () => {
+        expect(currentLogMock().info).to.have.been.calledWith('3 Mutant(s) generated');
       });
 
       it('should clean the stryker temp folder', () => {
@@ -228,6 +239,31 @@ describe('Stryker', function () {
 
       it('should let the reporters wrapUp any async tasks', () => {
         expect(reporter.wrapUp).to.have.been.called;
+      });
+    });
+
+    describe('with excluded mutants', () => {
+
+      it('should log the number of mutants generated and excluded', async () => {
+        strykerConfig.excludedMutations = ['fooMutator'];
+        sut = new Stryker({});
+        await sut.runMutationTest();
+        expect(currentLogMock().info).to.have.been.calledWith('2 Mutant(s) generated (1 Mutant(s) excluded)');
+      });
+
+      it('should log the absence of mutants and the excluded number when all mutants are excluded', async () => {
+        strykerConfig.excludedMutations = ['fooMutator', 'barMutator', 'bazMutator'];
+        sut = new Stryker({});
+        await sut.runMutationTest();
+        expect(currentLogMock().info).to.have.been.calledWith('It\'s a mutant-free world, nothing to test. (3 Mutant(s) excluded)');
+      });
+
+      it('should filter out the excluded mutations', async () => {
+        strykerConfig.excludedMutations = ['barMutator', 'bazMutator'];
+        sut = new Stryker({});
+        await sut.runMutationTest();
+        expect(mutantRunResultMatcher.default).calledWithNew;
+        expect(mutantRunResultMatcher.default).calledWith([mutants[0]]);
       });
     });
   });


### PR DESCRIPTION
This adds the ability to exclude specific mutation types ('BooleanSubstitution', 'ArrayLiteral', etc.) from being performed during the test run. Can be used via either command-line or config file. Defaults to an empty array, meaning all mutation types are used.