### PR TITLE
feat(Sandbox isolation): symbolic link node_modules in sandboxes

### DIFF
--- a/packages/stryker-api/src/config/Config.ts
+++ b/packages/stryker-api/src/config/Config.ts
@@ -19,6 +19,7 @@ export default class Config implements StrykerOptions {
   mutator: string | MutatorDescriptor = 'es5';
   transpilers: string[] = [];
   maxConcurrentTestRunners: number = Infinity;
+  symlinkNodeModules: boolean = true;
   thresholds: MutationScoreThresholds = {
     high: 80,
     low: 60,

--- a/packages/stryker-api/src/core/StrykerOptions.ts
+++ b/packages/stryker-api/src/core/StrykerOptions.ts
@@ -109,6 +109,12 @@ interface StrykerOptions {
   logLevel?: string;
 
   /**
+   * Indicates whether or not to symlink the node_modules folder inside the sandbox folder(s).
+   * Default: true
+   */
+  symlinkNodeModules?: boolean;
+
+  /**
    * Amount of additional time, in milliseconds, the mutation test is allowed to run
    */
   timeoutMs?: number;

--- a/packages/stryker/README.md
+++ b/packages/stryker/README.md
@@ -201,7 +201,7 @@ All `TRAVIS` environment variables are set by Travis for each build. However, yo
 **Command line:** `[--files|-f] src/**/*.js,a.js,test/**/*.js`  
 **Config file:** `files: ['src/**/*.js', '!src/**/index.js', 'test/**/*.js']`  
 **Default value:** result of `git ls-files --others --exclude-standard --cached`  
-**Mandatory**: No  
+**Mandatory:** No  
 **Description:**  
 With `files` you can choose which files should be included in your test runner sandbox. 
 This is normally not needed as it defaults to all files not ignored by git. 
@@ -214,6 +214,25 @@ When using the command line, the list can only contain a comma separated list of
 When using the config file you can provide an array with `string`s
 
 You can *ignore* files by adding an exclamation mark (`!`) at the start of an expression.
+
+#### Symlink node modules in the sandbox
+**Command line:** *none*  
+**Config file:** `symlinkNodeModules: true`  
+**Default value:** `true`  
+**Mandatory:** No  
+**Description:**  
+The `symlinkNodeModules` value indicates whether or not Stryker should create a [symbolic link](https://nodejs.org/api/fs.html#fs_fs_symlink_target_path_type_callback) 
+to your current node_modules directory in the sandbox directories. This makes running your tests by Stryker behave 
+more like your would run the tests yourself in your project directory.
+Only disable this setting if you really know what you are doing.
+
+For example, [Jest](https://facebook.github.io/) expects any plugins to be located at "./node_modules/..."
+in the Sandbox directory. Another example can be running [karma](http://karma-runner.github.io/) tests where
+you specify files from the 'node_modules/angular/...'. Without symlinking the
+node_modules directory this would not be possible.
+
+Stryker will look for the node_modules directory to use in the current basePath (or current working directory) and 
+its parent directories.
 
 #### Plugins  
 **Command line:** `--plugins stryker-html-reporter,stryker-karma-runner`  

--- a/packages/stryker/src/Sandbox.ts
+++ b/packages/stryker/src/Sandbox.ts
@@ -98,7 +98,7 @@ export default class Sandbox {
             }
           });
       } else {
-        this.log.warn(`Could not find a node_modules folder to symlink into the sandbox directory. Search "${basePath}" and it's parent directories`);
+        this.log.warn(`Could not find a node_modules folder to symlink into the sandbox directory. Search "${basePath}" and its parent directories`);
       }
     }
   }

--- a/packages/stryker/src/Sandbox.ts
+++ b/packages/stryker/src/Sandbox.ts
@@ -5,12 +5,12 @@ import * as mkdirp from 'mkdirp';
 import { RunResult } from 'stryker-api/test_runner';
 import { File } from 'stryker-api/core';
 import { TestFramework } from 'stryker-api/test_framework';
-import { wrapInClosure } from './utils/objectUtils';
+import { wrapInClosure, normalizeWhiteSpaces } from './utils/objectUtils';
 import TestRunnerDecorator from './isolated-runner/TestRunnerDecorator';
 import ResilientTestRunnerFactory from './isolated-runner/ResilientTestRunnerFactory';
 import IsolatedRunnerOptions from './isolated-runner/IsolatedRunnerOptions';
 import { TempFolder } from './utils/TempFolder';
-import { writeFile } from './utils/fileUtils';
+import { writeFile, findNodeModules, symlinkJunction } from './utils/fileUtils';
 import TestableMutant, { TestSelectionResult } from './TestableMutant';
 import TranspiledMutant from './TranspiledMutant';
 
@@ -34,6 +34,7 @@ export default class Sandbox {
 
   private async initialize(): Promise<void> {
     await this.fillSandbox();
+    await this.symlinkNodeModulesIfNeeded();
     return this.initializeTestRunner();
   }
 
@@ -78,6 +79,28 @@ export default class Sandbox {
     let copyPromises = this.files
       .map(file => this.fillFile(file));
     return Promise.all(copyPromises);
+  }
+
+  private async symlinkNodeModulesIfNeeded(): Promise<void> {
+    if (this.options.symlinkNodeModules) {
+      // TODO: Change with this.options.basePath when we have it
+      const basePath = process.cwd();
+      const nodeModules = await findNodeModules(basePath);
+      if (nodeModules) {
+        await symlinkJunction(nodeModules, path.join(this.workingFolder, 'node_modules'))
+          .catch((error: NodeJS.ErrnoException) => {
+            if (error.code === 'EEXIST') {
+              this.log.warn(normalizeWhiteSpaces(`Could not symlink "${nodeModules}" in sandbox directory, 
+              it is already created in the sandbox. Please remove the node_modules from your sandbox files. 
+              Alternatively, set \`symlinkNodeModules\` to \`false\` to disable this warning.`));
+            } else {
+              this.log.warn(`Unexpected error while trying to symlink "${nodeModules}" in sandbox directory.`, error);
+            }
+          });
+      } else {
+        this.log.warn(`Could not find a node_modules folder to symlink into the sandbox directory. Search "${basePath}" and it's parent directories`);
+      }
+    }
   }
 
   private fillFile(file: File): Promise<void> {

--- a/packages/stryker/src/utils/fileUtils.ts
+++ b/packages/stryker/src/utils/fileUtils.ts
@@ -1,4 +1,5 @@
 import * as fs from 'mz/fs';
+import * as path from 'path';
 import * as nodeGlob from 'glob';
 import * as mkdirp from 'mkdirp';
 import * as rimraf from 'rimraf';
@@ -44,5 +45,36 @@ export function writeFile(fileName: string, data: string | Buffer): Promise<void
     return fs.writeFile(fileName, data);
   } else {
     return fs.writeFile(fileName, data, 'utf8');
+  }
+}
+
+
+/**
+ * Creates a symlink at `from` that points to `to`
+ * @param to The thing you want to point to
+ * @param from The thing you want to point from
+ */
+export function symlinkJunction(to: string, from: string) {
+  return fs.symlink(to, from, 'junction');
+}
+
+/**
+ * Looks for the node_modules folder from basePath up to root. 
+ * returns the first occurrence of the node_modules, or null of none could be found.
+ * @param basePath starting point
+ */
+export async function findNodeModules(basePath: string): Promise<string | null> {
+  basePath = path.resolve(basePath);
+  const nodeModules = path.resolve(basePath, 'node_modules');
+  const exists = await fs.exists(nodeModules);
+  if (exists) {
+    return nodeModules;
+  } else {
+    const parent = path.dirname(basePath);
+    if (parent === basePath) {
+      return null;
+    } else {
+      return findNodeModules(path.dirname(basePath));
+    }
   }
 }

--- a/packages/stryker/stryker.conf.js
+++ b/packages/stryker/stryker.conf.js
@@ -14,6 +14,7 @@ module.exports = function (config) {
         'test/**/*.ts',
         '!test/**/*.d.ts'
       ],
+      symlinkNodeModules: false,
       mutate: ['src/**/*.ts'],
       coverageAnalysis: 'perTest',
       tsconfigFile: 'tsconfig.json',

--- a/packages/stryker/test/helpers/producers.ts
+++ b/packages/stryker/test/helpers/producers.ts
@@ -204,3 +204,18 @@ export const testableMutant = (fileName = 'file', mutatorName = 'foobarMutator')
 
 export const transpiledMutant = (fileName = 'file') =>
   new TranspiledMutant(testableMutant(fileName), transpileResult(), true);
+
+
+export function createFileNotFoundError(): NodeJS.ErrnoException {
+  return createErrnoException('ENOENT');
+}
+
+export function createFileAlreadyExistsError(): NodeJS.ErrnoException {
+  return createErrnoException('EEXIST');
+}
+
+function createErrnoException(errorCode: string) {
+  const fileNotFoundError: NodeJS.ErrnoException = new Error('');
+  fileNotFoundError.code = errorCode;
+  return fileNotFoundError;
+}

--- a/packages/stryker/test/unit/SandboxSpec.ts
+++ b/packages/stryker/test/unit/SandboxSpec.ts
@@ -6,13 +6,13 @@ import * as path from 'path';
 import * as mkdirp from 'mkdirp';
 import { expect } from 'chai';
 import { File } from 'stryker-api/core';
-import { wrapInClosure } from '../../src/utils/objectUtils';
+import { wrapInClosure, normalizeWhiteSpaces } from '../../src/utils/objectUtils';
 import Sandbox from '../../src/Sandbox';
 import { TempFolder } from '../../src/utils/TempFolder';
 import ResilientTestRunnerFactory from '../../src/isolated-runner/ResilientTestRunnerFactory';
 import IsolatedRunnerOptions from '../../src/isolated-runner/IsolatedRunnerOptions';
 import TestableMutant, { TestSelectionResult } from '../../src/TestableMutant';
-import { mutant as createMutant, testResult, Mock } from '../helpers/producers';
+import { mutant as createMutant, testResult, Mock, createFileAlreadyExistsError } from '../helpers/producers';
 import SourceFile from '../../src/SourceFile';
 import '../helpers/globals';
 import TranspiledMutant from '../../src/TranspiledMutant';
@@ -21,167 +21,196 @@ import currentLogMock from '../helpers/log4jsMock';
 import TestRunnerDecorator from '../../src/isolated-runner/TestRunnerDecorator';
 
 describe('Sandbox', () => {
-  let sut: Sandbox;
   let options: Config;
   let files: File[];
   let testRunner: Mock<TestRunnerDecorator>;
   let testFrameworkStub: any;
   let expectedFileToMutate: File;
   let notMutatedFile: File;
-  let workingFolder: string;
+  let sandboxFolder: string;
   let expectedTargetFileToMutate: string;
   let expectedTestFrameworkHooksFile: string;
-  let fileSystemStub: sinon.SinonStub;
+  let writeFileStub: sinon.SinonStub;
+  let symlinkJunctionStub: sinon.SinonStub;
+  let findNodeModulesStub: sinon.SinonStub;
   let log: Mock<Logger>;
 
   beforeEach(() => {
-    options = { port: 43, timeoutFactor: 23, timeoutMs: 1000, testRunner: 'sandboxUnitTestRunner' } as any;
+    options = { port: 43, timeoutFactor: 23, timeoutMs: 1000, testRunner: 'sandboxUnitTestRunner', symlinkNodeModules: true } as any;
     testRunner = { init: sandbox.stub(), run: sandbox.stub().resolves(), dispose: sandbox.stub() };
     testFrameworkStub = {
       filter: sandbox.stub()
     };
     expectedFileToMutate = new File(path.resolve('file1'), 'original code');
     notMutatedFile = new File(path.resolve('file2'), 'to be mutated');
-    workingFolder = path.resolve('random-folder-3');
-    expectedTargetFileToMutate = path.join(workingFolder, 'file1');
-    expectedTestFrameworkHooksFile = path.join(workingFolder, '___testHooksForStryker.js');
+    sandboxFolder = path.resolve('random-folder-3');
+    expectedTargetFileToMutate = path.join(sandboxFolder, 'file1');
+    expectedTestFrameworkHooksFile = path.join(sandboxFolder, '___testHooksForStryker.js');
     files = [
       expectedFileToMutate,
       notMutatedFile,
     ];
-    sandbox.stub(TempFolder.instance(), 'createRandomFolder').returns(workingFolder);
-    fileSystemStub = sandbox.stub(fileUtils, 'writeFile');
-    fileSystemStub.resolves();
+    sandbox.stub(TempFolder.instance(), 'createRandomFolder').returns(sandboxFolder);
+    writeFileStub = sandbox.stub(fileUtils, 'writeFile');
+    symlinkJunctionStub = sandbox.stub(fileUtils, 'symlinkJunction');
+    findNodeModulesStub = sandbox.stub(fileUtils, 'findNodeModules');
+    symlinkJunctionStub.resolves();
+    findNodeModulesStub.resolves('node_modules');
+    writeFileStub.resolves();
     sandbox.stub(mkdirp, 'sync').returns('');
     sandbox.stub(ResilientTestRunnerFactory, 'create').returns(testRunner);
     log = currentLogMock();
   });
 
-  it('should copy input files when created', async () => {
-    sut = await Sandbox.create(options, 3, files, null);
-    expect(fileUtils.writeFile).calledWith(expectedTargetFileToMutate, files[0].content);
-    expect(fileUtils.writeFile).calledWith(path.join(workingFolder, 'file2'), files[1].content);
-  });
 
-  it('should copy a local file when created', async () => {
-    sut = await Sandbox.create(options, 3, [new File('localFile.js', 'foobar')], null);
-    expect(fileUtils.writeFile).calledWith(path.join(workingFolder, 'localFile.js'), Buffer.from('foobar'));
-  });
+  describe('create()', () => {
 
-  describe('when constructed with a testFramework', () => {
-
-    beforeEach(async () => {
-      sut = await Sandbox.create(options, 3, files, testFrameworkStub);
+    it('should copy input files when created', async () => {
+      await Sandbox.create(options, 3, files, null);
+      expect(fileUtils.writeFile).calledWith(expectedTargetFileToMutate, files[0].content);
+      expect(fileUtils.writeFile).calledWith(path.join(sandboxFolder, 'file2'), files[1].content);
     });
 
-    it('should have created a workingFolder', () => {
-      expect(TempFolder.instance().createRandomFolder).to.have.been.calledWith('sandbox');
+    it('should copy a local file when created', async () => {
+      await Sandbox.create(options, 3, [new File('localFile.js', 'foobar')], null);
+      expect(fileUtils.writeFile).calledWith(path.join(sandboxFolder, 'localFile.js'), Buffer.from('foobar'));
     });
 
-    it('should have created the isolated test runner without framework hook', () => {
+    it('should have created the isolated test runner', async () => {
+      await Sandbox.create(options, 3, files, null);
       const expectedSettings: IsolatedRunnerOptions = {
         port: 46,
         strykerOptions: options,
-        sandboxWorkingFolder: workingFolder,
-        fileNames: [path.resolve('random-folder-3', 'file1'), path.resolve('random-folder-3', 'file2')]
-      };
-      expect(ResilientTestRunnerFactory.create).calledWith(options.testRunner, expectedSettings);
-    });
-
-    describe('when run', () => {
-      it('should run the testRunner', async () => {
-        await sut.run(231313, 'hooks');
-        expect(testRunner.run).to.have.been.calledWith({
-          timeout: 231313,
-          testHooks: 'hooks'
-        });
-      });
-    });
-
-    describe('when runMutant()', () => {
-      let transpiledMutant: TranspiledMutant;
-      let mutant: Mutant;
-      const testFilterCodeFragment = 'Some code fragment';
-
-      beforeEach(() => {
-        mutant = createMutant({ fileName: expectedFileToMutate.name, replacement: 'mutated', range: [0, 8] });
-
-        const testableMutant = new TestableMutant(
-          '1',
-          mutant,
-          new SourceFile(new File('foobar.js', 'original code')));
-        testableMutant.selectTest(testResult({ timeSpentMs: 10 }), 1);
-        testableMutant.selectTest(testResult({ timeSpentMs: 2 }), 2);
-        transpiledMutant = new TranspiledMutant(testableMutant, { outputFiles: [new File(expectedFileToMutate.name, 'mutated code')], error: null }, true);
-        testFrameworkStub.filter.returns(testFilterCodeFragment);
-      });
-
-      it('should save the mutant to disk', async () => {
-        await sut.runMutant(transpiledMutant);
-        expect(fileUtils.writeFile).calledWith(expectedTargetFileToMutate, Buffer.from('mutated code'));
-        expect(log.warn).not.called;
-      });
-
-      it('should nog log a warning if test selection was failed but already reported', async () => {
-        transpiledMutant.mutant.testSelectionResult = TestSelectionResult.FailedButAlreadyReported;
-        await sut.runMutant(transpiledMutant);
-        expect(log.warn).not.called;
-      });
-
-      it('should log a warning if tests could not have been selected', async () => {
-        transpiledMutant.mutant.testSelectionResult = TestSelectionResult.Failed;
-        await sut.runMutant(transpiledMutant);
-        const expectedLogMessage = `Failed find coverage data for this mutant, running all tests. This might have an impact on performance: ${transpiledMutant.mutant.toString()}`;
-        expect(log.warn).calledWith(expectedLogMessage);
-      });
-
-      it('should filter the scoped tests', async () => {
-        await sut.runMutant(transpiledMutant);
-        expect(testFrameworkStub.filter).to.have.been.calledWith(transpiledMutant.mutant.selectedTests);
-      });
-
-      it('should provide the filter code as testHooks and correct timeout', async () => {
-        await sut.runMutant(transpiledMutant);
-        const expectedRunOptions = { testHooks: wrapInClosure(testFilterCodeFragment), timeout: 12 * 23 + 1000 };
-        expect(testRunner.run).calledWith(expectedRunOptions);
-      });
-
-      it('should have reset the source file', async () => {
-        await sut.runMutant(transpiledMutant);
-
-        let timesCalled = fileSystemStub.getCalls().length - 1;
-        let lastCall = fileSystemStub.getCall(timesCalled);
-        expect(lastCall.args).to.deep.equal([expectedTargetFileToMutate, Buffer.from('original code')]);
-      });
-    });
-  });
-
-  describe('when constructed without a testFramework', () => {
-    beforeEach(async () => {
-      sut = await Sandbox.create(options, 3, files, null);
-    });
-
-
-    it('should have created the isolated test runner', () => {
-      const expectedSettings: IsolatedRunnerOptions = {
-        port: 46,
-        strykerOptions: options,
-        sandboxWorkingFolder: workingFolder,
+        sandboxWorkingFolder: sandboxFolder,
         fileNames: [path.resolve('random-folder-3', 'file1'), path.resolve('random-folder-3', 'file2')]
       };
       expect(ResilientTestRunnerFactory.create).to.have.been.calledWith(options.testRunner, expectedSettings);
     });
 
-    describe('when runMutant()', () => {
+    it('should have created a sandbox folder', async () => {
+      await Sandbox.create(options, 3, files, testFrameworkStub);
+      expect(TempFolder.instance().createRandomFolder).to.have.been.calledWith('sandbox');
+    });
 
-      beforeEach(() => {
-        const mutant = new TestableMutant('2', createMutant(), new SourceFile(new File('', '')));
-        return sut.runMutant(new TranspiledMutant(mutant, { outputFiles: [new File(expectedTargetFileToMutate, '')], error: null }, true));
-      });
+    it('should symlink node modules in sandbox directory if exists', async () => {
+      await Sandbox.create(options, 3, files, testFrameworkStub);
+      expect(findNodeModulesStub).calledWith(process.cwd());
+      expect(symlinkJunctionStub).calledWith('node_modules', path.join(sandboxFolder, 'node_modules'));
+    });
 
-      it('should not filter any tests', () => {
-        expect(fileUtils.writeFile).not.calledWith(expectedTestFrameworkHooksFile);
+    it('should not symlink node modules in sandbox directory if no node_modules exist', async () => {
+      findNodeModulesStub.resolves(null);
+      await Sandbox.create(options, 3, files, testFrameworkStub);
+      expect(log.warn).calledWithMatch('Could not find a node_modules');
+      expect(log.warn).calledWithMatch(process.cwd());
+      expect(symlinkJunctionStub).not.called;
+    });
+
+    it('should log a warning if "node_modules" already exists in the working folder', async () => {
+      findNodeModulesStub.resolves('node_modules');
+      symlinkJunctionStub.rejects(createFileAlreadyExistsError());
+      await Sandbox.create(options, 3, files, testFrameworkStub);
+      expect(log.warn).calledWithMatch(normalizeWhiteSpaces(
+        `Could not symlink "node_modules" in sandbox directory, it is already created in the sandbox. 
+        Please remove the node_modules from your sandbox files. Alternatively, set \`symlinkNodeModules\` 
+        to \`false\` to disable this warning.`));
+    });
+
+    it('should log a warning if linking "node_modules" results in an unknown error', async () => {
+      findNodeModulesStub.resolves('basepath/node_modules');
+      const error = new Error('unknown');
+      symlinkJunctionStub.rejects(error);
+      await Sandbox.create(options, 3, files, testFrameworkStub);
+      expect(log.warn).calledWithMatch(normalizeWhiteSpaces(
+        `Unexpected error while trying to symlink "basepath/node_modules" in sandbox directory.`), error);
+    });
+
+    it('should symlink node modules in sandbox directory if `symlinkNodeModules` is `false`', async () => {
+      options.symlinkNodeModules = false;
+      await Sandbox.create(options, 3, files, testFrameworkStub);
+      expect(symlinkJunctionStub).not.called;
+      expect(findNodeModulesStub).not.called;
+    });
+  });
+
+  describe('run()', () => {
+    it('should run the testRunner', async () => {
+      const sut = await Sandbox.create(options, 3, files, null);
+      await sut.run(231313, 'hooks');
+      expect(testRunner.run).to.have.been.calledWith({
+        timeout: 231313,
+        testHooks: 'hooks'
       });
     });
+  });
+
+  describe('runMutant()', () => {
+    let transpiledMutant: TranspiledMutant;
+    let mutant: Mutant;
+    const testFilterCodeFragment = 'Some code fragment';
+
+    beforeEach(() => {
+      mutant = createMutant({ fileName: expectedFileToMutate.name, replacement: 'mutated', range: [0, 8] });
+
+      const testableMutant = new TestableMutant(
+        '1',
+        mutant,
+        new SourceFile(new File('foobar.js', 'original code')));
+      testableMutant.selectTest(testResult({ timeSpentMs: 10 }), 1);
+      testableMutant.selectTest(testResult({ timeSpentMs: 2 }), 2);
+      transpiledMutant = new TranspiledMutant(testableMutant, { outputFiles: [new File(expectedFileToMutate.name, 'mutated code')], error: null }, true);
+      testFrameworkStub.filter.returns(testFilterCodeFragment);
+    });
+
+    it('should save the mutant to disk', async () => {
+      const sut = await Sandbox.create(options, 3, files, null);
+      await sut.runMutant(transpiledMutant);
+      expect(fileUtils.writeFile).calledWith(expectedTargetFileToMutate, Buffer.from('mutated code'));
+      expect(log.warn).not.called;
+    });
+
+    it('should nog log a warning if test selection was failed but already reported', async () => {
+      const sut = await Sandbox.create(options, 3, files, null);
+      transpiledMutant.mutant.testSelectionResult = TestSelectionResult.FailedButAlreadyReported;
+      await sut.runMutant(transpiledMutant);
+      expect(log.warn).not.called;
+    });
+
+    it('should log a warning if tests could not have been selected', async () => {
+      const sut = await Sandbox.create(options, 3, files, null);
+      transpiledMutant.mutant.testSelectionResult = TestSelectionResult.Failed;
+      await sut.runMutant(transpiledMutant);
+      const expectedLogMessage = `Failed find coverage data for this mutant, running all tests. This might have an impact on performance: ${transpiledMutant.mutant.toString()}`;
+      expect(log.warn).calledWith(expectedLogMessage);
+    });
+
+    it('should filter the scoped tests', async () => {
+      const sut = await Sandbox.create(options, 3, files, testFrameworkStub);
+      await sut.runMutant(transpiledMutant);
+      expect(testFrameworkStub.filter).to.have.been.calledWith(transpiledMutant.mutant.selectedTests);
+    });
+
+    it('should provide the filter code as testHooks and correct timeout', async () => {
+      const sut = await Sandbox.create(options, 3, files, testFrameworkStub);
+      await sut.runMutant(transpiledMutant);
+      const expectedRunOptions = { testHooks: wrapInClosure(testFilterCodeFragment), timeout: 12 * 23 + 1000 };
+      expect(testRunner.run).calledWith(expectedRunOptions);
+    });
+
+    it('should have reset the source file', async () => {
+      const sut = await Sandbox.create(options, 3, files, null);
+      await sut.runMutant(transpiledMutant);
+      let timesCalled = writeFileStub.getCalls().length - 1;
+      let lastCall = writeFileStub.getCall(timesCalled);
+      expect(lastCall.args).to.deep.equal([expectedTargetFileToMutate, Buffer.from('original code')]);
+    });
+
+    it('should not filter any tests when testFramework = null', async () => {
+      const sut = await Sandbox.create(options, 3, files, null);
+      const mutant = new TestableMutant('2', createMutant(), new SourceFile(new File('', '')));
+      sut.runMutant(new TranspiledMutant(mutant, { outputFiles: [new File(expectedTargetFileToMutate, '')], error: null }, true));
+      expect(fileUtils.writeFile).not.calledWith(expectedTestFrameworkHooksFile);
+    });
+
   });
 });

--- a/packages/stryker/test/unit/input/InputFileResolverSpec.ts
+++ b/packages/stryker/test/unit/input/InputFileResolverSpec.ts
@@ -10,7 +10,7 @@ import * as sinon from 'sinon';
 import * as fileUtils from '../../../src/utils/fileUtils';
 import currentLogMock from '../../helpers/log4jsMock';
 import BroadcastReporter from '../../../src/reporters/BroadcastReporter';
-import { Mock, mock } from '../../helpers/producers';
+import { Mock, mock, createFileNotFoundError } from '../../helpers/producers';
 import { errorToString, normalizeWhiteSpaces } from '../../../src/utils/objectUtils';
 
 const files = (...namesWithContent: [string, string][]): File[] =>
@@ -84,8 +84,7 @@ describe('InputFileResolver', () => {
     childProcessExecStub.resolves([Buffer.from(`
       deleted/file.js
     `)]);
-    const fileNotFoundError: NodeJS.ErrnoException = new Error('');
-    fileNotFoundError.code = 'ENOENT';
+    const fileNotFoundError = createFileNotFoundError();
     readFileStub.withArgs('deleted/file.js').rejects(fileNotFoundError);
     const result = await sut.resolve();
     expect(result.files).lengthOf(0);
@@ -266,5 +265,4 @@ describe('InputFileResolver', () => {
       expect(actual[index].textContent).eq(expected[index].textContent);
     }
   }
-
 });

--- a/packages/stryker/test/unit/utils/fileUtilsSpec.ts
+++ b/packages/stryker/test/unit/utils/fileUtilsSpec.ts
@@ -1,17 +1,55 @@
 import { expect } from 'chai';
 import * as fileUtils from '../../../src/utils/fileUtils';
 import * as fs from 'mz/fs';
+import * as path from 'path';
 
 describe('fileUtils', () => {
 
+  let existsStub: sinon.SinonStub;
+
   beforeEach(() => {
     sandbox.stub(fs, 'writeFile');
+    sandbox.stub(fs, 'symlink');
+    existsStub = sandbox.stub(fs, 'exists');
   });
 
   describe('writeFile', () => {
     it('should call fs.writeFile', () => {
       fileUtils.writeFile('filename', 'data');
-      expect(fs.writeFile).to.have.been.calledWith('filename', 'data', 'utf8');
+      expect(fs.writeFile).calledWith('filename', 'data', 'utf8');
+    });
+  });
+
+  describe('symlinkJunction', () => {
+    it('should call fs.symlink', async () => {
+      await fileUtils.symlinkJunction('a', 'b');
+      expect(fs.symlink).calledWith('a', 'b', 'junction');
+    });
+  });
+
+  describe('findNodeModules', () => {
+    it('should return node_modules located in `basePath`', async () => {
+      existsStub.resolves(true);
+      const basePath = path.resolve('a', 'b', 'c');
+      const expectedNodeModules = path.join(basePath, 'node_modules');
+      const actual = await fileUtils.findNodeModules(basePath);
+      expect(actual).eq(expectedNodeModules);
+    });
+
+    it('should return node_modules located in parent directory of `basePath` if it didn\'t exist in base path', async () => {
+      const basePath = path.resolve('a', 'b', 'c');
+      const expectedNodeModules = path.resolve('a', 'node_modules');
+      existsStub.resolves(false) // default
+        .withArgs(expectedNodeModules).resolves(true);
+      const actual = await fileUtils.findNodeModules(basePath);
+      expect(actual).eq(expectedNodeModules);
+    });
+
+    it('should return null if no node_modules exist in basePath or parent directories', async () => {
+      const basePath = path.resolve('a', 'b', 'c');
+      existsStub.resolves(false);
+      const actual = await fileUtils.findNodeModules(basePath);
+      expect(actual).null;
     });
   });
 });


### PR DESCRIPTION
Add support for `symlinkNodeModules` setting. If true (also the default)
symlink the current node_modules folder in the test runner sandboxes
This will make a test run more "production like".

Also refactor the SandboxSpec so they are more
[DAMP](https://stackoverflow.com/questions/6453235/).

Fixes #672 