### PR TITLE
fix(tempDir): don't resolve temp dir as input files

### DIFF
--- a/packages/core/src/input/InputFileResolver.ts
+++ b/packages/core/src/input/InputFileResolver.ts
@@ -26,13 +26,15 @@ const IGNORE_PATTERN_CHARACTER = '!';
 export default class InputFileResolver {
   private readonly mutatePatterns: ReadonlyArray<string>;
   private readonly filePatterns: ReadonlyArray<string> | undefined;
+  private readonly tempDirName: string;
 
   public static inject = tokens(commonTokens.logger, commonTokens.options, coreTokens.reporter);
   constructor(
     private readonly log: Logger,
-    { mutate, files }: StrykerOptions,
+    { mutate, files, tempDirName }: StrykerOptions,
     private readonly reporter: StrictReporter
   ) {
+    this.tempDirName = tempDirName;
     this.mutatePatterns = mutate || [];
     if (files) {
       this.filePatterns = files;
@@ -108,7 +110,7 @@ export default class InputFileResolver {
   private async resolveFilesUsingGit(): Promise<string[]> {
     try {
       const { stdout } = await childProcessAsPromised.exec(
-        'git ls-files --others --exclude-standard --cached --exclude .stryker-tmp',
+        `git ls-files --others --exclude-standard --cached --exclude /${this.tempDirName}/*`,
         { maxBuffer: 10 * 1000 * 1024 }
       );
       const fileNames = stdout.toString()

--- a/packages/core/src/utils/TemporaryDirectory.ts
+++ b/packages/core/src/utils/TemporaryDirectory.ts
@@ -66,7 +66,7 @@ export class TemporaryDirectory implements Disposable {
     }
     this.log.debug(`Deleting stryker temp directory %s`, this.temporaryDirectory);
     try {
-      return deleteDir(this.temporaryDirectory);
+      await deleteDir(this.temporaryDirectory);
     }
     catch (e) {
       return this.log.info(`Failed to delete stryker temp directory ${this.temporaryDirectory}`);

--- a/packages/core/test/unit/input/InputFileResolver.spec.ts
+++ b/packages/core/test/unit/input/InputFileResolver.spec.ts
@@ -59,10 +59,25 @@ describe(InputFileResolver.name, () => {
     `)
     });
     const result = await sut.resolve();
-    expect(childProcessExecStub).calledWith('git ls-files --others --exclude-standard --cached --exclude .stryker-tmp',
+    expect(childProcessExecStub).calledWith('git ls-files --others --exclude-standard --cached --exclude /.stryker-tmp/*',
       { maxBuffer: 10 * 1000 * 1024 });
     expect(result.files.map(file => file.name)).deep.eq([path.resolve('file1.js'), path.resolve('foo/bar/baz.ts')]);
   });
+
+  it('should exclude the overridden tempDirName when identifying files with git', async () => {
+    // Arrange
+    testInjector.options.tempDirName = 'foo-bar';
+    sut = createSut();
+    childProcessExecStub.resolves({
+      stdout: Buffer.from('')
+    });
+
+    // Act
+    await sut.resolve();
+
+    // Assert
+    expect(childProcessExecStub).calledWith('git ls-files --others --exclude-standard --cached --exclude /foo-bar/*');
+   });
 
   it('should reject if there is no `files` array and `git ls-files` command fails', () => {
     const expectedError = new Error('fatal: Not a git repository (or any of the parent directories): .git');


### PR DESCRIPTION
When overriding the tempDir, make sure those files aren't used as input files