### PR TITLE
feat(babel config): remove babelrcFile and babelConfig config keys

### DIFF
--- a/packages/stryker-babel-transpiler/src/BabelConfigReader.ts
+++ b/packages/stryker-babel-transpiler/src/BabelConfigReader.ts
@@ -10,8 +10,6 @@ export interface StrykerBabelConfig {
   optionsFile: string | null;
 }
 
-export const DEPRECATED_CONFIG_KEY_FILE = 'babelrcFile';
-export const DEPRECATED_CONFIG_KEY_OPTIONS = 'babelConfig';
 export const CONFIG_KEY = 'babel';
 export const FILE_KEY: keyof StrykerBabelConfig = 'optionsFile';
 export const OPTIONS_KEY: keyof StrykerBabelConfig = 'options';
@@ -34,24 +32,12 @@ export class BabelConfigReader {
       ...DEFAULT_BABEL_CONFIG,
       ...strykerOptions[CONFIG_KEY]
     };
-    this.loadDeprecatedOptions(strykerOptions, babelConfig);
     babelConfig.options = {
       ...this.readBabelOptionsFromFile(babelConfig.optionsFile),
       ...babelConfig.options
     };
     this.log.debug(`Babel config is: ${JSON.stringify(babelConfig, null, 2)}`);
     return babelConfig;
-  }
-
-  private loadDeprecatedOptions(strykerOptions: StrykerOptions, babelConfig: StrykerBabelConfig) {
-    if (strykerOptions[DEPRECATED_CONFIG_KEY_OPTIONS]) {
-      babelConfig.options = strykerOptions[DEPRECATED_CONFIG_KEY_OPTIONS];
-      this.log.warn(`"${DEPRECATED_CONFIG_KEY_OPTIONS}" is deprecated, please use { ${CONFIG_KEY}: { ${OPTIONS_KEY}: ${JSON.stringify(babelConfig.options)} }`);
-    }
-    if (strykerOptions[DEPRECATED_CONFIG_KEY_FILE]) {
-      babelConfig.optionsFile = strykerOptions[DEPRECATED_CONFIG_KEY_FILE];
-      this.log.warn(`"${DEPRECATED_CONFIG_KEY_FILE}" is deprecated, please use { ${CONFIG_KEY}: { ${FILE_KEY}: '${babelConfig.optionsFile}' } }`);
-    }
   }
 
   private readBabelOptionsFromFile(relativeFileName: string | null): babel.TransformOptions {

--- a/packages/stryker-babel-transpiler/test/unit/BabelConfigReader.spec.ts
+++ b/packages/stryker-babel-transpiler/test/unit/BabelConfigReader.spec.ts
@@ -1,4 +1,4 @@
-import { BabelConfigReader, StrykerBabelConfig, DEPRECATED_CONFIG_KEY_FILE, DEPRECATED_CONFIG_KEY_OPTIONS } from '../../src/BabelConfigReader';
+import { BabelConfigReader, StrykerBabelConfig } from '../../src/BabelConfigReader';
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as sinon from 'sinon';
@@ -75,34 +75,8 @@ describe(BabelConfigReader.name, () => {
     expect(result).deep.equal(expected);
   });
 
-  it('should load deprecated properties', () => {
-    // Arrange
-    const expectedBabelConfig: StrykerBabelConfig = {
-      extensions: [],
-      options: {
-        auxiliaryCommentAfter: 'bar',
-        auxiliaryCommentBefore: 'foo'
-      },
-      optionsFile: 'foo.babelrc'
-    };
-    const strykerOptions = factory.strykerOptions({
-      [DEPRECATED_CONFIG_KEY_FILE]: expectedBabelConfig.optionsFile,
-      [DEPRECATED_CONFIG_KEY_OPTIONS]: { auxiliaryCommentBefore: 'foo' }
-    });
-    arrangeBabelOptionsFile({ auxiliaryCommentAfter: 'bar' }, 'foo.babelrc');
-
-    // Act
-    const result = sut.readConfig(strykerOptions);
-
-    // Assert
-    expect(result).deep.eq(expectedBabelConfig);
-    expect(testInjector.logger.warn).calledWith(`"babelConfig" is deprecated, please use { babel: { options: {"auxiliaryCommentBefore":"foo"} }`);
-    expect(testInjector.logger.warn).calledWith(`"babelrcFile" is deprecated, please use { babel: { optionsFile: 'foo.babelrc' } }`);
-  });
-
   function arrangeBabelOptionsFile(babelOptions: babel.TransformOptions, fileName = '.babelrc') {
     sinon.stub(fs, 'existsSync').returns(true);
     sinon.stub(fs, 'readFileSync').withArgs(path.resolve(fileName), 'utf8').returns(JSON.stringify(babelOptions));
   }
-
 });


### PR DESCRIPTION
BREAKING CHANGE: removed the babelrcFile and babelConfig config keys. Please use the `babel: { }` config key.