### PR TITLE
feat(striker-cli): add remark to run again with loglevel trace

### DIFF
--- a/packages/stryker/src/Stryker.ts
+++ b/packages/stryker/src/Stryker.ts
@@ -69,6 +69,8 @@ export default class Stryker {
         await this.logDone();
         await LogConfigurator.shutdown();
         return mutantResults;
+      } else {
+        this.logRemark();
       }
     }
     return Promise.resolve([]);
@@ -150,6 +152,12 @@ export default class Stryker {
 
   private logDone() {
     this.log.info('Done in %s.', this.timer.humanReadableElapsed());
+  }
+
+  private logRemark() {
+    if (!this.log.isTraceEnabled()) {
+      this.log.info('Trouble figuring out what went wrong? Try `npx stryker run --fileLogLevel trace --logLevel debug` to get some more info.');
+    }
   }
 
   private reportScore(mutantResults: MutantResult[]) {

--- a/packages/stryker/src/StrykerCli.ts
+++ b/packages/stryker/src/StrykerCli.ts
@@ -76,6 +76,9 @@ export default class StrykerCli {
     if (Object.keys(commands).indexOf(this.command) >= 0) {
       commands[this.command]().catch(err => {
         log.error(`an error occurred`, err);
+        if (!log.isTraceEnabled()) {
+          log.info('Trouble figuring out what went wrong? Try `npx stryker run --fileLogLevel trace --logLevel debug` to get some more info.');
+        }
         process.exitCode = 1;
         process.kill(process.pid, 'SIGINT');
       });

--- a/packages/stryker/test/unit/StrykerSpec.ts
+++ b/packages/stryker/test/unit/StrykerSpec.ts
@@ -208,6 +208,18 @@ describe('Stryker', () => {
         await sut.runMutationTest();
         expect(currentLogMock().info).to.have.been.calledWith('It\'s a mutant-free world, nothing to test.');
       });
+
+      it('should log the remark to run again with logLevel trace if no tests were executed in initial test run', async () => {
+        while (initialRunResult.tests.pop());
+        await sut.runMutationTest();
+        expect(currentLogMock().info).to.have.been.calledWith('Trouble figuring out what went wrong? Try `npx stryker run --fileLogLevel trace --logLevel debug` to get some more info.');
+      });
+
+      it('should log the remark to run again with logLevel trace if no mutants were generated', async () => {
+        while (mutants.pop()); // clear all mutants
+        await sut.runMutationTest();
+        expect(currentLogMock().info).to.have.been.calledWith('Trouble figuring out what went wrong? Try `npx stryker run --fileLogLevel trace --logLevel debug` to get some more info.');
+      });
     });
 
     describe('happy flow', () => {


### PR DESCRIPTION
fixes #1205 