### PR TITLE
Broader CI support

### DIFF
--- a/packages/stryker/src/reporters/DashboardReporter.ts
+++ b/packages/stryker/src/reporters/DashboardReporter.ts
@@ -1,11 +1,13 @@
 import {Reporter, ScoreResult} from 'stryker-api/report';
 import DashboardReporterClient from './dashboard-reporter/DashboardReporterClient';
 import {getEnvironmentVariable} from '../utils/objectUtils';
+import { determineCiProvider } from './ci/Provider';
 import { getLogger } from 'log4js';
 import { StrykerOptions } from 'stryker-api/core';
 
 export default class DashboardReporter implements Reporter {
   private readonly log = getLogger(DashboardReporter.name);
+  private readonly ciProvider = determineCiProvider();
 
   constructor(
     setting: StrykerOptions,
@@ -24,14 +26,13 @@ export default class DashboardReporter implements Reporter {
 
   async onScoreCalculated(ScoreResult: ScoreResult) {
     const mutationScore = ScoreResult.mutationScore;
-    const travisBuild = getEnvironmentVariable('TRAVIS');
 
-    if (travisBuild) {
-      const pullRequest = getEnvironmentVariable('TRAVIS_PULL_REQUEST');
+    if (this.ciProvider !== undefined) {
+      const isPullRequest = this.ciProvider.isPullRequest();
 
-      if (pullRequest === 'false') {
-        const repository = this.readEnvironmentVariable('TRAVIS_REPO_SLUG');
-        const branch = this.readEnvironmentVariable('TRAVIS_BRANCH');
+      if (!isPullRequest) {
+        const repository = this.ciProvider.determineRepository();
+        const branch = this.ciProvider.determineBranch();
         const apiKey = this.readEnvironmentVariable('STRYKER_DASHBOARD_API_KEY');
 
         if (repository && branch && apiKey) {
@@ -43,10 +44,10 @@ export default class DashboardReporter implements Reporter {
           });
         }
       } else {
-        this.log.info('Dashboard report is not sent when build is for a pull request {TRAVIS_PULL_REQUEST=<number>}');
+        this.log.info('Dashboard report is not sent when building a pull request');
       }
     } else {
-      this.log.info('Dashboard report is not sent when stryker didn\'t run on buildserver {TRAVIS=true}');
+      this.log.info('Dashboard report is not sent when not running on a buildserver');
     }
   }
 }

--- a/packages/stryker/src/reporters/ci/CircleProvider.ts
+++ b/packages/stryker/src/reporters/ci/CircleProvider.ts
@@ -1,0 +1,21 @@
+import { CiProvider } from './Provider';
+
+import { getEnvironmentVariable } from '../../utils/objectUtils';
+
+class CircleProvider implements CiProvider {
+  isPullRequest = () => getEnvironmentVariable('CIRCLE_PULL_REQUEST') !== undefined;
+
+  determineBranch = () => getEnvironmentVariable('CIRCLE_BRANCH') || '(unknown)';
+
+  determineRepository = () => {
+    const username = getEnvironmentVariable('CIRCLE_PROJECT_USERNAME');
+    const reponame = getEnvironmentVariable('CIRCLE_PROJECT_REPONAME');
+    if (username !== '' && reponame !== '') {
+      return `${username}/${reponame}`;
+    } else {
+      return '(unknown)';
+    }
+  }
+}
+
+export default CircleProvider;

--- a/packages/stryker/src/reporters/ci/Provider.ts
+++ b/packages/stryker/src/reporters/ci/Provider.ts
@@ -1,0 +1,29 @@
+import TravisProvider from './TravisProvider';
+
+import { getEnvironmentVariable } from '../../utils/objectUtils';
+
+/**
+ * Represents an object that can provide information about a CI/CD provider.
+ */
+export interface CiProvider {
+  /** Returns whether Stryker is running on a pull request. */
+  isPullRequest: () => boolean;
+  /** Returns the name of the Git branch of the project on which Stryker is running. */
+  determineBranch: () => string;
+  /** Returns the name of the GitHub repository of the project on which Stryker is running. */
+  determineRepository: () => string;
+}
+
+/**
+ * Return an approriate instance of CiProvider.
+ * @returns An instance of CiProvider, or undefined if it appears Stryker is not running in a CI/CD environment.
+ */
+export function determineCiProvider()  {
+  // By far the coolest env. variable from all those listed at
+  // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+  if (getEnvironmentVariable('HAS_JOSH_K_SEAL_OF_APPROVAL')) {
+    return new TravisProvider();
+  }
+
+  return undefined;
+}

--- a/packages/stryker/src/reporters/ci/Provider.ts
+++ b/packages/stryker/src/reporters/ci/Provider.ts
@@ -1,3 +1,4 @@
+import CircleProvider from './CircleProvider';
 import TravisProvider from './TravisProvider';
 
 import { getEnvironmentVariable } from '../../utils/objectUtils';
@@ -23,6 +24,9 @@ export function determineCiProvider()  {
   // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
   if (getEnvironmentVariable('HAS_JOSH_K_SEAL_OF_APPROVAL')) {
     return new TravisProvider();
+  } else if (getEnvironmentVariable('CIRCLECI')) {
+    return new CircleProvider();
+
   }
 
   return undefined;

--- a/packages/stryker/src/reporters/ci/TravisProvider.ts
+++ b/packages/stryker/src/reporters/ci/TravisProvider.ts
@@ -1,0 +1,13 @@
+import { CiProvider } from './Provider';
+
+import { getEnvironmentVariable } from '../../utils/objectUtils';
+
+class TravisReporter implements CiProvider {
+  isPullRequest = () => getEnvironmentVariable('TRAVIS_PULL_REQUEST') !== 'false';
+
+  determineBranch = () => getEnvironmentVariable('TRAVIS_BRANCH') || '(unknown)';
+
+  determineRepository = () => getEnvironmentVariable('TRAVIS_REPO_SLUG') || '(unknown)';
+}
+
+export default TravisReporter;

--- a/packages/stryker/test/unit/reporters/ci/CircleProviderSpec.ts
+++ b/packages/stryker/test/unit/reporters/ci/CircleProviderSpec.ts
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as environmentVariables from '../../../../src/utils/objectUtils';
+
+import CircleProvider from '../../../../src/reporters/ci/CircleProvider';
+
+describe('CircleCI Provider', () => {
+  let getEnvironmentVariables: sinon.SinonStub;
+
+  const circleProvider = new CircleProvider();
+
+  beforeEach(() => {
+    getEnvironmentVariables = sandbox.stub(environmentVariables, 'getEnvironmentVariable');
+  });
+
+  describe('isPullRequest()', () => {
+    it('should return false when not building a pull request', () => {
+      getEnvironmentVariables.withArgs('CIRCLE_PULL_REQUEST').returns(undefined);
+  
+      const result = circleProvider.isPullRequest();
+  
+      expect(result).to.be.false;
+    });
+
+    it('should return true when building a pull request', () => {
+      // CIRCLE_PULL_REQUEST will be the URL of the PR being built.
+      // If there was more than one PR, it will contain one 'em (picked randomly).
+      // Either way, it will be populated.
+      getEnvironmentVariables.withArgs('CIRCLE_PULL_REQUEST').returns('https://github.com/stryker-mutator/stryker/pull/42');
+  
+      const result = circleProvider.isPullRequest();
+  
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('determineBranch()', () => {
+    it('should return the appropriate value', () => {
+      getEnvironmentVariables.withArgs('CIRCLE_BRANCH').returns('master');
+  
+      const result = circleProvider.determineBranch();
+  
+      expect(result).to.equal('master');
+    });
+
+    it('should return a fall-back value', () => {
+      getEnvironmentVariables.withArgs('CIRCLE_BRANCH').returns('');
+  
+      const result = circleProvider.determineBranch();
+  
+      expect(result).to.equal('(unknown)');
+    });
+  });
+
+  describe('determineRepository()', () => {
+    it('should return the appropriate value', () => {
+      getEnvironmentVariables.withArgs('CIRCLE_PROJECT_USERNAME').returns('stryker');
+      getEnvironmentVariables.withArgs('CIRCLE_PROJECT_REPONAME').returns('stryker');
+  
+      const result = circleProvider.determineRepository();
+  
+      expect(result).to.equal('stryker/stryker');
+    });
+    
+    it('should return a fall-back value', () => {
+      getEnvironmentVariables.withArgs('CIRCLE_PROJECT_USERNAME').returns('');
+      getEnvironmentVariables.withArgs('CIRCLE_PROJECT_REPONAME').returns('');
+  
+      const result = circleProvider.determineRepository();
+  
+      expect(result).to.equal('(unknown)');
+    });
+  });
+
+});

--- a/packages/stryker/test/unit/reporters/ci/ProviderSpec.ts
+++ b/packages/stryker/test/unit/reporters/ci/ProviderSpec.ts
@@ -30,4 +30,14 @@ describe('determineCiProvider()', () => {
       expect(result).to.be.not.undefined;
     });
   });
+
+  describe('When CIRCLECI is \'true\'', () => {
+    it('should provide a CI Provider implementation', () => {
+      getEnvironmentVariables.withArgs('CIRCLECI').returns(true);
+
+      const result = determineCiProvider();
+  
+      expect(result).to.be.not.undefined;
+    });
+  });
 });

--- a/packages/stryker/test/unit/reporters/ci/ProviderSpec.ts
+++ b/packages/stryker/test/unit/reporters/ci/ProviderSpec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as environmentVariables from '../../../../src/utils/objectUtils';
+
+import { determineCiProvider } from '../../../../src/reporters/ci/Provider';
+
+describe('determineCiProvider()', () => {
+  let getEnvironmentVariables: sinon.SinonStub;
+
+  beforeEach(() => {
+    getEnvironmentVariables = sandbox.stub(environmentVariables, 'getEnvironmentVariable');
+  });
+
+  describe('Without CI environment', () => {
+    it('should not select a CI Provider', () => {
+      getEnvironmentVariables.withArgs('HAS_JOSH_K_SEAL_OF_APPROVAL').returns('');
+  
+      const result = determineCiProvider();
+  
+      expect(result).to.be.undefined;
+    });
+  });
+
+  describe('When HAS_JOSH_K_SEAL_OF_APPROVAL is \'true\'', () => {
+    it('should provide a CI Provider implementation', () => {
+      getEnvironmentVariables.withArgs('HAS_JOSH_K_SEAL_OF_APPROVAL').returns(true);
+
+      const result = determineCiProvider();
+  
+      expect(result).to.be.not.undefined;
+    });
+  });
+});

--- a/packages/stryker/test/unit/reporters/ci/TravisProviderSpec.ts
+++ b/packages/stryker/test/unit/reporters/ci/TravisProviderSpec.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as environmentVariables from '../../../../src/utils/objectUtils';
+
+import TravisProvider from '../../../../src/reporters/ci/TravisProvider';
+
+describe('Travis Provider', () => {
+  let getEnvironmentVariables: sinon.SinonStub;
+
+  const travisProvider = new TravisProvider();
+
+  beforeEach(() => {
+    getEnvironmentVariables = sandbox.stub(environmentVariables, 'getEnvironmentVariable');
+  });
+
+  describe('isPullRequest()', () => {
+    it('should return false when not building a pull request', () => {
+      getEnvironmentVariables.withArgs('TRAVIS_PULL_REQUEST').returns('false');
+  
+      const result = travisProvider.isPullRequest();
+  
+      expect(result).to.be.false;
+    });
+
+    it('should return true when building a pull request', () => {
+      getEnvironmentVariables.withArgs('TRAVIS_PULL_REQUEST').returns('42');
+  
+      const result = travisProvider.isPullRequest();
+  
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('determineBranch()', () => {
+    it('should return the appropriate value', () => {
+      getEnvironmentVariables.withArgs('TRAVIS_BRANCH').returns('master');
+  
+      const result = travisProvider.determineBranch();
+  
+      expect(result).to.equal('master');
+    });
+
+    it('should return a fall-back value', () => {
+      getEnvironmentVariables.withArgs('TRAVIS_BRANCH').returns('');
+  
+      const result = travisProvider.determineBranch();
+  
+      expect(result).to.equal('(unknown)');
+    });
+  });
+
+  describe('determineRepository()', () => {
+    it('should return the appropriate value', () => {
+      getEnvironmentVariables.withArgs('TRAVIS_REPO_SLUG').returns('stryker/stryker');
+  
+      const result = travisProvider.determineRepository();
+  
+      expect(result).to.equal('stryker/stryker');
+    });
+    
+    it('should return a fall-back value', () => {
+      getEnvironmentVariables.withArgs('TRAVIS_REPO_SLUG').returns('');
+  
+      const result = travisProvider.determineRepository();
+  
+      expect(result).to.equal('(unknown)');
+    });
+  });
+
+});


### PR DESCRIPTION
As noted in #744, the Dashboard reported will currently only work when building on Travis.
This PR addresses that by de-coupling the reporter from the CI/CD system being used.