### PR TITLE
docs(stryker-package): add missing comma

### DIFF
--- a/packages/stryker/README.md
+++ b/packages/stryker/README.md
@@ -48,7 +48,7 @@ The following is an example `stryker.conf.js` file:
 module.exports = function(config){
   config.set({
     mutate: [
-      'src/**/*.js'
+      'src/**/*.js',
       '!src/index.js'
     ],
     testFramework: 'mocha',


### PR DESCRIPTION
Add comma to example config to make it syntactically correct