### PR TITLE
Add decorators to babel parser

### DIFF
--- a/packages/stryker-javascript-mutator/src/helpers/BabelHelper.ts
+++ b/packages/stryker-javascript-mutator/src/helpers/BabelHelper.ts
@@ -13,6 +13,7 @@ export default class BabelHelper {
   private static createOptions(): ParserOptions {
     return {
       plugins: [
+        'decorators-legacy',
         'asyncGenerators',
         'bigInt',
         'classProperties',


### PR DESCRIPTION
We have a project that is using decorators. We would like to add the option to the babel parser so that Stryker will work on our project