### PR TITLE
fix(Sandbox): Timeout sandbox creation

### DIFF
--- a/packages/stryker/src/Sandbox.ts
+++ b/packages/stryker/src/Sandbox.ts
@@ -16,8 +16,8 @@ import LoggingClientContext from './logging/LoggingClientContext';
 
 // The initial sandbox creation should not take long at all.
 // A long hang here could indicate testrunner hidden error logs
-// 30 seconds
-const SANDBOX_CREATE_TIMEOUT = 30 * 1000;
+// 60 seconds
+const SANDBOX_CREATE_TIMEOUT = 60 * 1000;
 
 interface FileMap {
   [sourceFile: string]: string;

--- a/packages/stryker/src/Sandbox.ts
+++ b/packages/stryker/src/Sandbox.ts
@@ -53,7 +53,7 @@ export default class Sandbox {
       // and throw an error if it never does (e.g. karma server hang)
       // https://github.com/stryker-mutator/stryker/issues/621
       setTimeout(() => reject(new Error('Sandbox creation timed out')), SANDBOX_CREATE_TIMEOUT);
-    })
+    });
   }
 
   public run(timeout: number, testHooks: string | undefined): Promise<RunResult> {

--- a/packages/stryker/src/utils/objectUtils.ts
+++ b/packages/stryker/src/utils/objectUtils.ts
@@ -117,6 +117,25 @@ export function timeout<T>(promise: Promise<T>, ms: number): Promise<T | typeof 
   return sleep;
 }
 
+export function isTimeoutExpired<T>(result: T | typeof TimeoutExpired): result is typeof TimeoutExpired {
+  return result === TimeoutExpired;
+}
+
+/**
+ * Unwrap a potentially TimeoutExpired result into a definite result.
+ * If the timeout did expire, throw an error with the given message.
+ *
+ * @param result The return of `timeout`
+ * @param msg An error message to throw if the timeout expired
+ */
+export function unwrapTimeout<T>(result: T | typeof TimeoutExpired, msg: string): T {
+  if (isTimeoutExpired(result)) {
+    throw new Error(msg);
+  } else {
+    return result;
+  }
+}
+
 export function padLeft(input: string): string {
   return input.split('\n').map(str => '\t' + str).join('\n');
 }

--- a/packages/stryker/test/unit/utils/objectUtilsSpec.ts
+++ b/packages/stryker/test/unit/utils/objectUtilsSpec.ts
@@ -31,4 +31,18 @@ describe('objectUtils', () => {
       expect(setTimeoutStub).calledWith(match.func, delay);
     });
   });
+
+  describe('unwrapTimeout', () => {
+    it('should return the result if timeout did not expire', async () => {
+      const result: string | typeof sut.TimeoutExpired = 'timeout did not expire';
+      const actual = sut.unwrapTimeout(result, 'This error should not be thrown');
+      expect(actual).eq('timeout did not expire');
+    });
+
+    it('should throw an error if timeout expired', async () => {
+      const result: string | typeof sut.TimeoutExpired = sut.TimeoutExpired;
+      const actual = () => sut.unwrapTimeout(result, 'This error should be thrown');
+      expect(actual).to.throw(Error, 'This error should be thrown');
+    });
+  });
 });


### PR DESCRIPTION
Currently we set a timeout for test runs inside the sandbox, but do not set a timeout for sandbox creation. This can lead to stryker hanging forever (e.g. with a bad `karma` configuration).

This PR implements a naive timeout on sandbox creation. If preferred I can use an external module/factor out to a util function for reuse.

Closes #621 