### PR TITLE
chore: add .DS_Store files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ packages/*/test/**/*.d.ts
 *.tmp.txt
 .nyc_output
 package-lock.json
+.DS_Store


### PR DESCRIPTION
A convenience for OSX users 🙂 