### PR TITLE
feat(jest project config): Remove deprecated project setting and 'default' project name

### DIFF
--- a/packages/stryker-jest-runner/src/JestConfigEditor.ts
+++ b/packages/stryker-jest-runner/src/JestConfigEditor.ts
@@ -5,32 +5,17 @@ import ReactScriptsJestConfigLoader from './configLoaders/ReactScriptsJestConfig
 import ReactScriptsTSJestConfigLoader from './configLoaders/ReactScriptsTSJestConfigLoader';
 import JEST_OVERRIDE_OPTIONS from './jestOverrideOptions';
 import { Configuration } from 'jest';
-import { Logger } from 'stryker-api/logging';
-import { tokens, commonTokens } from 'stryker-api/plugin';
 
 const DEFAULT_PROJECT_NAME = 'custom';
-const DEFAULT_PROJECT_NAME_DEPRECATED = 'default';
 
 export default class JestConfigEditor implements ConfigEditor {
-
-  public static inject = tokens(commonTokens.logger);
-  constructor(private readonly log: Logger) { }
 
   public edit(strykerConfig: Config): void {
     // If there is no Jest property on the Stryker config create it
     strykerConfig.jest = strykerConfig.jest || {};
 
-    if (strykerConfig.jest.project) {
-      this.log.warn('DEPRECATED: `jest.project` is renamed to `jest.projectType`. Please change it in your stryker configuration.');
-    }
-
     // When no projectType is set, set it to the default
     strykerConfig.jest.projectType = strykerConfig.jest.projectType || strykerConfig.jest.project || DEFAULT_PROJECT_NAME;
-
-    if (strykerConfig.jest.projectType.toLowerCase() === DEFAULT_PROJECT_NAME_DEPRECATED) {
-      this.log.warn(`DEPRECATED: The '${DEFAULT_PROJECT_NAME_DEPRECATED}' \`jest.projectType\` is renamed to '${DEFAULT_PROJECT_NAME}'. Please rename it in your stryker configuration.`);
-      strykerConfig.jest.projectType = DEFAULT_PROJECT_NAME;
-    }
 
     // When no config property is set, load the configuration with the project type
     strykerConfig.jest.config = strykerConfig.jest.config || this.getConfigLoader(strykerConfig.jest.projectType).loadConfig();

--- a/packages/stryker-jest-runner/test/unit/JestConfigEditor.spec.ts
+++ b/packages/stryker-jest-runner/test/unit/JestConfigEditor.spec.ts
@@ -73,21 +73,6 @@ describe('JestConfigEditor', () => {
 
     expect(() => sut.edit(config)).to.throw(Error, `No configLoader available for ${projectType}`);
   });
-
-  it('should warn when using deprecated `project` property', () => {
-    const projectType = 'custom';
-    config.jest = { project: projectType };
-    sut.edit(config);
-    expect(testInjector.logger.warn).calledWith('DEPRECATED: `jest.project` is renamed to `jest.projectType`. Please change it in your stryker configuration.');
-    expect(config.jest.projectType).eq(projectType);
-  });
-
-  it('should warn when using deprecated "default" project type', () => {
-    config.jest = { projectType: 'default' };
-    sut.edit(config);
-    expect(testInjector.logger.warn).calledWith('DEPRECATED: The \'default\' `jest.projectType` is renamed to \'custom\'. Please rename it in your stryker configuration.');
-    expect(config.jest.projectType).eq('custom');
-  });
 });
 
 interface ConfigLoaderStub {


### PR DESCRIPTION
BREAKING CHANGE: removes deprecated 'jest.project' config key and project value 'default'. Please use the 'jest.projectType' config key and the 'custom' project value.