### PR TITLE
feat(webpack): Add support for config files exporting a function

### DIFF
--- a/packages/stryker-webpack-transpiler/src/WebpackTranspiler.ts
+++ b/packages/stryker-webpack-transpiler/src/WebpackTranspiler.ts
@@ -37,7 +37,7 @@ export default class WebpackTranspiler implements Transpiler {
 export interface StrykerWebpackConfig {
   configFile?: string;
   silent: boolean;
-
+  configFileArgs?: Array<any>;
   // TODO: Remove this when stryker implements projectRoot, see https://github.com/stryker-mutator/stryker/issues/650 */
   context?: string;
 }

--- a/packages/stryker-webpack-transpiler/src/compiler/ConfigLoader.ts
+++ b/packages/stryker-webpack-transpiler/src/compiler/ConfigLoader.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { Configuration } from 'webpack';
 import { StrykerWebpackConfig } from '../WebpackTranspiler';
 import { getLogger, Logger } from 'log4js';
+import { isFunction } from 'lodash';
 
 const PROGRESS_PLUGIN_NAME = 'ProgressPlugin';
 
@@ -20,6 +21,9 @@ export default class ConfigLoader {
 
     if (config.configFile) {
       webpackConfig = this.loaderWebpackConfigFromProjectRoot(config.configFile);
+      if (isFunction(webpackConfig)) {
+        webpackConfig = webpackConfig.apply(null, config.configFileArgs);
+      }
       if (config.silent) {
         this.configureSilent(webpackConfig);
       }

--- a/packages/stryker-webpack-transpiler/test/unit/compiler/ConfigLoaderSpec.ts
+++ b/packages/stryker-webpack-transpiler/test/unit/compiler/ConfigLoaderSpec.ts
@@ -32,6 +32,18 @@ describe('ConfigLoader', () => {
     expect(requireStub).calledWith(path.resolve('webpack.foo.config.js'));
   });
 
+  it('should call function with configFileArgs if webpack config file exports a function', () => {
+    const configFunctionStub = sandbox.stub();
+    configFunctionStub.returns('webpackconfig');
+    requireStub.returns(configFunctionStub);
+    existsSyncStub.returns(true);
+
+    const result = sut.load(createStrykerWebpackConfig({ configFile: 'webpack.foo.config.js', configFileArgs: [1, 2] }));
+    expect(result).eq('webpackconfig');
+    expect(requireStub).calledWith(path.resolve('webpack.foo.config.js'));
+    expect(configFunctionStub).calledWith(1, 2);
+  });
+
   it('should remove "ProgressPlugin" if silent is `true`', () => {
     // Arrange
     const bazPlugin = { baz: true, apply() { } };


### PR DESCRIPTION
The stryker-webpack-transpiler currently expects that the webpack config file exports an object. This PR adds support for config files that exports a function as well - to avoid having to create multiple webpack config files. 