### PR TITLE
Add ^7.0.0-bridge.0 to babel-core range

### DIFF
--- a/packages/stryker-babel-transpiler/README.md
+++ b/packages/stryker-babel-transpiler/README.md
@@ -39,7 +39,8 @@ $ stryker run
 ## Peer dependencies
 The `stryker-babel-transpiler` plugin requires the following packages to be installed in order to work: 
 * `stryker-api`
-* `babel-core`
+* `babel-core` (When using babel 6)
+* 'babel-core@^7.0.0-bridge.0' (When using babel 7)
 
 For the current versions, see the `peerDependencies` section in the package.json file.
 

--- a/packages/stryker-babel-transpiler/package.json
+++ b/packages/stryker-babel-transpiler/package.json
@@ -58,7 +58,7 @@
     "stryker-api": "^0.21.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.26.0",
+    "babel-core": "^6.26.0" || ^7.0.0-bridge.0",
     "stryker-api": ">=0.18.0 <0.22.0"
   },
   "initStrykerConfig": {

--- a/packages/stryker-babel-transpiler/package.json
+++ b/packages/stryker-babel-transpiler/package.json
@@ -58,7 +58,7 @@
     "stryker-api": "^0.21.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.26.0" || ^7.0.0-bridge.0",
+    "babel-core": "^6.26.0 || ^7.0.0-bridge.0",
     "stryker-api": ">=0.18.0 <0.22.0"
   },
   "initStrykerConfig": {


### PR DESCRIPTION
We're in the process of upgrading to Babel 7 and have hit an issue with stryker-babel-transpiler. It loads babel-core 6.

This PR adds ^7.0.0-bridge.0 to the babel-core peer range, as recommended by Babel https://github.com/babel/babel-bridge