### PR TITLE
feat(jest config): set notify to false in JEST_OVERRIDE_OPTIONS

### DIFF
--- a/packages/jest-runner/src/jestOverrideOptions.ts
+++ b/packages/jest-runner/src/jestOverrideOptions.ts
@@ -11,6 +11,10 @@ const JEST_OVERRIDE_OPTIONS = Object.freeze({
 
     // Disable bail so the jest process does not quit with a non-zero exit code
     bail: false,
+
+    // Disable notifications for test results, this will otherwise show a notification about
+    // the results each time Stryker runs the tests
+    notify: false
 });
 
 export default JEST_OVERRIDE_OPTIONS;

--- a/packages/jest-runner/test/integration/JestConfigEditor.it.spec.ts
+++ b/packages/jest-runner/test/integration/JestConfigEditor.it.spec.ts
@@ -49,6 +49,7 @@ describe('Integration test for Jest ConfigEditor', () => {
         '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
         '^react-native$': 'react-native-web'
       },
+      notify: false,
       rootDir: projectRoot,
       setupFiles: [path.join(projectRoot, 'node_modules', 'react-app-polyfill', 'jsdom.js')],
       setupTestFrameworkScriptFile: undefined,
@@ -107,6 +108,7 @@ describe('Integration test for Jest ConfigEditor', () => {
       moduleNameMapper: {
         '^react-native$': 'react-native-web'
       },
+      notify: false,
       rootDir: projectRoot,
       setupFiles: [path.join(projectRoot, 'node_modules', 'react-scripts-ts', 'config', 'polyfills.js')],
       setupTestFrameworkScriptFile: undefined,
@@ -142,6 +144,7 @@ describe('Integration test for Jest ConfigEditor', () => {
       bail: false,
       collectCoverage: false,
       moduleFileExtensions: ['js', 'json', 'jsx', 'node'],
+      notify: false,
       testEnvironment: 'jest-environment-jsdom',
       testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
       testResultsProcessor: undefined,
@@ -161,6 +164,7 @@ describe('Integration test for Jest ConfigEditor', () => {
       bail: false,
       collectCoverage: false,
       moduleFileExtensions: ['js', 'json', 'jsx', 'node'],
+      notify: false,
       testEnvironment: 'jest-environment-jsdom',
       testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
       testResultsProcessor: undefined,
@@ -178,6 +182,7 @@ describe('Integration test for Jest ConfigEditor', () => {
     expect(config.jest.config).to.deep.equal({
       bail: false,
       collectCoverage: false,
+      notify: false,
       testResultsProcessor: undefined,
       verbose: false,
     });

--- a/packages/jest-runner/test/unit/JestConfigEditor.spec.ts
+++ b/packages/jest-runner/test/unit/JestConfigEditor.spec.ts
@@ -56,12 +56,13 @@ describe('JestConfigEditor', () => {
     assert(reactScriptsTSJestConfigLoaderStub.loadConfig.calledOnce, 'ReactScriptsTSJestConfigLoader loadConfig not called');
   });
 
-  it('should override verbose, collectCoverage, testResultsProcessor and bail on all loaded configs', () => {
+  it('should override verbose, collectCoverage, testResultsProcessor, notify and bail on all loaded configs', () => {
     sut.edit(config);
 
     expect(config.jest.config).to.deep.equal({
       bail: false,
       collectCoverage: false,
+      notify: false,
       testResultsProcessor: undefined,
       verbose: false
     });

--- a/packages/jest-runner/testResources/exampleProject/package.json
+++ b/packages/jest-runner/testResources/exampleProject/package.json
@@ -12,6 +12,7 @@
     "testURL": "http://localhost",
     "collectCoverage": true,
     "verbose": true,
-    "bail": false
+    "bail": false,
+    "notify": true
   }
 }

--- a/packages/jest-runner/testResources/exampleProjectWithExplicitJestConfig/jest.config.js
+++ b/packages/jest-runner/testResources/exampleProjectWithExplicitJestConfig/jest.config.js
@@ -7,5 +7,6 @@ module.exports = {
   collectCoverage: true,
   verbose: true,
   testURL: "http://localhost",
-  bail: false
+  bail: false,
+  notify: true,
 }


### PR DESCRIPTION
I propose turning of jest notifications by default. Having test notifications turned on in a project can ofc be a great thing but when stryker runs the tests this adds a lot of noise (one notification each time stryker runs the tests against a mutant). 

### Summary of changes
- Adding `notify: false` to jestOverrideOptions.ts
- Updating tests to verify that this property is overridden