### PR TITLE
Fix perTest coverageAnalysis

### DIFF
--- a/packages/core/src/transpiler/coverageHooks.ts
+++ b/packages/core/src/transpiler/coverageHooks.ts
@@ -36,13 +36,13 @@ Object.keys(coveragePerFile).forEach(function (file) {
     var fileResult = { s: {}, f: {} };
     var touchedFile = false;
     for(var i in coverage.s){
-      if(coverage.s[i] !== baseline.s[i]){
+      if(!baseline || coverage.s[i] !== baseline.s[i]){
         fileResult.s[i] = coverage.s[i];
         touchedFile = true;
       }
     }
     for(var i in coverage.f){
-      if(coverage.f[i] !== baseline.f[i]){
+      if(!baseline || coverage.f[i] !== baseline.f[i]){
         fileResult.f[i] = coverage.f[i];
         touchedFile = true;
       }


### PR DESCRIPTION
Don't know why, but sometimes the baseline is undefined which crashes the initial run. With the proposed modification I was able to successfully run with perTest coverageAnalysis.

Fixes #1815