### PR TITLE
docs: fixing typos in core/readme

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -87,15 +87,16 @@ This is the same globbing format you might know from [Grunt](https://github.com/
 
 You can *ignore* files by adding an exclamation mark (`!`) at the start of an expression.
 
+
 ### `mutate` [`string[]`]
 
 Default: `['{src,lib}/**/*.js?(x)', '!{src,lib}/**/__tests__/**/*.js?(x)', '!{src,lib}/**/?(*.)+(spec|test).js?(x)', '!{src,lib}/**/*+(Spec|Test).js?(x)']`  
 Command line: `[--mutate|-m] src/**/*.js,a.js`  
-Config file: `mutate: ['src/**/*.js', 'a.js']` 
-  
-With `mutate` you configure the subset of files to use for mutation testing. 
+Config file: `mutate: ['src/**/*.js', 'a.js']`
+
+With `mutate` you configure the subset of files to use for mutation testing.
 Generally speaking, these should be your own source files.  
-This is optional, as you can choose to not mutate any files at all and perform a dry-run (running only your tests without mutating). 
+This is optional, as you can choose to not mutate any files at all and perform a dry-run (running only your tests without mutating).
 
 ### `testRunner` [`string`]
 
@@ -103,52 +104,52 @@ Default: `'command'`
 Command line: `--testRunner karma`  
 Config file: `testRunner: 'karma'`  
 
-With `testRunner` you specify the test runner that Stryker uses to run your tests. The default value is `command`. The command runner runs a configurable bash/cmd command and bases the result on the exit code of that program (0 for success, otherwise failed). You can configure this command via the config file using the `commandRunner: { command: 'npm run mocha' }`. It uses `npm test` as the command by default. 
+With `testRunner` you specify the test runner that Stryker uses to run your tests. The default value is `command`. The command runner runs a configurable bash/cmd command and bases the result on the exit code of that program (0 for success, otherwise failed). You can configure this command via the config file using the `commandRunner: { command: 'npm run mocha' }`. It uses `npm test` as the command by default.
 
 The command test runner can be made to work in any use case, but comes with a performance
-penalty, as Stryker cannot do any optimizations and just runs all tests for all mutants. 
-If possible, you should try to use one of the test runner plugins that hook into your test runner of choice. 
-For example: install and use the `stryker-karma-runner` to use `karma` as a test runner. 
+penalty, as Stryker cannot do any optimizations and just runs all tests for all mutants.
+If possible, you should try to use one of the test runner plugins that hook into your test runner of choice.
+For example: install and use the `stryker-karma-runner` to use `karma` as a test runner.
 See the [list of plugins](https://stryker-mutator.io/plugins.html) for an up-to-date list of supported test runners and plugins.
 
-### `testFramework` [`string`] 
+### `testFramework` [`string`]
 
 Default: *none*  
 Command line: `--testFramework jasmine`  
 Config file: `testFramework: 'jasmine'`  
 
-Configure which test framework you are using. 
-This option is not mandatory, as Stryker is test framework agnostic (it doesn't care what framework you use), 
+Configure which test framework you are using.
+This option is not mandatory, as Stryker is test framework agnostic (it doesn't care what framework you use),
 However, it is required when `coverageAnalysis` is set to `'perTest'`, because Stryker needs to hook into the test framework in order to measure code coverage results per test and filter tests to run.
 
-Make sure the a plugin is installed for your chosen test framework. E.g. install `stryker-mocha-framework` to use `'mocha'` as a test framework.
+Make sure the plugin is installed for your chosen test framework. E.g. install `stryker-mocha-framework` to use `'mocha'` as a test framework.
 
 ### `coverageAnalysis` [`string`]
 
 Default: `off`  
 Command line: `--coverageAnalysis perTest`  
 Config file: `coverageAnalysis: 'perTest'`   
-  
+
 With `coverageAnalysis` you specify which coverage analysis strategy you want to use.
 
-Stryker can analyse code coverage results. This can potentially speed up mutation testing a lot, as only the tests covering a 
-particular mutation are tested for each mutant. 
+Stryker can analyse code coverage results. This can potentially speed up mutation testing a lot, as only the tests covering a
+particular mutation are tested for each mutant.
 This does *not* influence the resulting mutation testing score. It only improves performance, so we enable it by default.
 
-The possible values are: 
-* **off**: Stryker will not determine the code covered by tests during the initial test run phase. All tests will be executed for each mutant 
+The possible values are:
+* **off**: Stryker will not determine the code covered by tests during the initial test run phase. All tests will be executed for each mutant
 during the mutation testing phase.
 
-* **all**: Stryker will determine the code covered by all tests during the initial test run phase. Only mutants actually covered by your 
-test suite are tested during the mutation testing phase. This setting requires your test runner to be able to report the code coverage back to Stryker. 
+* **all**: Stryker will determine the code covered by all tests during the initial test run phase. Only mutants actually covered by your
+test suite are tested during the mutation testing phase. This setting requires your test runner to be able to report the code coverage back to Stryker.
 Currently, only the `stryker-mocha-runner` and the `stryker-karma-runner` do this.  
 
-* **perTest**: Stryker will determine the code covered by your test per executed test during the initial test run phase. Only mutants actually covered by your 
-test suite are tested during the mutation testing phase. 
-Only the tests that cover a particular mutant are tested for each one. This requires your tests to be able to run independently of each other and in random order. 
+* **perTest**: Stryker will determine the code covered by your test per executed test during the initial test run phase. Only mutants actually covered by your
+test suite are tested during the mutation testing phase.
+Only the tests that cover a particular mutant are tested for each one. This requires your tests to be able to run independently of each other and in random order.
 In addition to requiring your test runner to be able to report the code coverage back to Stryker, your chosen `testFramework` also needs to support running code
  before and after each test, as well as test filtering.  
- Currently, `stryker-mocha-runner` as well as `stryker-karma-runner` support this. However, `stryker-karma-runner` support is limited to using it with `Jasmine` as the test framework 
+ Currently, `stryker-mocha-runner` as well as `stryker-karma-runner` support this. However, `stryker-karma-runner` support is limited to using it with `Jasmine` as the test framework
  (`Mocha` is not yet supported).
 
 ### `mutator` [`object` | `string`]
@@ -159,7 +160,7 @@ Config file:  `mutator: 'javascript'` or `mutator: { name: 'javascript', exclude
 With `mutator` you configure which mutator plugin you want to use, and optionally, which mutation types to exclude from the test run.  
 The mutator plugin name defaults to `javascript` if not specified. Note: this requires you to have the `@stryker-mutator/javascript-mutator` plugin installed. The list of excluded mutation types defaults to an empty array, meaning all mutation types will be included in the test.  
 The full list of mutation types varies slightly between mutators (for example, the `javascript` mutator will not use the same mutation types as the `typescript` mutator). Mutation type names are case-sensitive, and can be found either in the source code or in a generated Stryker report.  
- 
+
 When using the command line, only the mutator name as a string may be provided.  
 When using the config file, you can provide either a string representing the mutator name, or a `MutatorDescriptor` object, like so:  
 
@@ -174,15 +175,15 @@ Default: `[]`
 With `transpilers` you configure which transpiler plugins should transpile the code before it's executed. This is an array where the transpilers are called in the other of the array. This defaults to an empty array meaning no transpilation will be done.  
 
 
-### `reporters` [`string[]`] 
+### `reporters` [`string[]`]
 
 Default: `['clear-text', 'progress']`  
 Command line: `--reporters clear-text,progress,dots,dashboard`  
 Config file: `reporters: ['clear-text', 'progress', 'dots', 'dashboard']`     
- 
-With `reporters` you can set the reporters for stryker to use.
+
+With `reporters`, you can set the reporters for stryker to use.
 These reporters can be used out of the box: `clear-text`, `progress`, `dots`, `dashboard` and `event-recorder`.
-By default `clear-text` and `progress` are active if no reporters are configured.
+By default, `clear-text` and `progress` are active if no reporters are configured.
 You can load additional plugins to get more reporters. See [stryker-mutator.io](https://stryker-mutator.io)
 for an up-to-date list of supported reporter plugins and a description on each reporter.
 
@@ -200,15 +201,15 @@ The `dashboard` reporter is a special kind of reporter. It sends a report to htt
 You will need to pass the `STRYKER_DASHBOARD_API_KEY` environment variable yourself. You can create one for your repository by logging in on [the Stryker dashboard](https://dashboard.stryker-mutator.io). We strongly recommend you use encrypted environment variables:
 * [Travis documentation](https://docs.travis-ci.com/user/environment-variables/#Encrypting-environment-variables)
 * [CircleCI documentation](https://circleci.com/security/#secrets_section)
-  
+
 ### `files` [`string[]`]
 
 Default: result of `git ls-files --others --exclude-standard --cached --exclude .stryker-tmp`  
 Command line: `[--files|-f] src/**/*.js,a.js,test/**/*.js`  
 Config file: `files: ['src/**/*.js', '!src/**/index.js', 'test/**/*.js']`  
- 
-With `files` you can choose which files should be included in your test runner sandbox. 
-This is normally not needed as it defaults to all files not ignored by git. 
+
+With `files`, you can choose which files should be included in your test runner sandbox.
+This is normally not needed as it defaults to all files not ignored by git.
 Try it out yourself with this command: `git ls-files --others --exclude-standard --cached --exclude .stryker-tmp`.
 
 If you do need to override `files` (for example: when your project does not live in a git repository),
@@ -224,10 +225,10 @@ You can *ignore* files by adding an exclamation mark (`!`) at the start of an ex
 Default: `true`  
 Command line: *none*  
 Config file: `symlinkNodeModules: true`  
- 
-  
-The `symlinkNodeModules` value indicates whether or not Stryker should create a [symbolic link](https://nodejs.org/api/fs.html#fs_fs_symlink_target_path_type_callback) 
-to your current node_modules directory in the sandbox directories. This makes running your tests by Stryker behave 
+
+
+The `symlinkNodeModules` value indicates whether Stryker should create a [symbolic link](https://nodejs.org/api/fs.html#fs_fs_symlink_target_path_type_callback)
+to your current node_modules directory in the sandbox directories. This makes running your tests by Stryker behave
 more like your would run the tests yourself in your project directory.
 Only disable this setting if you really know what you are doing.
 
@@ -236,7 +237,7 @@ in the Sandbox directory. Another example can be running [karma](http://karma-ru
 you specify files from the 'node_modules/angular/...'. Without symlinking the
 node_modules directory this would not be possible.
 
-Stryker will look for the node_modules directory to use in the current basePath (or current working directory) and 
+Stryker will look for the node_modules directory to use in the current basePath (or current working directory) and
 its parent directories.
 
 ### `plugins` [`string[]`]  
@@ -244,12 +245,12 @@ its parent directories.
 Default: `['@stryker-mutator/*']`  
 Command line: `--plugins stryker-html-reporter,stryker-karma-runner`  
 Config file: `plugins: ['stryker-html-reporter', 'stryker-karma-runner']`  
- 
-  
-With `plugins` you can add additional Node modules for Stryker to load (or `require`).
+
+
+With `plugins`, you can add additional Node modules for Stryker to load (or `require`).
 By default, all `node_modules` starting with `@stryker-mutator/*` will be loaded, so you would normally not need to specify this option.
 These modules should be installed right next to stryker. For a current list of plugins,
-you can consult [npm](https://www.npmjs.com/search?q=%40stryker-plugin) or 
+you can consult [npm](https://www.npmjs.com/search?q=%40stryker-plugin) or
 [stryker-mutator.io](https://stryker-mutator.io).
 
 ### `tempDirName` [`string`]
@@ -261,7 +262,7 @@ Config file: `tempDirName: '.stryker-tmp'`
 Choose a different temp dir that Stryker uses for mutation testing. This directory will contain copies of your source code during a mutation test run.
 It will be created if it not exists and is **entirely deleted** after a successful run, so change this with caution.
 
-It is advised to use a directory inside the directory that holds your repository. This way `node_modules` are resolved as expected. Be sure to 
+It is advised to use a directory inside the directory that holds your repository. This way `node_modules` are resolved as expected. Be sure to
 not check-in your chosen temp directory in your `.gitignore` file.
 
 ### `timeoutMS` [`number`]
@@ -269,15 +270,15 @@ not check-in your chosen temp directory in your `.gitignore` file.
 Default: `5000`  
 Command line: `--timeoutMS 5000`  
 Config file: `timeoutMS: 5000`  
- 
-  
-When Stryker is mutating code, it cannot determine indefinitely whether or not a code mutation results in an infinite loop (see [Halting problem](https://en.wikipedia.org/wiki/Halting_problem)).
-In order to battle infinite loops, a test run gets killed after a certain period of time. This period is configurable with two settings: `timeoutMS` and `timeoutFactor`. 
+
+
+When Stryker is mutating code, it cannot determine indefinitely whether a code mutation results in an infinite loop (see [Halting problem](https://en.wikipedia.org/wiki/Halting_problem)).
+In order to battle infinite loops, a test run gets killed after a certain period of time. This period is configurable with two settings: `timeoutMS` and `timeoutFactor`.
 To calculate the actual timeout in milliseconds the, following formula is used:
 
 ```
 timeoutForTestRunMs = netTimeMs * timeoutFactor + timeoutMS + overheadMs
-``` 
+```
 
 Both `netTimeMs` and `overheadMs` are calculated during the initial test run. They are logged on `info` level. For example when `overheadMs` is 92 and `netTimeMs` is 5: `Initial test run succeeded. Ran 6 tests in 4 seconds (net 5 ms, overhead 92 ms).`
 
@@ -289,17 +290,17 @@ With `timeoutFactor` you can configure the allowed deviation relative to the tim
 Default: `1.5`  
 Command line: `--timeoutFactor 1.5`  
 Config file: `timeoutFactor: 1.5`  
- 
+
 See [Timeout in milliseconds](#Timeout-in-milliseconds).
 
-### `maxConcurrentTestRunners` [`number`] 
+### `maxConcurrentTestRunners` [`number`]
 
 Default: `(number of CPU Cores)`  
 Command line: `--maxConcurrentTestRunners 3`  
 Config file: `maxConcurrentTestRunners: 3`   
-  
+
 Specifies the maximum number of concurrent test runners to spawn.  
-Mutation testing is time consuming. By default Stryker tries to make the most of your CPU, by spawning as many test runners as you have CPU cores.  
+Mutation testing is time consuming. By default, Stryker tries to make the most of your CPU, by spawning as many test runners as you have CPU cores.  
 This setting allows you to override this default behavior.
 
 Reasons you might want to lower this setting:
@@ -312,10 +313,10 @@ Reasons you might want to lower this setting:
 
 Default: `{ high: 80, low: 60, break: null }`   
 Command line: *none*  
-Config file: `thresholds: { high: 80, low: 60, break: null }` 
- 
+Config file: `thresholds: { high: 80, low: 60, break: null }`
+
 Description  
-Specify the thresholds for mutation score. 
+Specify the thresholds for mutation score.
 
 * `mutation score >= high`: Awesome! Reporters should color this green and happy.
 * `high > mutation score >= low`: Warning! Reporters should color this orange/yellow. Watch yourself!
@@ -324,30 +325,30 @@ Specify the thresholds for mutation score.
 
 It is not allowed to only supply one value of the values (it's all or nothing). However, `high` and `low` values can be the same, making sure colors are either red or green. Set `break` to `null` (default) to never let your build fail.
 
-### `logLevel` [`string`] 
+### `logLevel` [`string`]
 
 Default: `info`  
 Command line: `--logLevel info`    
 Config file: `logLevel: 'info'`
 
-  
+
  Set the log level that Stryker uses to write to the console. Possible values: `off`, `fatal`, `error`, `warn`, `info`, `debug` and `trace`
 
  *Note*: Test runners are run as child processes of the Stryker Node process. All output (stdout) of the `testRunner` is logged as `trace`.  
  Thus, to see logging output from the test runner set the `logLevel` to `all` or `trace`.
 
-### `fileLogLevel` [`string`] 
+### `fileLogLevel` [`string`]
 
 Default: `off`  
 Command line: `--fileLogLevel info`    
 Config file: `fileLogLevel: 'info'`
-  
+
  Set the log level that Stryker uses to write to the "stryker.log" file. Possible values: `off`, `fatal`, `error`, `warn`, `info`, `debug` and `trace`
 
- ### `allowConsoleColors` [`boolean`] 
+ ### `allowConsoleColors` [`boolean`]
 
 Default: `true`  
 Command line: `--allowConsoleColors true`
 Config file: `allowConsoleColors: true`
-  
- The `allowConsoleColors` value indicates whether or not Stryker should use colors in console.
+
+ The `allowConsoleColors` value indicates whether Stryker should use colors in console.


### PR DESCRIPTION
# Changelog: 
* fixing fixing typos in core/readme

First improvement for #1667 