### PR TITLE
feat(karma-runner): Support angular public api

### DIFF
--- a/packages/stryker-karma-runner/src/starters/angularStarter.ts
+++ b/packages/stryker-karma-runner/src/starters/angularStarter.ts
@@ -10,7 +10,7 @@ export async function start(): Promise<void> {
   if (!version || semver.lt(version, MIN_ANGULAR_CLI_VERSION)) {
     throw new Error(`Your @angular/cli version (${version}) is not supported. Please install ${MIN_ANGULAR_CLI_VERSION} or higher`);
   }
-  let cli = requireModule('@angular/cli/lib/cli');
+  let cli = requireModule('@angular/cli');
   if ('default' in cli) {
     cli = cli.default;
   }

--- a/packages/stryker-karma-runner/test/unit/starters/angularStarterSpec.ts
+++ b/packages/stryker-karma-runner/test/unit/starters/angularStarterSpec.ts
@@ -9,7 +9,7 @@ describe('angularStarter', () => {
   beforeEach(() => {
     cliStub = sandbox.stub();
     requireModuleStub = sandbox.stub(utils, 'requireModule');
-    requireModuleStub.withArgs('@angular/cli/lib/cli').returns(cliStub);
+    requireModuleStub.withArgs('@angular/cli').returns(cliStub);
   });
 
   it('should throw an error if angular cli version < 6.1.0', async () => {


### PR DESCRIPTION
Add support for angular's public API. It is save to merge, the public api was already there since angular 6.0, but never documented. The private API we're now using will be **removed** when https://github.com/angular/angular-cli/pull/12499 is merged.