### PR TITLE
fix(jest-runner): fix stryker error on todo tests

### DIFF
--- a/packages/jest-runner/src/JestTestRunner.ts
+++ b/packages/jest-runner/src/JestTestRunner.ts
@@ -92,6 +92,8 @@ export default class JestTestRunner implements TestRunner {
         return TestStatus.Success;
       case 'pending':
         return TestStatus.Skipped;
+      case 'todo':
+        return TestStatus.Skipped;
       default:
         return TestStatus.Failed;
     }

--- a/packages/jest-runner/test/helpers/testResultProducer.ts
+++ b/packages/jest-runner/test/helpers/testResultProducer.ts
@@ -156,3 +156,58 @@ export const createPendingResult = () => ({
   ],
   wasInterrupted: false
 });
+
+export const createTodoResult = () => ({
+  numFailedTests: 0,
+  numFailedTestSuites: 0,
+  numPassedTests: 1,
+  numPassedTestSuites: 1,
+  numPendingTests: 0,
+  numPendingTestSuites: 0,
+  numRuntimeErrorTestSuites: 0,
+  numTodoTests: 1,
+  numTotalTests: 2,
+  numTotalTestSuites: 1,
+  startTime: 1551045971122,
+  success: true,
+  testResults: [
+    {
+      console: null,
+      coverage: undefined,
+      displayName: undefined,
+      failureMessage: null,
+      leaks: false,
+      numFailingTests: 0,
+      numPassingTests: 1,
+      numPendingTests: 0,
+      numTodoTests: 1,
+      perfStats: [Object],
+      skipped: false,
+      snapshot: [Object],
+      sourceMaps: {},
+      testResults: [
+        {
+          ancestorTitles: [ 'App' ],
+          duration: 4,
+          failureMessages: [],
+          fullName: 'App renders without crashing',
+          location: null,
+          numPassingAsserts: 0,
+          status: 'passed',
+          title: 'renders without crashing'
+        },
+        {
+          ancestorTitles: [ 'App' ],
+          duration: 0,
+          failureMessages: [],
+          fullName: 'App renders without crashing with children',
+          location: null,
+          numPassingAsserts: 0,
+          status: 'todo',
+          title: 'renders without crashing with children'
+        }
+      ],
+    }
+  ],
+  wasInterrupted: false
+});

--- a/packages/jest-runner/test/unit/JestTestRunner.spec.ts
+++ b/packages/jest-runner/test/unit/JestTestRunner.spec.ts
@@ -79,6 +79,31 @@ describe('JestTestRunner', () => {
     });
   });
 
+  it('should call the jestTestRunner run method and return a todo runResult', async () => {
+    jestTestAdapterMock.run.resolves({ results: fakeResults.createTodoResult() });
+
+    const result = await jestTestRunner.run(runOptions);
+
+    expect(result).to.deep.equal({
+      errorMessages: [],
+      status: RunStatus.Complete,
+      tests: [
+        {
+          failureMessages: [],
+          name: 'App renders without crashing',
+          status: TestStatus.Success,
+          timeSpentMs: 4
+        },
+        {
+          failureMessages: [],
+          name: 'App renders without crashing with children',
+          status: TestStatus.Skipped,
+          timeSpentMs: 0
+        }
+      ]
+    });
+  });
+
   it('should call the jestTestRunner run method and return a negative runResult', async () => {
     jestTestAdapterMock.run.resolves({ results: fakeResults.createFailResult() });
 


### PR DESCRIPTION
Stryker currently treats todo tests `it.todo('some description')` as failed tests. Having these in your test suite will result in `There were failed tests in the initial test run`, and the mutation test run fails. This PR fixes this by treating tests marked todo as skipped instead.

### Summary of changes
- Checking for tests with 'todo' status when test result status is being determined
- Adding unit test to verify that tests with todo status is marked as skipped