### PR TITLE
feat(Mutator): Add StringLiteral mutator

### DIFF
--- a/packages/stryker-javascript-mutator/src/helpers/BabelParser.ts
+++ b/packages/stryker-javascript-mutator/src/helpers/BabelParser.ts
@@ -2,11 +2,12 @@ import * as babel from 'babel-core';
 import * as babylon from 'babylon';
 import generate from 'babel-generator';
 import { NodePath } from 'babel-traverse';
+import { NodeWithParent } from './ParentNode';
 
 export default class BabelParser {
   static getAst(code: string): babel.types.File {
     let ast: babel.types.File;
-    
+
     const options: babylon.BabylonOptions = {
       sourceType: 'script',
       plugins: [
@@ -28,14 +29,15 @@ export default class BabelParser {
     return ast;
   }
 
-  static getNodes(ast: babel.types.File): babel.types.Node[] {
-    const nodes: babel.types.Node[] = [];
+  static getNodes(ast: babel.types.File): NodeWithParent[] {
+    const nodes: NodeWithParent[] = [];
 
     babel.traverse(ast, {
       enter(path: NodePath<babel.types.Node>) {
         const node = path.node;
+        (node as NodeWithParent).parent = path.parent;
         Object.freeze(node);
-        nodes.push(node);
+        nodes.push((node as NodeWithParent));
       }
     });
 

--- a/packages/stryker-javascript-mutator/src/helpers/BabelParser.ts
+++ b/packages/stryker-javascript-mutator/src/helpers/BabelParser.ts
@@ -34,10 +34,10 @@ export default class BabelParser {
 
     babel.traverse(ast, {
       enter(path: NodePath<babel.types.Node>) {
-        const node = path.node;
-        (node as NodeWithParent).parent = path.parent;
+        const node: NodeWithParent = path.node;
+        node.parent = path.parent;
         Object.freeze(node);
-        nodes.push((node as NodeWithParent));
+        nodes.push(node);
       }
     });
 

--- a/packages/stryker-javascript-mutator/src/helpers/ParentNode.ts
+++ b/packages/stryker-javascript-mutator/src/helpers/ParentNode.ts
@@ -1,0 +1,7 @@
+
+import { types } from 'babel-core';
+export default interface NodeParent {
+  parent: types.Node;
+}
+
+export type NodeWithParent = types.Node & NodeParent;

--- a/packages/stryker-javascript-mutator/src/helpers/ParentNode.ts
+++ b/packages/stryker-javascript-mutator/src/helpers/ParentNode.ts
@@ -1,7 +1,7 @@
 
 import { types } from 'babel-core';
 export default interface NodeParent {
-  parent: types.Node;
+  parent?: types.Node;
 }
 
 export type NodeWithParent = types.Node & NodeParent;

--- a/packages/stryker-javascript-mutator/src/mutators/NodeMutator.ts
+++ b/packages/stryker-javascript-mutator/src/mutators/NodeMutator.ts
@@ -1,4 +1,5 @@
 import { types } from 'babel-core';
+import { NodeWithParent } from '../helpers/ParentNode';
 
 /**
  * Represents a class which can mutate parts of an Abstract Syntax Tree.
@@ -19,5 +20,5 @@ export default interface NodeMutator {
    * @param copy A function to create a copy of an object.
    * @returns An array of mutated Nodes.
    */
-  mutate(node: types.Node, copy: <T extends types.Node> (obj: T, deep?: boolean) => T): void | types.Node[];
+  mutate(node: NodeWithParent, copy: <T extends types.Node> (obj: T, deep?: boolean) => T): void | types.Node[];
 }

--- a/packages/stryker-javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/stryker-javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -1,0 +1,36 @@
+import { types } from 'babel-core';
+import NodeMutator from './NodeMutator';
+import { NodeWithParent } from '../helpers/ParentNode';
+
+export default class StringLiteralMutator implements NodeMutator {
+  name = 'StringLiteral';
+
+  mutate(node: NodeWithParent, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] {
+    const nodes: types.Node[] = [];
+
+    if (types.isTemplateLiteral(node)) {
+      let mutatedNode: types.StringLiteral = {
+        type: 'StringLiteral',
+        start: node.start,
+        end: node.end,
+        loc: node.loc,
+        value: ''
+      };
+
+      if (node.quasis.length === 1 && node.quasis[0].value.raw.length === 0) {
+        mutatedNode.value = 'Stryker was here!';
+      }
+
+      nodes.push(mutatedNode);
+    } else if (types.isStringLiteral(node) && !types.isImportDeclaration(node.parent) && !types.isJSXAttribute(node.parent)) {
+      if (node.value === 'foo') {
+        console.log(node);
+      }
+      let mutatedNode = copy(node);
+      mutatedNode.value = mutatedNode.value.length === 0 ? 'Stryker was here!' : '';
+      nodes.push(mutatedNode);
+    }
+
+    return nodes;
+  }
+}

--- a/packages/stryker-javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/stryker-javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -22,11 +22,8 @@ export default class StringLiteralMutator implements NodeMutator {
       }
 
       nodes.push(mutatedNode);
-    } else if ((node.parent === undefined || (node.parent && !types.isImportDeclaration(node.parent) && !types.isJSXAttribute(node.parent)))
+    } else if ((!node.parent || (!types.isImportDeclaration(node.parent) && !types.isJSXAttribute(node.parent)))
       && types.isStringLiteral(node)) {
-      if (node.value === 'foo') {
-        console.log(node);
-      }
       let mutatedNode = copy(node);
       mutatedNode.value = mutatedNode.value.length === 0 ? 'Stryker was here!' : '';
       nodes.push(mutatedNode);

--- a/packages/stryker-javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/stryker-javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -22,7 +22,8 @@ export default class StringLiteralMutator implements NodeMutator {
       }
 
       nodes.push(mutatedNode);
-    } else if (types.isStringLiteral(node) && !types.isImportDeclaration(node.parent) && !types.isJSXAttribute(node.parent)) {
+    } else if ((node.parent === undefined || (node.parent && !types.isImportDeclaration(node.parent) && !types.isJSXAttribute(node.parent)))
+      && types.isStringLiteral(node)) {
       if (node.value === 'foo') {
         console.log(node);
       }

--- a/packages/stryker-javascript-mutator/src/mutators/index.ts
+++ b/packages/stryker-javascript-mutator/src/mutators/index.ts
@@ -8,8 +8,9 @@ import ConditionalExpressionMutator from './ConditionalExpressionMutator';
 import DoStatementMutator from './DoStatementMutator';
 import ForStatementMutator from './ForStatementMutator';
 import IfStatementMutator from './IfStatementMutator';
-import PrefixUnaryExpressionMutator from './PrefixUnaryExpressionMutator';
 import PostfixUnaryExpressionMutator from './PostfixUnaryExpressionMutator';
+import PrefixUnaryExpressionMutator from './PrefixUnaryExpressionMutator';
+import StringLiteralMutator from './StringLiteralMutator';
 import WhileStatementMutator from './WhileStatementMutator';
 
 const factory = NodeMutatorFactory.instance();
@@ -22,6 +23,7 @@ factory.register(ConditionalExpressionMutator.name, ConditionalExpressionMutator
 factory.register(DoStatementMutator.name, DoStatementMutator);
 factory.register(ForStatementMutator.name, ForStatementMutator);
 factory.register(IfStatementMutator.name, IfStatementMutator);
-factory.register(PrefixUnaryExpressionMutator.name, PrefixUnaryExpressionMutator);
 factory.register(PostfixUnaryExpressionMutator.name, PostfixUnaryExpressionMutator);
+factory.register(PrefixUnaryExpressionMutator.name, PrefixUnaryExpressionMutator);
+factory.register(StringLiteralMutator.name, StringLiteralMutator);
 factory.register(WhileStatementMutator.name, WhileStatementMutator);

--- a/packages/stryker-javascript-mutator/test/unit/JavaScriptMutatorSpec.ts
+++ b/packages/stryker-javascript-mutator/test/unit/JavaScriptMutatorSpec.ts
@@ -42,7 +42,7 @@ describe('JavaScriptMutator', () => {
 
     const mutants = mutator.mutate(files);
 
-    expect(mutants.length).to.equal(4);
+    expect(mutants.length).to.equal(6);
     expect(mutants).to.deep.include({
       mutatorName: 'IfStatement',
       fileName: 'testFile.jsx',
@@ -95,7 +95,7 @@ describe('JavaScriptMutator', () => {
 
     const mutants = mutator.mutate(files);
 
-    expect(mutants.length).to.equal(4);
+    expect(mutants.length).to.equal(5);
     expect(mutants).to.deep.include({
       mutatorName: 'IfStatement',
       fileName: 'testFile.js',

--- a/packages/stryker-javascript-mutator/test/unit/mutators/StringLiteralMutatorSpec.ts
+++ b/packages/stryker-javascript-mutator/test/unit/mutators/StringLiteralMutatorSpec.ts
@@ -1,0 +1,5 @@
+import StringLiteralMutator from '../../../src/mutators/StringLiteralMutator';
+import { verifySpecification } from '../../helpers/mutatorAssertions';
+import { StringLiteralMutatorSpec } from 'stryker-mutator-specification/src/index';
+
+verifySpecification(StringLiteralMutatorSpec, StringLiteralMutator);


### PR DESCRIPTION
Mutates strings into an empty string: `"Hello world!"` -> `""`
Mutates empty strings into non-empty strings: `""` -> `"Stryker was here!"`
Does not mutate `require`, `import`, `"use strict"` or JSX element properties

Fixes #685 