### PR TITLE
Stopped mutating nodes with a `declare` modifier

### DIFF
--- a/packages/typescript/src/TypescriptMutator.ts
+++ b/packages/typescript/src/TypescriptMutator.ts
@@ -30,6 +30,10 @@ export class TypescriptMutator {
   }
 
   private mutateForNode<T extends ts.Node>(node: T, sourceFile: ts.SourceFile): Mutant[] {
+    if (shouldNodeBeSkipped(node)) {
+      return [];
+    }
+
     const targetMutators = this.mutators.filter(mutator => mutator.guard(node));
     const mutants = flatMap(targetMutators, mutator => mutator.mutate(node, sourceFile));
     node.forEachChild(child => {
@@ -39,3 +43,7 @@ export class TypescriptMutator {
     return mutants;
   }
 }
+
+const shouldNodeBeSkipped = (node: ts.Node): boolean => {
+  return node.modifiers !== undefined && node.modifiers.some(modifier => modifier.kind === ts.SyntaxKind.DeclareKeyword);
+};

--- a/packages/typescript/src/TypescriptMutator.ts
+++ b/packages/typescript/src/TypescriptMutator.ts
@@ -32,15 +32,15 @@ export class TypescriptMutator {
   private mutateForNode<T extends ts.Node>(node: T, sourceFile: ts.SourceFile): Mutant[] {
     if (shouldNodeBeSkipped(node)) {
       return [];
+    } else {
+      const targetMutators = this.mutators.filter(mutator => mutator.guard(node));
+      const mutants = flatMap(targetMutators, mutator => mutator.mutate(node, sourceFile));
+      node.forEachChild(child => {
+        // It is important that forEachChild does not return a true, otherwise node visiting is halted!
+        mutants.push(... this.mutateForNode(child, sourceFile));
+      });
+      return mutants;
     }
-
-    const targetMutators = this.mutators.filter(mutator => mutator.guard(node));
-    const mutants = flatMap(targetMutators, mutator => mutator.mutate(node, sourceFile));
-    node.forEachChild(child => {
-      // It is important that forEachChild does not return a true, otherwise node visiting is halted!
-      mutants.push(... this.mutateForNode(child, sourceFile));
-    });
-    return mutants;
   }
 }
 

--- a/packages/typescript/test/unit/TypescriptMutator.spec.ts
+++ b/packages/typescript/test/unit/TypescriptMutator.spec.ts
@@ -93,22 +93,61 @@ describe('TypescriptMutator', () => {
     describe('declaration nodes', () => {
       beforeEach(() => {
         sut = createSut();
-        file1 = new File(
-          'file1.ts',
-          `declare function notMutated(a: number, b: number);
-          declare module "not-mutated" { }
-
-          function mutated(a: number) { }`);
       });
 
-      it('should skip nodes with declare keywords', () => {
+      it('should not skip a node when it does not have a declare modifier', () => {
+        // Arrange
+        file1 = new File(
+          'file1.ts',
+          `function mutated(a: number, b: number);`);
+
+        // Act
         const mutants = sut.mutate([
           file1,
         ]);
-        expect(mutants.map(mutant => mutant.mutatorName)).to.deep.equal([
-          'SourceFileForTest',
-          'FunctionDeclarationForTest',
-          'FunctionDeclarationForTest'
+
+        // Assert
+        expect(mutants).to.deep.equal([
+          {
+            fileName: 'file1.ts',
+            mutatorName: 'SourceFileForTest',
+            range: [0, 39],
+            replacement: '"stryker was here"'
+          },
+          {
+            fileName: 'file1.ts',
+            mutatorName: 'FunctionDeclarationForTest',
+            range: [0, 39],
+            replacement: '// Function declaration removed'
+          },
+          {
+            fileName: 'file1.ts',
+            mutatorName: 'FunctionDeclarationForTest',
+            range: [0, 39],
+            replacement: 'changedToOtherCall()'
+          }
+        ]);
+      });
+
+      it('should skip a node when it has a declare modifier', () => {
+        // Arrange
+        file1 = new File(
+          'file1.ts',
+          `declare function notMutated(a: number, b: number);`);
+
+        // Act
+        const mutants = sut.mutate([
+          file1,
+        ]);
+
+        // Assert
+        expect(mutants).to.deep.equal([
+          {
+            fileName: 'file1.ts',
+            mutatorName: 'SourceFileForTest',
+            range: [0, 50],
+            replacement: '"stryker was here"',
+          }
         ]);
       });
     });

--- a/packages/typescript/test/unit/TypescriptMutator.spec.ts
+++ b/packages/typescript/test/unit/TypescriptMutator.spec.ts
@@ -105,8 +105,11 @@ describe('TypescriptMutator', () => {
         const mutants = sut.mutate([
           file1,
         ]);
-        expect(mutants.filter(mutant => mutant.mutatorName === 'SourceFileForTest')).lengthOf(1);
-        expect(mutants.filter(mutant => mutant.mutatorName !== 'SourceFileForTest')).lengthOf(2);
+        expect(mutants.map(mutant => mutant.mutatorName)).to.deep.equal([
+          'SourceFileForTest',
+          'FunctionDeclarationForTest',
+          'FunctionDeclarationForTest'
+        ]);
       });
     });
 

--- a/packages/typescript/test/unit/TypescriptMutator.spec.ts
+++ b/packages/typescript/test/unit/TypescriptMutator.spec.ts
@@ -90,5 +90,25 @@ describe('TypescriptMutator', () => {
       expect(mutants.filter(mutant => mutant.mutatorName === 'FunctionDeclarationForTest')).lengthOf(4);
     });
 
+    describe('declaration nodes', () => {
+      beforeEach(() => {
+        sut = createSut();
+        file1 = new File(
+          'file1.ts',
+          `declare function notMutated(a: number, b: number);
+          declare module "not-mutated" { }
+
+          function mutated(a: number) { }`);
+      });
+
+      it('should skip nodes with declare keywords', () => {
+        const mutants = sut.mutate([
+          file1,
+        ]);
+        expect(mutants.filter(mutant => mutant.mutatorName === 'SourceFileForTest')).lengthOf(1);
+        expect(mutants.filter(mutant => mutant.mutatorName !== 'SourceFileForTest')).lengthOf(2);
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Starts on #656. If this is the right approach, I can also send a PR to remove type definition nodes.