### PR TITLE
Configurable ng test arguments

### DIFF
--- a/packages/stryker-karma-runner/src/KarmaTestRunner.ts
+++ b/packages/stryker-karma-runner/src/KarmaTestRunner.ts
@@ -26,7 +26,7 @@ export default class KarmaTestRunner implements TestRunner {
       setup.projectType = setup.project;
       this.log.warn('DEPRECATED: `karma.project` is renamed to `karma.projectType`. Please change it in your stryker configuration.');
     }
-    this.starter = new ProjectStarter(setup.projectType);
+    this.starter = new ProjectStarter(setup);
     this.setGlobals(setup, options.port);
     this.cleanRun();
     this.listenToRunComplete();

--- a/packages/stryker-karma-runner/src/StrykerKarmaSetup.ts
+++ b/packages/stryker-karma-runner/src/StrykerKarmaSetup.ts
@@ -6,10 +6,15 @@ export const KARMA_CONFIG_KEY = 'karma';
 
 export type ProjectKind = 'custom' | 'angular-cli';
 
+export interface NgConfigOptions {
+  testArguments?: string[];
+}
+
 export default interface StrykerKarmaSetup {
   // Deprecrated
   project?: ProjectKind;
   projectType: ProjectKind;
   configFile?: string;
   config?: karma.ConfigOptions;
+  ngConfig?: NgConfigOptions;
 }

--- a/packages/stryker-karma-runner/src/StrykerKarmaSetup.ts
+++ b/packages/stryker-karma-runner/src/StrykerKarmaSetup.ts
@@ -6,8 +6,12 @@ export const KARMA_CONFIG_KEY = 'karma';
 
 export type ProjectKind = 'custom' | 'angular-cli';
 
+export interface NgTestArguments {
+  [key: string]: string | undefined;
+}
+
 export interface NgConfigOptions {
-  testArguments?: string[];
+  testArguments?: NgTestArguments;
 }
 
 export default interface StrykerKarmaSetup {

--- a/packages/stryker-karma-runner/src/starters/ProjectStarter.ts
+++ b/packages/stryker-karma-runner/src/starters/ProjectStarter.ts
@@ -1,12 +1,12 @@
-import { ProjectKind } from '../StrykerKarmaSetup';
+import StrykerKarmaSetup from '../StrykerKarmaSetup';
 import * as angularStarter from './angularStarter';
 import * as karmaStarter from './karmaStarter';
 
 export default class ProjectStarter {
-  constructor(private kind: ProjectKind) { }
+  constructor(private setup: StrykerKarmaSetup) { }
   start() {
-    if (this.kind === 'angular-cli') {
-      return angularStarter.start();
+    if (this.setup.projectType === 'angular-cli') {
+      return angularStarter.start(this.setup.ngConfig);
     } else {
       return karmaStarter.start();
     }

--- a/packages/stryker-karma-runner/src/starters/angularStarter.ts
+++ b/packages/stryker-karma-runner/src/starters/angularStarter.ts
@@ -1,9 +1,10 @@
 import * as semver from 'semver';
 import { requireModule } from '../utils';
+import { NgConfigOptions } from '../StrykerKarmaSetup';
 
 const MIN_ANGULAR_CLI_VERSION = '6.1.0';
 
-export async function start(): Promise<void> {
+export async function start(ngConfig?: NgConfigOptions): Promise<void> {
   
   // Make sure require angular cli from inside this function, that way it won't break if angular isn't installed and this file is required.
   const version = semver.coerce(requireModule('@angular/cli/package').version);
@@ -14,8 +15,12 @@ export async function start(): Promise<void> {
   if ('default' in cli) {
     cli = cli.default;
   }
+  let cliArgs = ['test', '--progress=false', `--karma-config=${require.resolve('./stryker-karma.conf')}`];
+  if (ngConfig && ngConfig.testArguments) {
+    cliArgs = cliArgs.concat(ngConfig.testArguments || []);
+  }
   return cli({
-    cliArgs: ['test', '--progress=false', `--karma-config=${require.resolve('./stryker-karma.conf')}`],
+    cliArgs: cliArgs,
     inputStream: process.stdin,
     outputStream: process.stdout
   });

--- a/packages/stryker-karma-runner/src/starters/angularStarter.ts
+++ b/packages/stryker-karma-runner/src/starters/angularStarter.ts
@@ -1,11 +1,14 @@
+import * as decamelize from 'decamelize';
 import * as semver from 'semver';
 import { requireModule } from '../utils';
-import { NgConfigOptions } from '../StrykerKarmaSetup';
+import { NgConfigOptions, NgTestArguments } from '../StrykerKarmaSetup';
+import { getLogger, Logger } from 'stryker-api/logging';
+import * as path from 'path';
 
 const MIN_ANGULAR_CLI_VERSION = '6.1.0';
 
 export async function start(ngConfig?: NgConfigOptions): Promise<void> {
-  
+  const logger: Logger = getLogger(path.basename(__filename));
   // Make sure require angular cli from inside this function, that way it won't break if angular isn't installed and this file is required.
   const version = semver.coerce(requireModule('@angular/cli/package').version);
   if (!version || semver.lt(version, MIN_ANGULAR_CLI_VERSION)) {
@@ -15,10 +18,17 @@ export async function start(ngConfig?: NgConfigOptions): Promise<void> {
   if ('default' in cli) {
     cli = cli.default;
   }
-  let cliArgs = ['test', '--progress=false', `--karma-config=${require.resolve('./stryker-karma.conf')}`];
+  const cliArgs = ['test', '--progress=false', `--karma-config=${require.resolve('./stryker-karma.conf')}`];
   if (ngConfig && ngConfig.testArguments) {
-    cliArgs = cliArgs.concat(ngConfig.testArguments || []);
+    const testArguments: NgTestArguments = ngConfig.testArguments;
+    Object.keys(testArguments).forEach(key => {
+      let decamelizedKey = decamelize(key);
+      if ('progress' !== key && 'karma-config' !== decamelizedKey && !decamelizedKey.trim().startsWith('-')) {
+        cliArgs.push(`--${decamelizedKey}=${testArguments[key]}`);
+      }
+    });
   }
+  logger.debug('Starting Angular tests: ng', cliArgs.join(' '));
   return cli({
     cliArgs: cliArgs,
     inputStream: process.stdin,


### PR DESCRIPTION
This is a proposition to allow customization of arguments passed to `ng test`. Below is sample conf file:
```
module.exports = function (config) {
  config.set({
    files: ['*', 'src/**/*'],
    mutate: [
      'src/app/**/*.ts',
      '!src/**/*.unit-spec.ts',
      '!src/**/*.integration-spec.ts',
      '!src/test.ts',
      '!src/environments/*.ts'
    ],
    testRunner: 'karma',
    mutator: 'typescript',
    port: 9336,
    karma: {
      configFile: 'src/karma.conf.js',
      project: 'angular-cli',
      config: {
        browsers: (process.env.KARMA_BROWSERS || 'ChromeHeadless').split(',')
      },
      ngConfig: {
        ngTestArguments: ['--main', 'src/test-unit.ts']
      }
    },
    reporters: ['progress', 'html'],
    coverageAnalysis: 'off',
    maxConcurrentTestRunners: 1,
    fileLogLevel: 'trace'
  });
};
```