### PR TITLE
fix(Webpack transpiler): Loader exception logging

### DIFF
--- a/packages/stryker-webpack-transpiler/src/compiler/ConfigLoader.ts
+++ b/packages/stryker-webpack-transpiler/src/compiler/ConfigLoader.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'fs';
 import { Configuration } from 'webpack';
 import { StrykerWebpackConfig } from '../WebpackTranspiler';
 import { getLogger, Logger } from 'log4js';
@@ -30,13 +31,13 @@ export default class ConfigLoader {
     return webpackConfig;
   }
 
-  private loaderWebpackConfigFromProjectRoot(configFileLocation: string) {
-    try {
-      return this.loader(path.resolve(configFileLocation));
-    } catch {
-      throw new Error(`Could not load webpack config at "${configFileLocation}", file not found.`);
-    }
+private loaderWebpackConfigFromProjectRoot(configFileLocation: string) {
+  if (!fs.existsSync(path.resolve(configFileLocation))) {
+    throw new Error(`Could not load webpack config at "${configFileLocation}", file not found.`);
   }
+
+  return this.loader(path.resolve(configFileLocation));
+}
 
   private configureSilent(webpackConfig: Configuration) {
     if (webpackConfig.plugins) {


### PR DESCRIPTION
The webpack transpiler, when trying to load a config file, incorrectly
swallowed exceptions caused by errors in the config file.

Instead of logging the proper error you would get a misleading file not
found error.

To help the user, we perform an explicit check on the existence of
the configuration file and leave the rest up for the standard behavior
of node. It turns out that this is good enough for people to debug the
problem on their own.

Fixes #699 