### PR TITLE
feat(timeoutMS): remove deprecated timeoutMs property

### DIFF
--- a/packages/stryker-api/src/core/StrykerOptions.ts
+++ b/packages/stryker-api/src/core/StrykerOptions.ts
@@ -124,11 +124,6 @@ interface StrykerOptions {
    * Default: true
    */
   symlinkNodeModules: boolean;
-
-  /**
-   * DEPRECATED PROPERTY. Please use the `timeoutMS` property
-   */
-  timeoutMs?: number;
   /**
    * Amount of additional time, in milliseconds, the mutation test is allowed to run
    */

--- a/packages/stryker/src/config/ConfigReader.ts
+++ b/packages/stryker/src/config/ConfigReader.ts
@@ -42,11 +42,6 @@ export default class ConfigReader {
       this.log.warn(`DEPRECATED: please change the config setting 'reporter: ${JSON.stringify(config.reporter)}' into 'reporters: ${JSON.stringify(config.reporters)}'`);
     }
 
-    if (config.timeoutMs) {
-      config.timeoutMS = config.timeoutMs;
-      this.log.warn(`DEPRECATED: please change the config setting 'timeoutMs: ${config.timeoutMs}' into 'timeoutMS: ${config.timeoutMS}'`);
-    }
-
     return config;
   }
 

--- a/packages/stryker/test/integration/config-reader/ConfigReaderSpec.ts
+++ b/packages/stryker/test/integration/config-reader/ConfigReaderSpec.ts
@@ -150,16 +150,6 @@ describe(ConfigReader.name, () => {
         expect(result.reporters).to.deep.eq(configuredReporters);
         expect(testInjector.logger.warn).calledWithExactly(`DEPRECATED: please change the config setting 'reporter: ${JSON.stringify(configuredReporters)}' into 'reporters: ${JSON.stringify(configuredReporters)}'`);
       });
-
-      it('should log a warning when timeoutMs is specified', () => {
-        const timeoutMs = 30000;
-        sut = createSut({ timeoutMs });
-
-        const result = sut.readConfig();
-
-        expect(result.timeoutMS).to.deep.eq(timeoutMs);
-        expect(testInjector.logger.warn).calledWithExactly(`DEPRECATED: please change the config setting 'timeoutMs: ${timeoutMs}' into 'timeoutMS: ${timeoutMs}'`);
-      });
     });
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: Removes the 'timeoutMs' config option. Please use the 'timeoutMS' config option instead.