### PR TITLE
fix(mutator): Fix empty case statement unkillable mutant

### DIFF
--- a/packages/stryker-javascript-mutator/src/mutators/SwitchCaseMutator.ts
+++ b/packages/stryker-javascript-mutator/src/mutators/SwitchCaseMutator.ts
@@ -10,9 +10,12 @@ export default class SwitchCaseMutator implements NodeMutator {
 
   public mutate(node: types.Node, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] | void {
     if (types.isSwitchCase(node)) {
-      const mutatedNode = copy(node);
-      mutatedNode.consequent = [];
-      return [mutatedNode];
+      // if not a fallthrough case
+      if (node.consequent.length > 0) {
+        const mutatedNode = copy(node);
+        mutatedNode.consequent = [];
+        return [mutatedNode];
+      }
     }
   }
 }

--- a/packages/stryker-mutator-specification/src/SwitchCaseMutatorSpec.ts
+++ b/packages/stryker-mutator-specification/src/SwitchCaseMutatorSpec.ts
@@ -18,5 +18,13 @@ export default function SwitchCaseMutatorSpec(
         'switch (v) {case 0: a = "foo"; case 1: a = "qux"; break; default:}'
       );
     });
+
+    it('should not mutate empty cases (0 consequent statements)', () => {
+      expectMutation(
+        'switch (v) {case 0: case 1: break; default: a = "spam";}',
+        'switch (v) {case 0: case 1: default: a = "spam";}',
+        'switch (v) {case 0: case 1: break; default:}'
+      );
+    });
   });
 }

--- a/packages/stryker-typescript/src/mutator/SwitchCaseMutator.ts
+++ b/packages/stryker-typescript/src/mutator/SwitchCaseMutator.ts
@@ -18,10 +18,15 @@ export default class SwitchCaseMutator extends NodeMutator<ts.CaseOrDefaultClaus
   }
 
   protected identifyReplacements(node: ts.CaseOrDefaultClause, sourceFile: ts.SourceFile): NodeReplacement[] {
-    const clause = isDefaultClause(node)
-      ? ts.createDefaultClause([])
-      : ts.createCaseClause(node.expression, []);
-    const replacement = printNode(clause, sourceFile);
-    return [{ node, replacement }];
+    // if not a fallthrough case
+    if (node.statements.length > 0) {
+      const clause = isDefaultClause(node)
+        ? ts.createDefaultClause([])
+        : ts.createCaseClause(node.expression, []);
+      const replacement = printNode(clause, sourceFile);
+      return [{ node, replacement }];
+    } else {
+      return [];
+    }
   }
 }


### PR DESCRIPTION
Hotfix for #1156: if a case clause contains no statements, do not mutate it.

---

I think a better fix (technically) would be to always remove the case clause altogether. However this was discounted as part of #1127 due to it producing unclear reporter output - stryker then considers the entire `switch` block mutated, rather than the single `case` clause.

One possible alternative is ensuring the case is never matched, rather than removing the statments:
```
case "A":
case "B":
  console.log("Do some actions");
...

// becomes
case "stryker/expression-that-is-never-matched/40ed2198-a801-40fe-8edd-0531783bc069":
case "B":
  console.log("Do some actions");
```

This would pick up mutants for:
- the case clause never being matched
- the case clause resulting action not being tested

Downside is, I don't think this is immediately readable/clear to the user. Unlike the `IfStatement` mutator, we we can't simply replace it with `case false:` or `case null:`, as these are valid expressions that could be easily matched.