### PR TITLE
ci: disable execa timeout to prevent failing perf job

### DIFF
--- a/perf/tasks/run-perf-tests.ts
+++ b/perf/tasks/run-perf-tests.ts
@@ -36,7 +36,7 @@ function execNpm(args: string[], testDir: string): Observable<string> {
   console.log(`Exec ${testDir} npm ${args.join(' ')}`);
 
   return new Observable(observer => {
-    const testProcess = execa('npm', args, { timeout: 500000, cwd: currentTestDir, stdio: 'pipe' });
+    const testProcess = execa('npm', args, { timeout: 0, cwd: currentTestDir, stdio: 'pipe' });
     let stderr = '';
     testProcess.stderr.on('data', chunk => stderr += chunk.toString());
     testProcess.stdout.on('data', chunk => observer.next(chunk.toString().trim()));


### PR DESCRIPTION
https://github.com/sindresorhus/execa/blob/master/readme.md#timeout

> If timeout is greater than `0`, the parent will send the signal identified by the `killSignal` property (the default is `SIGTERM`) if the child runs longer than timeout milliseconds.

Let's see if this improves the current CI issue with the performance tests.

Otherwise I'll have to install the complete project with all dependencies when I can use the other laptop (this one overheats too much - which is not great at around 30°C here).