### PR TITLE
fix(Sandbox): make sure .stryker-tmp does not appear in the sandbox

### DIFF
--- a/packages/stryker/README.md
+++ b/packages/stryker/README.md
@@ -200,12 +200,12 @@ All `TRAVIS` environment variables are set by Travis for each build. However, yo
 #### Files in the sandbox
 **Command line:** `[--files|-f] src/**/*.js,a.js,test/**/*.js`  
 **Config file:** `files: ['src/**/*.js', '!src/**/index.js', 'test/**/*.js']`  
-**Default value:** result of `git ls-files --others --exclude-standard --cached`  
+**Default value:** result of `git ls-files --others --exclude-standard --cached --exclude .stryker-tmp`  
 **Mandatory:** No  
 **Description:**  
 With `files` you can choose which files should be included in your test runner sandbox. 
 This is normally not needed as it defaults to all files not ignored by git. 
-Try it out yourself with this command: `git ls-files --others --exclude-standard --cached`.
+Try it out yourself with this command: `git ls-files --others --exclude-standard --cached --exclude .stryker-tmp`.
 
 If you do need to override `files` (for example: when your project does not live in a git repository),
 you can override the files here.

--- a/packages/stryker/src/input/InputFileResolver.ts
+++ b/packages/stryker/src/input/InputFileResolver.ts
@@ -48,7 +48,7 @@ export default class InputFileResolver {
   }
 
   private resolveFilesUsingGit(): Promise<string[]> {
-    return exec('git ls-files --others --exclude-standard --cached', { maxBuffer: 10 * 1000 * 1024 })
+    return exec('git ls-files --others --exclude-standard --cached --exclude .stryker-tmp', { maxBuffer: 10 * 1000 * 1024 })
       .then(([stdout]) => stdout.toString())
       .then(output => output.split('\n').map(fileName => fileName.trim()))
       .then(fileNames => fileNames.filter(fileName => fileName).map(fileName => path.resolve(fileName)))

--- a/packages/stryker/test/unit/input/InputFileResolverSpec.ts
+++ b/packages/stryker/test/unit/input/InputFileResolverSpec.ts
@@ -57,7 +57,7 @@ describe('InputFileResolver', () => {
     foo/bar/baz.ts
     `)]);
     const result = await sut.resolve();
-    expect(childProcessExecStub).calledWith('git ls-files --others --exclude-standard --cached',
+    expect(childProcessExecStub).calledWith('git ls-files --others --exclude-standard --cached --exclude .stryker-tmp',
       { maxBuffer: 10 * 1000 * 1024 });
     expect(result.files.map(file => file.name)).deep.eq([path.resolve('file1.js'), path.resolve('foo/bar/baz.ts')]);
   });


### PR DESCRIPTION
Fixes #698 