### PR TITLE
feat(reporter config): remove deprecated reporter config option

### DIFF
--- a/e2e/test/command/stryker.conf.js
+++ b/e2e/test/command/stryker.conf.js
@@ -3,7 +3,7 @@ module.exports = function (config) {
     mutate: ['src/*.js'],
     testFramework: 'mocha',
     coverageAnalysis: 'off',
-    reporter: ['clear-text', 'event-recorder'],
+    reporters: ['clear-text', 'event-recorder'],
     mutator: 'javascript',
     maxConcurrentTestRunners: 2,
     commandRunner: {

--- a/e2e/test/vue-javascript/stryker.conf.js
+++ b/e2e/test/vue-javascript/stryker.conf.js
@@ -4,7 +4,7 @@ module.exports = function (config) {
     mutator: 'vue',
     testFramework: 'jasmine',
     testRunner: 'karma',
-    reporter: ['clear-text', 'event-recorder'],
+    reporters: ['clear-text', 'event-recorder'],
     maxConcurrentTestRunners: 2,
     karma: {
       configFile: 'test/unit/karma.conf.js'

--- a/packages/stryker-api/src/config/Config.ts
+++ b/packages/stryker-api/src/config/Config.ts
@@ -17,7 +17,6 @@ export default class Config implements StrykerOptions {
   public timeoutMS = 5000;
   public timeoutFactor = 1.5;
   public plugins: string[] = ['stryker-*'];
-  public reporter = [];
   public reporters: string[] = ['progress', 'clear-text'];
   public coverageAnalysis: 'perTest' | 'all' | 'off' = 'off';
   public testRunner: string = 'command';

--- a/packages/stryker-api/src/core/StrykerOptions.ts
+++ b/packages/stryker-api/src/core/StrykerOptions.ts
@@ -96,7 +96,7 @@ interface StrykerOptions {
    * 'off': Don't use coverage analysis
    */
   coverageAnalysis: 'perTest' | 'all' | 'off';
-  
+
   /**
    * The names of the reporters to use
    * Possible values: 'clear-text', 'progress'.

--- a/packages/stryker-api/src/core/StrykerOptions.ts
+++ b/packages/stryker-api/src/core/StrykerOptions.ts
@@ -96,11 +96,7 @@ interface StrykerOptions {
    * 'off': Don't use coverage analysis
    */
   coverageAnalysis: 'perTest' | 'all' | 'off';
-
-  /**
-   * DEPRECATED PROPERTY. Please use the `reporters` property
-   */
-  reporter?: string | string[];
+  
   /**
    * The names of the reporters to use
    * Possible values: 'clear-text', 'progress'.

--- a/packages/stryker/src/config/ConfigReader.ts
+++ b/packages/stryker/src/config/ConfigReader.ts
@@ -33,15 +33,6 @@ export default class ConfigReader {
     // merge the config from config file and cliOptions (precedence)
     config.set(this.cliOptions);
 
-    if (config.reporter.length) {
-      if (Array.isArray(config.reporter)) {
-        config.reporters = config.reporter;
-      } else {
-        config.reporters = [config.reporter];
-      }
-      this.log.warn(`DEPRECATED: please change the config setting 'reporter: ${JSON.stringify(config.reporter)}' into 'reporters: ${JSON.stringify(config.reporters)}'`);
-    }
-
     if (config.timeoutMs) {
       config.timeoutMS = config.timeoutMs;
       this.log.warn(`DEPRECATED: please change the config setting 'timeoutMs: ${config.timeoutMs}' into 'timeoutMS: ${config.timeoutMS}'`);

--- a/packages/stryker/src/initializer/presets/VueJsPreset.ts
+++ b/packages/stryker/src/initializer/presets/VueJsPreset.ts
@@ -24,7 +24,7 @@ export class VueJsPreset implements Preset {
       jest: {
         // config: require('path/to/your/custom/jestConfig.js')
       },
-      reporter: ['progress', 'clear-text', 'html'],
+      reporters: ['progress', 'clear-text', 'html'],
       coverageAnalysis: 'off'
     }`;
 
@@ -39,7 +39,7 @@ export class VueJsPreset implements Preset {
           browsers: ['ChromeHeadless']
         }
       },
-      reporter: ['progress', 'clear-text', 'html'],
+      reporters: ['progress', 'clear-text', 'html'],
       coverageAnalysis: 'off'
     }`;
 

--- a/packages/stryker/test/integration/config-reader/ConfigReaderSpec.ts
+++ b/packages/stryker/test/integration/config-reader/ConfigReaderSpec.ts
@@ -130,27 +130,7 @@ describe(ConfigReader.name, () => {
       });
     });
 
-    describe('with deprecated reporter property', () => {
-      it('should log a warning when a single reporter is specified', () => {
-        const reporterName = 'html';
-        sut = createSut({ reporter: reporterName });
-
-        const result = sut.readConfig();
-
-        expect(result.reporters).to.deep.eq([reporterName]);
-        expect(testInjector.logger.warn).calledWithExactly(`DEPRECATED: please change the config setting 'reporter: "${reporterName}"' into 'reporters: ["${reporterName}"]'`);
-      });
-
-      it('should log a warning when multiple reporters are specified', () => {
-        const configuredReporters = ['html', 'progress'];
-        sut = createSut({ reporter: configuredReporters });
-
-        const result = sut.readConfig();
-
-        expect(result.reporters).to.deep.eq(configuredReporters);
-        expect(testInjector.logger.warn).calledWithExactly(`DEPRECATED: please change the config setting 'reporter: ${JSON.stringify(configuredReporters)}' into 'reporters: ${JSON.stringify(configuredReporters)}'`);
-      });
-
+    describe('with deprecated timeoutMs property', () => {
       it('should log a warning when timeoutMs is specified', () => {
         const timeoutMs = 30000;
         sut = createSut({ timeoutMs });


### PR DESCRIPTION
BREAKING CHANGE: Removes the 'reporter' config option. Please use the 'reporters' (plural) config option instead.