### PR TITLE
fix(vue): fix vue mutator throwing an error on vue files without a script tag

### DIFF
--- a/packages/vue-mutator/src/VueMutator.ts
+++ b/packages/vue-mutator/src/VueMutator.ts
@@ -18,18 +18,20 @@ export default class VueMutator implements Mutator {
     inputFiles.forEach(file => {
       if (file.name.endsWith('.vue')) {
         const script = compiler.parseComponent(file.textContent).script;
-        const { mutator, extension } = this.getVueScriptMutatorAndExtension(script);
-        const vueFile = new File(
-          file.name + extension,
-          file.textContent.substring(script.start, script.end)
-        );
-        const vueMutants = mutator.mutate([vueFile]);
-        vueMutants.forEach(mutant => {
-          mutant.fileName = file.name;
-          mutant.range[0] += script.start;
-          mutant.range[1] += script.start;
-        });
-        mutants.push(...vueMutants);
+        if (script) { // Vue file must have <script></script> tag to be mutated
+          const { mutator, extension } = this.getVueScriptMutatorAndExtension(script);
+          const vueFile = new File(
+            file.name + extension,
+            file.textContent.substring(script.start, script.end)
+          );
+          const vueMutants = mutator.mutate([vueFile]);
+          vueMutants.forEach(mutant => {
+            mutant.fileName = file.name;
+            mutant.range[0] += script.start;
+            mutant.range[1] += script.start;
+          });
+          mutants.push(...vueMutants);
+        }
       } else {
         const mutator = this.getMutator(file);
         mutants.push(...mutator.mutate([file]));

--- a/packages/vue-mutator/test/unit/VueMutator.spec.ts
+++ b/packages/vue-mutator/test/unit/VueMutator.spec.ts
@@ -296,7 +296,7 @@ describe('VueMutator', () => {
     const result = sut.mutate(files);
 
     expect(result).to.be.empty;
-    expect(stubJavaScriptMutator.mutate).calledWith([vueFile]);
+    expect(stubJavaScriptMutator.mutate).not.calledWith([vueFile]);
   });
 
   it('should generate correct vue mutants', () => {

--- a/packages/vue-mutator/test/unit/VueMutator.spec.ts
+++ b/packages/vue-mutator/test/unit/VueMutator.spec.ts
@@ -284,6 +284,21 @@ describe('VueMutator', () => {
       expect(() => sut.mutate(files)).throws(`Found unsupported language attribute 'lang="coffeescript"' on a <script> block.`);
   });
 
+  it('should not mutate a .vue file without a <script> block', () => {
+    mutators = { javascript: stubJavaScriptMutator };
+    const vueFile = new File('Component.vue',
+      `<template>
+      <span id="msg">{{ message }}</span>
+    </template>`);
+    const files = [vueFile];
+    const sut = createSut();
+
+    const result = sut.mutate(files);
+
+    expect(result).to.be.empty;
+    expect(stubJavaScriptMutator.mutate).calledWith([vueFile]);
+  });
+
   it('should generate correct vue mutants', () => {
     mutators = { javascript: stubJavaScriptMutator };
 


### PR DESCRIPTION
If a .vue file does not have a `<script>` tag (such as in the example project of the vue-cli), Stryker will still attempt to mutate it and access the tag. This will cause the following error: 

```
12:34:42 (665) ERROR StrykerCli an error occurred TypeError: Cannot read property 'attrs' of null
    at VueMutator.getVueScriptMutatorAndExtension (/workspace/vue-test-proj/node_modules/@stryker-mutator/vue-mutator/src/VueMutator.js:37:27)
    at /workspace/vue-test-proj/node_modules/@stryker-mutator/vue-mutator/src/VueMutator.js:19:32
    at Array.forEach (<anonymous>)
    at VueMutator.mutate (/workspace/vue-test-proj/node_modules/@stryker-mutator/vue-mutator/src/VueMutator.js:16:20)
    at MutatorFacade.mutate (/workspace/vue-test-proj/node_modules/@stryker-mutator/core/src/mutants/MutatorFacade.js:13:14)
    at Stryker.<anonymous> (/workspace/vue-test-proj/node_modules/@stryker-mutator/core/src/Stryker.js:94:59)
    at step (/workspace/vue-test-proj/node_modules/tslib/tslib.js:133:27)
    at Object.next (/workspace/vue-test-proj/node_modules/tslib/tslib.js:114:57)
    at fulfilled (/workspace/vue-test-proj/node_modules/tslib/tslib.js:104:62)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

This PR includes a check in the `.vue` files for a script tag.