### PR TITLE
fix(stryker): kill entire test process tree

### DIFF
--- a/packages/stryker/package-lock.json
+++ b/packages/stryker/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@types/babel-types": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.3.tgz",
-			"integrity": "sha512-fm2ymG5DSwzaIRx6eUvuftTufjbeHnxLBIQTNbfO27Q1OzPKNrnfVAAcCMC++AbPTDYjBGWXBo2g8SYjN0Lm3Q==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.4.tgz",
+			"integrity": "sha512-WiZhq3SVJHFRgRYLXvpf65XnV6ipVHhnNaNvE8yCimejrGglkg38kEj0JcizqwSHxmPSjcTlig/6JouxLGEhGw==",
 			"dev": true
 		},
 		"@types/inquirer": {
@@ -38,9 +38,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.0.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.8.tgz",
-			"integrity": "sha512-MFFKFv2X4iZy/NFl1m1E8uwE1CR96SGwJjgHma09PLtqOWoj3nqeJHMG+P/EuJGVLvC2I6MdQRQsr4TcRduIow==",
+			"version": "10.5.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.1.tgz",
+			"integrity": "sha512-AFLl1IALIuyt6oK4AYZsgWVJ/5rnyzQWud7IebaZWWV3YmgtPZkQmYio9R5Ze/2pdd7XfqF5bP+hWS11mAKoOQ==",
 			"dev": true
 		},
 		"@types/prettier": {
@@ -968,6 +968,11 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+		},
+		"tree-kill": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
+			"integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg=="
 		},
 		"trim-right": {
 			"version": "1.0.1",

--- a/packages/stryker/package.json
+++ b/packages/stryker/package.json
@@ -70,6 +70,7 @@
     "rxjs": "^6.0.0",
     "source-map": "^0.6.1",
     "surrial": "^0.1.3",
+    "tree-kill": "^1.2.0",
     "tslib": "^1.5.0",
     "typed-rest-client": "^1.0.7"
   },

--- a/packages/stryker/src/isolated-runner/IsolatedTestRunnerAdapter.ts
+++ b/packages/stryker/src/isolated-runner/IsolatedTestRunnerAdapter.ts
@@ -3,10 +3,11 @@ import { getLogger } from 'log4js';
 import * as _ from 'lodash';
 import { fork, ChildProcess } from 'child_process';
 import { TestRunner, RunResult, RunOptions } from 'stryker-api/test_runner';
-import { serialize } from '../utils/objectUtils';
+import { serialize, kill } from '../utils/objectUtils';
 import { AdapterMessage, WorkerMessage } from './MessageProtocol';
 import IsolatedRunnerOptions from './IsolatedRunnerOptions';
 import Task from '../utils/Task';
+
 const MAX_WAIT_FOR_DISPOSE = 2000;
 
 class InitTask extends Task<void> {
@@ -19,6 +20,7 @@ class RunTask extends Task<RunResult> {
   readonly kind = 'run';
 }
 type WorkerTask = InitTask | DisposeTask | RunTask;
+
 
 /**
  * Runs the given test runner in a child process and forwards reports about test results
@@ -137,7 +139,7 @@ export default class TestRunnerChildProcessAdapter extends EventEmitter implemen
     this.currentTask = new DisposeTask(MAX_WAIT_FOR_DISPOSE);
     this.sendDisposeCommand();
     return this.currentTask.promise
-      .then(() => this.workerProcess.kill());
+      .then(() => kill(this.workerProcess.pid));
   }
 
   private sendRunCommand(options: RunOptions) {

--- a/packages/stryker/src/utils/objectUtils.ts
+++ b/packages/stryker/src/utils/objectUtils.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import treeKill = require('tree-kill');
 export { serialize, deserialize } from 'surrial';
 
 export function freezeRecursively<T extends { [prop: string]: any }>(target: T): T {
@@ -81,4 +82,16 @@ export function base64Decode(base64EncodedString: string) {
  */
 export function normalizeWhiteSpaces(str: string) {
   return str.replace(/\s+/g, ' ').trim();
+}
+
+export function kill(pid: number): Promise<void> {
+  return new Promise((res, rej) => {
+    treeKill(pid, 'SIGKILL', err => {
+      if (err) {
+        rej(err);
+      } else {
+        res();
+      }
+    });
+  });
 }


### PR DESCRIPTION
We cannot trust that a test runner process didn't spawn additional processes. For example, angular cli will spawn an additional process to host the type checker (typescript) in. We should kill the entire process tree.

This fixes an edge case where Stryker doesn't shut down and keeps "hanging" after it is reported "done"