### PR TITLE
Added missing "string &" to keyof T types for ChildProcessProxy

### DIFF
--- a/packages/stryker/src/child-proxy/ChildProcessProxy.ts
+++ b/packages/stryker/src/child-proxy/ChildProcessProxy.ts
@@ -48,12 +48,12 @@ export default class ChildProcessProxy<T> {
   }
 
   private initProxy() {
-    Object.keys(this.constructorFunction.prototype).forEach((methodName: keyof T) => {
+    Object.keys(this.constructorFunction.prototype).forEach((methodName: string & keyof T) => {
       this.proxyMethod(methodName);
     });
   }
 
-  private proxyMethod(methodName: keyof T) {
+  private proxyMethod(methodName: string & keyof T) {
     this.proxy[methodName] = (...args: any[]) => {
       const workerTask = new Task<any>();
       this.initTask.promise.then(() => {


### PR DESCRIPTION
`Object.keys` gives a `string[]` so we're guaranteed the results to be strings. The `keyof` type implies they could also be `number` or `symbol`.

Fixes #960 