### PR TITLE
build(ts): Pin ts version to 3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sinon-chai": "^3.2.0",
     "source-map-support": "^0.5.6",
     "tslint": "~5.12.0",
-    "typescript": "^3.2.1",
+    "typescript": "3.2.2",
     "web-component-tester": "6.9.2"
   },
   "prettier": {


### PR DESCRIPTION
Fix issue where `Injector<{foo: string, bar: string}>` is not assignable to `Injector<{foo: string}>` by pinning the TS version to 3.2.2. Seems to be broken since latest TS release. Or it works as intended and was a bug in ts 3.2.2, see https://github.com/Microsoft/TypeScript/issues/29590