### PR TITLE
build(node versions): don't build every LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
 - node
-- 'lts/*'
 - '6'
 - '4'
 install: npm install


### PR DESCRIPTION
Don't build every LTS version. Build the oldest LTS version and the newest Node version. For now we should also build Node 6 because we use that to release Stryker. When we drop support for Node 4, we will only build `node` and `6`.

This speeds up our travis builds and decreases the chance of random build failures.