### PR TITLE
build(deps-dev): Update @types/sinon-chai from ^3.2.0 to 3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/node": "^10.11.5",
     "@types/rimraf": "2.0.2",
     "@types/sinon": "5.0.5",
-    "@types/sinon-chai": "^3.2.0",
+    "@types/sinon-chai": "3.2.2",
     "acorn": "^6.0.4",
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
Builds started failing at #1678 due to pulling in a patch version for sinon-chai (3.2.3) which causes builds to fail due to mismatched chai typings.