### PR TITLE
updated throwOnExpectionFailure to oneFailurePerSpec

### DIFF
--- a/packages/jasmine-runner/src/JasmineTestRunner.ts
+++ b/packages/jasmine-runner/src/JasmineTestRunner.ts
@@ -55,7 +55,7 @@ export default class JasmineTestRunner implements TestRunner {
     const jasmine = new Jasmine({ projectBaseDir: process.cwd() });
     // The `loadConfigFile` will fallback on the default
     jasmine.loadConfigFile(this.jasmineConfigFile);
-    jasmine.stopSpecOnExpectationFailure(true);
+    jasmine.env.oneFailurePerSpec(false);
     jasmine.exit = () => { };
     jasmine.clearReporters();
     jasmine.randomizeTests(false);

--- a/packages/jasmine-runner/src/JasmineTestRunner.ts
+++ b/packages/jasmine-runner/src/JasmineTestRunner.ts
@@ -56,7 +56,6 @@ export default class JasmineTestRunner implements TestRunner {
     // The `loadConfigFile` will fallback on the default
     jasmine.loadConfigFile(this.jasmineConfigFile);
     jasmine.stopSpecOnExpectationFailure(true);
-    jasmine.env.throwOnExpectationFailure(true);
     jasmine.exit = () => { };
     jasmine.clearReporters();
     jasmine.randomizeTests(false);

--- a/packages/jasmine-runner/test/unit/JasmineTestRunner.spec.ts
+++ b/packages/jasmine-runner/test/unit/JasmineTestRunner.spec.ts
@@ -23,9 +23,6 @@ describe('JasmineTestRunner', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     jasmineStub = sandbox.createStubInstance(Jasmine);
-    jasmineStub.env = {
-      throwOnExpectationFailure: sandbox.stub()
-    };
     evalGlobalStub = sandbox.stub(helpers, 'evalGlobal');
     sandbox.stub(helpers, 'Jasmine').returns(jasmineStub);
     fileNames = ['foo.js', 'bar.js'];
@@ -46,7 +43,6 @@ describe('JasmineTestRunner', () => {
     expect(helpers.Jasmine).calledWith({ projectBaseDir: process.cwd() });
     expect(jasmineStub.loadConfigFile).calledWith('jasmineConfFile');
     expect(jasmineStub.stopSpecOnExpectationFailure).calledWith(true);
-    expect(jasmineStub.env.throwOnExpectationFailure).calledWith(true);
     expect(jasmineStub.exit).ok;
     expect(jasmineStub.clearReporters).called;
     expect(jasmineStub.randomizeTests).calledWith(false);

--- a/packages/jasmine-runner/test/unit/JasmineTestRunner.spec.ts
+++ b/packages/jasmine-runner/test/unit/JasmineTestRunner.spec.ts
@@ -42,7 +42,7 @@ describe('JasmineTestRunner', () => {
     expect(helpers.Jasmine).calledWithNew;
     expect(helpers.Jasmine).calledWith({ projectBaseDir: process.cwd() });
     expect(jasmineStub.loadConfigFile).calledWith('jasmineConfFile');
-    expect(jasmineStub.stopSpecOnExpectationFailure).calledWith(true);
+    expect(jasmineStub.oneFailurePerSpec).calledWith(false);
     expect(jasmineStub.exit).ok;
     expect(jasmineStub.clearReporters).called;
     expect(jasmineStub.randomizeTests).calledWith(false);

--- a/packages/jasmine-runner/testResources/errors/spec/support/jasmine.json
+++ b/packages/jasmine-runner/testResources/errors/spec/support/jasmine.json
@@ -6,6 +6,6 @@
   "helpers": [
     "helpers/**/*.js"
   ],
-  "stopSpecOnExpectationFailure": false,
+  "oneFailurePerSpec": false,
   "random": false
 }

--- a/packages/jasmine-runner/testResources/jasmine-init/spec/support/jasmine.json
+++ b/packages/jasmine-runner/testResources/jasmine-init/spec/support/jasmine.json
@@ -7,5 +7,6 @@
     "helpers/**/*.js"
   ],
   "stopSpecOnExpectationFailure": false,
+  "oneFailurePerSpec": false,
   "random": false
 }

--- a/packages/jasmine-runner/testResources/jasmine-init/spec/support/jasmine.json
+++ b/packages/jasmine-runner/testResources/jasmine-init/spec/support/jasmine.json
@@ -6,7 +6,6 @@
   "helpers": [
     "helpers/**/*.js"
   ],
-  "stopSpecOnExpectationFailure": false,
   "oneFailurePerSpec": false,
   "random": false
 }

--- a/packages/jasmine-runner/testResources/test-failures/spec/support/jasmine.json
+++ b/packages/jasmine-runner/testResources/test-failures/spec/support/jasmine.json
@@ -7,5 +7,6 @@
     "helpers/**/*.js"
   ],
   "stopSpecOnExpectationFailure": false,
+  "oneFailurePerSpec": false,
   "random": false
 }

--- a/packages/jasmine-runner/testResources/test-failures/spec/support/jasmine.json
+++ b/packages/jasmine-runner/testResources/test-failures/spec/support/jasmine.json
@@ -6,7 +6,6 @@
   "helpers": [
     "helpers/**/*.js"
   ],
-  "stopSpecOnExpectationFailure": false,
   "oneFailurePerSpec": false,
   "random": false
 }

--- a/packages/jasmine-runner/typings/JasmineTypes.d.ts
+++ b/packages/jasmine-runner/typings/JasmineTypes.d.ts
@@ -54,9 +54,6 @@ declare namespace jasmine {
         suiteDone?(result: CustomReporterResult): void;
         jasmineDone(): void;
     }
-    interface Env {
-        throwOnExpectationFailure(value: boolean): void;
-    }
 }
 declare module 'jasmine' {
     class Jasmine {

--- a/packages/jasmine-runner/typings/JasmineTypes.d.ts
+++ b/packages/jasmine-runner/typings/JasmineTypes.d.ts
@@ -54,6 +54,9 @@ declare namespace jasmine {
         suiteDone?(result: CustomReporterResult): void;
         jasmineDone(): void;
     }
+    interface Env {
+        oneFailurePerSpec(value: boolean): void;
+    }
 }
 declare module 'jasmine' {
     class Jasmine {
@@ -75,8 +78,7 @@ declare module 'jasmine' {
         randomizeTests(value?: any): boolean;
         seed(value: any): void;
         showColors(value: any): void;
-        stopSpecOnExpectationFailure(value: boolean): void;
-        stopOnSpecFailure(value: boolean): void;
+        oneFailurePerSpec(value: boolean): void;
         static ConsoleReporter(): any;
         reportersCount: number;
         completionReporter: jasmine.CustomReporter;


### PR DESCRIPTION
worked on issue #1315
changed instances of throwOnExpectationFailure to use the newer call of 
oneFailurePerSpec

Please let me know if anything else needs to be changed