### PR TITLE
stryker-mocha-runner : Add support for --grep option

### DIFF
--- a/packages/stryker-mocha-runner/README.md
+++ b/packages/stryker-mocha-runner/README.md
@@ -42,7 +42,8 @@ module.exports = function (config) {
             ui: 'bdd',
             timeout: 3000,
             require: [ /*'babel-register' */],
-            asyncOnly: false
+            asyncOnly: false,
+            grep: /.*/
         }
     });
 }
@@ -62,7 +63,13 @@ Default: `'test/mocha.opts'`
 
 Specify a ['mocha.opts' file](https://mochajs.org/#mochaopts) to be loaded. Options specified directly in your stryker.conf.js file will overrule options from the 'mocha.opts' file.
 
-The only supported mocha options are used: `--ui`, `--require`, `--async-only`, `--timeout` (or their short form counterparts). Others are ignored by the stryker-mocha-runner.
+The only supported mocha options are used: `--ui`, `--require`, `--async-only`, `--timeout`, `--grep` (or their short form counterparts). Others are ignored by the stryker-mocha-runner.
+
+### `mochaOptions.grep` [`RegExp`]
+
+Default: `undefined`
+
+Specify a mocha [`grep`](https://mochajs.org/#grep) command, to single out individual tests.
 
 ### `mochaOptions.ui` [`string`]
 

--- a/packages/stryker-mocha-runner/src/MochaOptionsLoader.ts
+++ b/packages/stryker-mocha-runner/src/MochaOptionsLoader.ts
@@ -56,6 +56,14 @@ export default class MochaOptionsLoader {
           case '-u':
             mochaRunnerOptions.ui = this.parseNextString(args);
             break;
+          case '--grep':
+          case '-g':
+            let arg = `${this.parseNextString(args)}`;
+            if (arg.startsWith('/') && arg.endsWith('/')) {
+              arg = arg.substring(1, arg.length - 1);
+            }
+            mochaRunnerOptions.grep = new RegExp(arg);
+            break;
           default:
             this.log.debug(`Ignoring option "${args[0]}" as it is not supported.`);
             break;

--- a/packages/stryker-mocha-runner/src/MochaRunnerOptions.ts
+++ b/packages/stryker-mocha-runner/src/MochaRunnerOptions.ts
@@ -7,4 +7,5 @@ export default interface MochaRunnerOptions {
   asyncOnly?: boolean;
   ui?: string;
   files?: string[] | string;
+  grep?: RegExp;
 }

--- a/packages/stryker-mocha-runner/src/MochaTestRunner.ts
+++ b/packages/stryker-mocha-runner/src/MochaTestRunner.ts
@@ -111,6 +111,7 @@ export default class MochaTestRunner implements TestRunner {
       setIfDefined(options.asyncOnly, mocha.asyncOnly);
       setIfDefined(options.timeout, mocha.timeout);
       setIfDefined(options.ui, mocha.ui);
+      setIfDefined(options.grep, mocha.grep);
     }
   }
 

--- a/packages/stryker-mocha-runner/test/unit/MochaOptionsLoaderSpec.ts
+++ b/packages/stryker-mocha-runner/test/unit/MochaOptionsLoaderSpec.ts
@@ -92,6 +92,9 @@ describe('MochaOptionsLoader', () => {
   itShouldLoadProperty('--async-only', '', { asyncOnly: true });
   itShouldLoadProperty('--ui', 'qunit', { ui: 'qunit' });
   itShouldLoadProperty('-u', 'qunit', { ui: 'qunit' });
+  itShouldLoadProperty('-g', 'grepthis', { grep: /grepthis/ });
+  itShouldLoadProperty('--grep', '/grep(this|that)/', { grep: /grep(this|that)/ });
+  itShouldLoadProperty('--grep', 'grep(this|that)?', { grep: /grep(this|that)?/ });
 
   it('should not override additional properties', () => {
     readFileStub.returns(`

--- a/packages/stryker-mocha-runner/test/unit/MochaTestRunnerSpec.ts
+++ b/packages/stryker-mocha-runner/test/unit/MochaTestRunnerSpec.ts
@@ -73,6 +73,7 @@ describe('MochaTestRunner', () => {
     multimatchStub.returns(['foo.js', 'bar.js', 'foo2.js']);
     const mochaOptions: MochaRunnerOptions = {
       asyncOnly: true,
+      grep: /grepme/,
       opts: 'opts',
       require: [],
       timeout: 2000,
@@ -88,6 +89,7 @@ describe('MochaTestRunner', () => {
     expect(mocha.asyncOnly).calledWith(true);
     expect(mocha.timeout).calledWith(2000);
     expect(mocha.ui).calledWith('assert');
+    expect(mocha.grep).calledWith(/grepme/);
   });
 
   it('should pass require additional require options when constructed', () => {


### PR DESCRIPTION
Add support for the --grep option.

**Use case** 
I'm testing a REST service with a database. Testing the write operations makes the tests fail, which leads to false negative with mutation testing.
Example : 
- Test1: GET /something should only contain N elements.
- Test2: POST /something should be accepted.
If Test1 is runned again, it will fail, even with the original code (it contains N+1 elements now).
The alternative would be to reset the database before every test, but it is time consuming and will make mutation testing much longer.

The --grep option in mocha allows to test read-only operations exclusively, so I'm sure that there is no failed test due to a side effects.