### PR TITLE
fix(child process proxy): OutOfMemory detection

### DIFF
--- a/packages/core/src/utils/StringBuilder.ts
+++ b/packages/core/src/utils/StringBuilder.ts
@@ -1,4 +1,4 @@
-import * as os from 'os';
+import { EOL } from 'os';
 
 const DEFAULT_MAX_SIZE = 2048;
 
@@ -17,6 +17,12 @@ export default class StringBuilder {
   }
 
   public toString() {
-    return this.strings.join(os.EOL);
+    return this.strings.join('');
+  }
+
+  public static concat(...builders: StringBuilder[]): string {
+    return builders.map(b => b.toString())
+      .filter(Boolean)
+      .join(EOL);
   }
 }

--- a/packages/core/test/unit/utils/StringBuilder.spec.ts
+++ b/packages/core/test/unit/utils/StringBuilder.spec.ts
@@ -4,30 +4,58 @@ import StringBuilder from '../../../src/utils/StringBuilder';
 
 describe(StringBuilder.name, () => {
 
-  it('should append strings with new lines when `toString()` is called', () => {
-    const sut = new StringBuilder();
-    sut.append('1');
-    sut.append('2');
-    sut.append('3');
-    expect(sut.toString()).eq(`1${EOL}2${EOL}3`);
+  describe('toString', () => {
+
+    it('should append strings without separator when `toString()` is called', () => {
+      const sut = new StringBuilder();
+      sut.append('1');
+      sut.append('2');
+      sut.append('3');
+      expect(sut.toString()).eq(`123`);
+    });
+
+    const DEFAULT_MAX_CHARACTERS = 2048;
+    it(`should append a to maximum of ${DEFAULT_MAX_CHARACTERS} characters by default`, () => {
+      const sut = new StringBuilder();
+      for (let i = 0; i < DEFAULT_MAX_CHARACTERS; i++) {
+        sut.append('.');
+      }
+      sut.append('expected');
+      const result = sut.toString();
+      expect(result).lengthOf(DEFAULT_MAX_CHARACTERS);
+      const expectedLastPart = '...expected';
+      expect(result.substr(result.length - expectedLastPart.length)).eq(expectedLastPart);
+    });
+
+    it('should not split the last string, even if it exceeds the max characters', () => {
+      const input = new Array(DEFAULT_MAX_CHARACTERS + 1).fill('.').join('');
+      const sut = new StringBuilder();
+      sut.append(input);
+      expect(sut.toString()).eq(input);
+    });
   });
 
-  const DEFAULT_MAX_CHARACTERS = 2048;
-  it(`should append a to maximum of ${DEFAULT_MAX_CHARACTERS} characters by default`, () => {
-    const sut = new StringBuilder();
-    for (let i = 0; i < DEFAULT_MAX_CHARACTERS; i++) {
-      sut.append('.');
-    }
-    sut.append('expected');
-    const result = sut.toString();
-    expect(result.replace(new RegExp(EOL, 'g'), '')).lengthOf(DEFAULT_MAX_CHARACTERS);
-    expect(result.endsWith(`.${EOL}.${EOL}.${EOL}expected`)).ok;
-  });
-
-  it('should not split the last string, even if it exceeds the max characters', () => {
-    const input = new Array(DEFAULT_MAX_CHARACTERS + 1).fill('.').join('');
-    const sut = new StringBuilder();
-    sut.append(input);
-    expect(sut.toString()).eq(input);
+  describe('concat', () => {
+    it('should concatenate multiple string builders with new lines', () => {
+      const stringBuilders = [
+        new StringBuilder(),
+        new StringBuilder()
+      ];
+      stringBuilders[0].append('foo');
+      stringBuilders[0].append('bar');
+      stringBuilders[1].append('baz');
+      expect(StringBuilder.concat(...stringBuilders)).eq(`foobar${EOL}baz`);
+    });
+    it('should remove empty builders', () => {
+      const stringBuilders = [
+        new StringBuilder(),
+        new StringBuilder(),
+        new StringBuilder()
+      ];
+      stringBuilders[0].append('foo');
+      stringBuilders[0].append('bar');
+      stringBuilders[2].append('baz');
+      expect(StringBuilder.concat(...stringBuilders)).eq(`foobar${EOL}baz`);
+    });
   });
 });


### PR DESCRIPTION
Make sure out `OutOfMemory` detection works as expected. This fixes a race condition in which the detection didn't work correctly, and an unexpected error was assumed. See https://github.com/stryker-mutator/stryker/issues/1634

Fixes #1634 