### PR TITLE
Enable no implicit this in tsconfig #1210

### DIFF
--- a/packages/stryker-util/src/promisify.ts
+++ b/packages/stryker-util/src/promisify.ts
@@ -18,6 +18,7 @@ function promisify(original: any) {
 export function innerPromisify(original: any) {
   return function fn(...args: any[]) {
     return new Promise((resolve, reject) => {
+      // @ts-ignore
       original.call(this, ...args, (err: Error, ...values: any[]) => {
         if (original === exists) {
           // the exists callback is NOT consistent with NodeJS callbacks: https://nodejs.org/api/fs.html#fs_fs_exists_path_callback

--- a/packages/stryker-util/src/promisify.ts
+++ b/packages/stryker-util/src/promisify.ts
@@ -16,9 +16,8 @@ function promisify(original: any) {
 
 // This function is exported so that it can be tested on node >= 8
 export function innerPromisify(original: any) {
-  return function fn(...args: any[]) {
+  return function fn(this: unknown, ...args: any[]) {
     return new Promise((resolve, reject) => {
-      // @ts-ignore
       original.call(this, ...args, (err: Error, ...values: any[]) => {
         if (original === exists) {
           // the exists callback is NOT consistent with NodeJS callbacks: https://nodejs.org/api/fs.html#fs_fs_exists_path_callback

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
         "alwaysStrict": true,
         "noImplicitReturns": true,
         "strictNullChecks": true,
+        "noImplicitThis": true,
         "lib": [
           "es5",
           "es2015.promise",


### PR DESCRIPTION
Ended up having to use ts-ignore on the one issue that came up because it is using 'this' inside an arrow function.

Fixes #1210 