### PR TITLE
fix(String mutator): do not mutate prologue directives

### DIFF
--- a/packages/stryker-mutator-specification/src/StringLiteralMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/StringLiteralMutatorSpec.ts
@@ -50,5 +50,10 @@ export default function StringLiteralMutatorSpec(name: string, expectMutation: E
     it('should not mutate string JSX attributes', () => {
       expectMutation('<Record class="row" />');
     });
+
+    it('should not mutate directive prologues', () => {
+      expectMutation('"use strict";"use asm";');
+      expectMutation('function a() {"use strict";"use asm";}');
+    });
   });
 }

--- a/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
+++ b/packages/stryker-typescript/src/mutator/StringLiteralMutator.ts
@@ -21,7 +21,8 @@ export default class StringLiteralMutator extends NodeMutator<AllStringLiterals>
   private isInvalidParent(parent: ts.Node): boolean {
     return parent.kind === ts.SyntaxKind.ImportDeclaration ||
       parent.kind === ts.SyntaxKind.LastTypeNode ||
-      parent.kind === ts.SyntaxKind.JsxAttribute;
+      parent.kind === ts.SyntaxKind.JsxAttribute ||
+      parent.kind === ts.SyntaxKind.ExpressionStatement;
   }
 
   protected identifyReplacements(str: AllStringLiterals, sourceFile: ts.SourceFile): NodeReplacement[] {


### PR DESCRIPTION
String literals in a expression statement tend not to have any side effects. So lets assume it's just dead code.

The first string literals in an expression may, given ecma standard rules be converted to prologue directives and have no meaning when being executed.