### PR TITLE
fix(ScoreResultCalculator): fix faulty filenames in stryker score result

### DIFF
--- a/packages/stryker/src/ScoreResultCalculator.ts
+++ b/packages/stryker/src/ScoreResultCalculator.ts
@@ -98,12 +98,20 @@ export default class ScoreResultCalculator {
     const uniqueFileDirectories = uniqueFiles.map(file => file.substr(basePath.length).split(path.sep));
 
     if (uniqueFileDirectories.length) {
-      return uniqueFileDirectories
-        .reduce((previousDirectories, currentDirectories) => previousDirectories.filter((token, index) => currentDirectories[index] === token))
-        .join(path.sep);
+      return uniqueFileDirectories.reduce(this.filterDirectories).join(path.sep);
     } else {
       return '';
     }
+  }
+
+  private filterDirectories(previousDirectories: string[], currentDirectories: string[]) {
+    for (let i = 0; i < previousDirectories.length; i++) {
+      if (previousDirectories[i] !== currentDirectories[i]) {
+        return previousDirectories.splice(0, i);
+      }
+    }
+
+    return previousDirectories;
   }
 
   private countNumbers(mutantResults: MutantResult[]) {

--- a/packages/stryker/test/unit/ScoreResultCalculatorSpec.ts
+++ b/packages/stryker/test/unit/ScoreResultCalculatorSpec.ts
@@ -159,6 +159,17 @@ describe('ScoreResult', () => {
       expect(actual.childResults[0].name).to.eq('dir1/one');
       expect(actual.childResults[1].name).to.eq('dir2/two');
     });
+
+    it('should be able to handle the same file name in two different directories', () => {
+      const actual = sut.calculate([
+        mutantResult({ sourceFilePath: path.join('a', 'b', 'x.js') }),
+        mutantResult({ sourceFilePath: path.join('a', 'c', 'x.js') })
+      ]);
+
+      expect(actual.name).to.eq('a');
+      expect(actual.childResults[0].name).to.equal(path.join('b', 'x.js'));
+      expect(actual.childResults[1].name).to.equal(path.join('c', 'x.js'));
+    });
   });
 
   describe('determineExitCode', () => {


### PR DESCRIPTION
The filter method used causes a side-effect that creates a corrupt path, I solved this by short circuiting the filter method so it only returns the elements up untill the element that does no longer match.

solves https://github.com/stryker-mutator/stryker/issues/1140