### PR TITLE
refactor(mutant-generator): Change the 'error' message when a mutator plugin cannot be found

### DIFF
--- a/packages/stryker-api/src/mutant/MutatorFactory.ts
+++ b/packages/stryker-api/src/mutant/MutatorFactory.ts
@@ -10,6 +10,18 @@ namespace MutatorFactory {
     constructor() {
       super('mutant-generator');
     }
+
+    /**
+     * Returns the import suggestion for a Mutator
+     * @param name The name of the Mutator the user tried to use.
+     * @returns The name of the package the user may want to install (if it exists).
+     */
+    public importSuggestion(name: string) {
+      if (name === 'typescript') {
+        return `stryker-${name}`;
+      }
+      return `stryker-${name}-mutator`;
+    }
   }
   const mutatorFactoryInstance = new MutatorFactory();
 

--- a/packages/stryker-api/test/unit/mutant/MutantFactorySpec.ts
+++ b/packages/stryker-api/test/unit/mutant/MutantFactorySpec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { Config } from '../../../config';
+import { MutatorFactory } from '../../../mutant';
+
+describe('MutantFactory', () => {
+
+  describe('when correct mutator is not installed', () => {
+
+    const sut = MutatorFactory.instance();
+
+    it('should throw an error with package name "stryker-javascript-mutator" when using the "javascript" mutator', () => {
+      expect(() => sut.create('javascript', new Config()))
+        .to.throw(Error, 'Could not find a mutant-generator with name javascript, did you install it correctly (for example: npm install --save-dev stryker-javascript-mutator)?');
+    });
+
+    it('should throw an error with package name "stryker-vue-mutator" when using the "vue" mutator', () => {
+      expect(() => sut.create('vue', new Config()))
+        .to.throw(Error, 'Could not find a mutant-generator with name vue, did you install it correctly (for example: npm install --save-dev stryker-vue-mutator)?');
+    });
+
+    it('should throw an error with package name "stryker-typescript" when using the "typescript" mutator', () => {
+      expect(() => sut.create('typescript', new Config()))
+        .to.throw(Error, 'Could not find a mutant-generator with name typescript, did you install it correctly (for example: npm install --save-dev stryker-typescript)?');
+    });
+  });
+});


### PR DESCRIPTION
fixes #1161 