### PR TITLE
feat(mutant-matcher): lower memory usage

### DIFF
--- a/packages/api/src/report/MatchedMutant.ts
+++ b/packages/api/src/report/MatchedMutant.ts
@@ -1,9 +1,31 @@
 interface MatchedMutant {
+  /**
+   * The ID of the mutant
+   */
   readonly id: string;
+  /**
+   * The Mutator name
+   */
   readonly mutatorName: string;
+  /**
+   * Whether or not all tests will run for this mutant
+   */
+  readonly runAllTests: boolean;
+  /**
+   * If not all tests will run for this mutant, this array will contain the ids of the tests that will run.
+   */
   readonly scopedTestIds: number[];
+  /**
+   * The time spent on the tests that will run in initial test run
+   */
   readonly timeSpentScopedTests: number;
+  /**
+   * The file name that contains the mutant
+   */
   readonly fileName: string;
+  /**
+   * The replacement code to be inserted
+   */
   readonly replacement: string;
 }
 

--- a/packages/core/src/Sandbox.ts
+++ b/packages/core/src/Sandbox.ts
@@ -94,13 +94,13 @@ export default class Sandbox {
           `Transpile error occurred: "${transpiledMutant.transpileResult.error}" during transpiling of mutant ${transpiledMutant.mutant.toString()}`
         );
       }
-      const result = transpiledMutant.mutant.result(MutantStatus.TranspileError, []);
+      const result = transpiledMutant.mutant.createResult(MutantStatus.TranspileError, []);
       return result;
     } else if (!transpiledMutant.mutant.selectedTests.length) {
-      const result = transpiledMutant.mutant.result(MutantStatus.NoCoverage, []);
+      const result = transpiledMutant.mutant.createResult(MutantStatus.NoCoverage, []);
       return result;
     } else if (!transpiledMutant.changedAnyTranspiledFiles) {
-      const result = transpiledMutant.mutant.result(MutantStatus.Survived, []);
+      const result = transpiledMutant.mutant.createResult(MutantStatus.Survived, []);
       return result;
     } else {
       // No early result possible, need to run in the sandbox later
@@ -115,7 +115,7 @@ export default class Sandbox {
       const error = runResult.errorMessages ? runResult.errorMessages.toString() : '(undefined)';
       this.log.debug('A runtime error occurred: %s during execution of mutant: %s', error, mutant.toString());
     }
-    return mutant.result(status, testNames);
+    return mutant.createResult(status, testNames);
   }
 
   private determineMutantState(runResult: RunResult): MutantStatus {
@@ -195,7 +195,7 @@ export default class Sandbox {
   }
 
   private getFilterTestsHooks(mutant: TestableMutant): string | undefined {
-    if (this.testFramework) {
+    if (this.testFramework && !mutant.runAllTests) {
       return wrapInClosure(this.testFramework.filter(mutant.selectedTests));
     } else {
       return undefined;

--- a/packages/core/src/Sandbox.ts
+++ b/packages/core/src/Sandbox.ts
@@ -96,7 +96,7 @@ export default class Sandbox {
       }
       const result = transpiledMutant.mutant.createResult(MutantStatus.TranspileError, []);
       return result;
-    } else if (!transpiledMutant.mutant.selectedTests.length) {
+    } else if (!transpiledMutant.mutant.runAllTests && !transpiledMutant.mutant.selectedTests.length) {
       const result = transpiledMutant.mutant.createResult(MutantStatus.NoCoverage, []);
       return result;
     } else if (!transpiledMutant.changedAnyTranspiledFiles) {

--- a/packages/core/src/TestableMutant.ts
+++ b/packages/core/src/TestableMutant.ts
@@ -18,7 +18,7 @@ class TestFilter {
   public selectedTests: TestSelection[] = [];
 
   public selectAllTests(runResult: RunResult) {
-    runResult.tests.forEach(testResult => (this.timeSpentScopedTests += testResult.timeSpentMs));
+    this.timeSpentScopedTests = runResult.tests.reduce((time, test) => time + test.timeSpentMs, this.timeSpentScopedTests);
     this.runAllTests = true;
   }
 

--- a/packages/core/src/mutants/MutantTestMatcher.ts
+++ b/packages/core/src/mutants/MutantTestMatcher.ts
@@ -4,7 +4,6 @@ import { Mutant } from '@stryker-mutator/api/mutant';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { MatchedMutant } from '@stryker-mutator/api/report';
 import { CoverageCollection, CoveragePerTestResult, CoverageResult, StatementMap } from '@stryker-mutator/api/test_runner';
-import * as _ from 'lodash';
 import { coreTokens } from '../di';
 import InputFileCollection from '../input/InputFileCollection';
 import { InitialTestRunResult } from '../process/InitialTestExecutor';
@@ -143,14 +142,15 @@ export class MutantTestMatcher {
    * @returns The MatchedMutant
    */
   private mapMutantOnMatchedMutant(testableMutant: TestableMutant): MatchedMutant {
-    const matchedMutant = _.cloneDeep({
+    const matchedMutant: MatchedMutant = {
       fileName: testableMutant.mutant.fileName,
       id: testableMutant.id,
       mutatorName: testableMutant.mutant.mutatorName,
       replacement: testableMutant.mutant.replacement,
+      runAllTests: testableMutant.runAllTests,
       scopedTestIds: testableMutant.selectedTests.map(testSelection => testSelection.id),
       timeSpentScopedTests: testableMutant.timeSpentScopedTests
-    });
+    };
     return Object.freeze(matchedMutant);
   }
 

--- a/packages/core/src/reporters/ProgressKeeper.ts
+++ b/packages/core/src/reporters/ProgressKeeper.ts
@@ -14,7 +14,7 @@ abstract class ProgressKeeper implements Reporter {
 
   public onAllMutantsMatchedWithTests(matchedMutants: readonly MatchedMutant[]): void {
     this.timer = new Timer();
-    this.mutantIdsWithoutCoverage = matchedMutants.filter(m => m.scopedTestIds.length === 0).map(m => m.id);
+    this.mutantIdsWithoutCoverage = matchedMutants.filter(m => !m.runAllTests && m.scopedTestIds.length === 0).map(m => m.id);
     this.progress.total = matchedMutants.length - this.mutantIdsWithoutCoverage.length;
   }
 

--- a/packages/core/src/utils/objectUtils.ts
+++ b/packages/core/src/utils/objectUtils.ts
@@ -16,14 +16,6 @@ export function filterEmpty<T>(input: Array<T | null | void>) {
   return input.filter(item => item !== undefined && item !== null) as T[];
 }
 
-export function copy<T>(obj: T, deep?: boolean) {
-  if (deep) {
-    return _.cloneDeep(obj);
-  } else {
-    return _.clone(obj);
-  }
-}
-
 export function wrapInClosure(codeFragment: string) {
   return `
     (function (window) {

--- a/packages/core/test/unit/Sandbox.spec.ts
+++ b/packages/core/test/unit/Sandbox.spec.ts
@@ -258,6 +258,14 @@ describe(Sandbox.name, () => {
       expect(fileUtils.writeFile).not.calledWith(expectedTestFrameworkHooksFile);
     });
 
+    it('should not filter any tests when runAllTests = true', async () => {
+      const sut = await createSut();
+      const mutant = new TestableMutant('2', createMutant(), new SourceFile(new File('', '')));
+      mutant.selectAllTests(runResult, TestSelectionResult.Failed);
+      sut.runMutant(new TranspiledMutant(mutant, { outputFiles: [new File(expectedTargetFileToMutate, '')], error: null }, true));
+      expect(fileUtils.writeFile).not.calledWith(expectedTestFrameworkHooksFile);
+    });
+
     it('should report a runtime error when test run errored', async () => {
       runResult.status = RunStatus.Error;
       runResult.errorMessages = ['Cannot call "foo" of undefined (or something)'];

--- a/packages/core/test/unit/Sandbox.spec.ts
+++ b/packages/core/test/unit/Sandbox.spec.ts
@@ -254,8 +254,22 @@ describe(Sandbox.name, () => {
     it('should not filter any tests when testFramework = null', async () => {
       const sut = await createSut();
       const mutant = new TestableMutant('2', createMutant(), new SourceFile(new File('', '')));
-      sut.runMutant(new TranspiledMutant(mutant, { outputFiles: [new File(expectedTargetFileToMutate, '')], error: null }, true));
+      await sut.runMutant(new TranspiledMutant(mutant, { outputFiles: [new File(expectedTargetFileToMutate, '')], error: null }, true));
       expect(fileUtils.writeFile).not.calledWith(expectedTestFrameworkHooksFile);
+    });
+
+    it('should not filter any tests when runAllTests = true', async () => {
+      // Arrange
+      while (transpiledMutant.mutant.selectedTests.pop());
+      transpiledMutant.mutant.selectAllTests(runResult, TestSelectionResult.Success);
+      const sut = await createSut();
+
+      // Act
+      await sut.runMutant(transpiledMutant);
+
+      // Assert
+      expect(fileUtils.writeFile).not.calledWith(expectedTestFrameworkHooksFile);
+      expect(testRunner.run).called;
     });
 
     it('should not filter any tests when runAllTests = true', async () => {
@@ -287,6 +301,18 @@ describe(Sandbox.name, () => {
         `Transpile error occurred: "Error! Cannot negate a string (or something)" during transpiling of mutant ${transpiledMutant.mutant.toString()}`
       );
       expect(mutantResult.status).eq(MutantStatus.TranspileError);
+    });
+
+    it('should report an early result when there are no files scoped', async () => {
+      // Arrange
+      while (transpiledMutant.mutant.selectedTests.pop());
+
+      // Act
+      const sut = await createSut();
+
+      // Assert
+      const mutantResult = await sut.runMutant(transpiledMutant);
+      expect(mutantResult.status).eq(MutantStatus.NoCoverage);
     });
 
     it('should report an early result when there are no file changes', async () => {

--- a/packages/core/test/unit/TestableMutant.spec.ts
+++ b/packages/core/test/unit/TestableMutant.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import SourceFile from '../../src/SourceFile';
 import TestableMutant, { TestSelectionResult } from '../../src/TestableMutant';
 
-describe('TestableMutant', () => {
+describe(TestableMutant.name, () => {
   let innerMutant: Mutant;
 
   beforeEach(() => {
@@ -29,8 +29,17 @@ describe('TestableMutant', () => {
       TestSelectionResult.FailedButAlreadyReported
     );
     expect(sut.timeSpentScopedTests).eq(54);
-    expect(sut.selectedTests).deep.eq([{ id: 0, name: 'spec1' }, { id: 1, name: 'spec2' }]);
+    expect(sut.runAllTests).true;
     expect(sut.testSelectionResult).eq(TestSelectionResult.FailedButAlreadyReported);
+  });
+
+  it('should scope tests when selecting individual tests', () => {
+    const sut = new TestableMutant('3', innerMutant, new SourceFile(new File('foobar.js', 'alert("foobar")')));
+    sut.selectTest(testResult({ name: 'spec1', timeSpentMs: 12 }), 0);
+    sut.selectTest(testResult({ name: 'spec3', timeSpentMs: 32 }), 2);
+    expect(sut.timeSpentScopedTests).eq(44);
+    expect(sut.selectedTests).deep.eq([{ id: 0, name: 'spec1' }, { id: 2, name: 'spec3' }]);
+    expect(sut.testSelectionResult).eq(TestSelectionResult.Success);
   });
 
   it('should calculate position using sourceFile', () => {

--- a/packages/core/test/unit/mutants/MutantTestMatcher.spec.ts
+++ b/packages/core/test/unit/mutants/MutantTestMatcher.spec.ts
@@ -89,13 +89,11 @@ describe(MutantTestMatcher.name, () => {
         });
 
         describe('without code coverage info', () => {
-          it('should add both tests to the mutants and report failure', async () => {
-            const expectedTestSelection = [{ id: 0, name: 'test one' }, { id: 1, name: 'test two' }];
-
+          it('should run all tests for the mutants and report failure', async () => {
             const result = await sut.matchWithMutants(mutants);
 
-            expect(result[0].selectedTests).deep.eq(expectedTestSelection);
-            expect(result[1].selectedTests).deep.eq(expectedTestSelection);
+            expect(result[0].runAllTests).true;
+            expect(result[1].runAllTests).true;
             expect(TestSelectionResult[result[0].testSelectionResult]).eq(TestSelectionResult[TestSelectionResult.FailedButAlreadyReported]);
             expect(TestSelectionResult[result[1].testSelectionResult]).eq(TestSelectionResult[TestSelectionResult.FailedButAlreadyReported]);
             expect(testInjector.logger.warn).calledWith(
@@ -113,7 +111,8 @@ describe(MutantTestMatcher.name, () => {
                 id: '0',
                 mutatorName: result[0].mutatorName,
                 replacement: result[0].replacement,
-                scopedTestIds: result[0].selectedTests.map(test => test.id),
+                runAllTests: true,
+                scopedTestIds: [],
                 timeSpentScopedTests: result[0].timeSpentScopedTests
               },
               {
@@ -121,7 +120,8 @@ describe(MutantTestMatcher.name, () => {
                 id: '1',
                 mutatorName: result[1].mutatorName,
                 replacement: result[1].replacement,
-                scopedTestIds: result[1].selectedTests.map(test => test.id),
+                runAllTests: true,
+                scopedTestIds: [],
                 timeSpentScopedTests: result[1].timeSpentScopedTests
               }
             ];
@@ -254,12 +254,10 @@ describe(MutantTestMatcher.name, () => {
           });
 
           it('should select all test in the test run but not report the error yet', async () => {
-            const expectedTestSelection: TestSelection[] = [{ name: 'test one', id: 0 }, { name: 'test two', id: 1 }];
-
             const result = await sut.matchWithMutants(mutants);
 
-            expect(result[0].selectedTests).deep.eq(expectedTestSelection);
-            expect(result[1].selectedTests).deep.eq(expectedTestSelection);
+            expect(result[0].runAllTests).true;
+            expect(result[1].runAllTests).true;
             expect(result[0].testSelectionResult).eq(TestSelectionResult.Failed);
             expect(result[1].testSelectionResult).eq(TestSelectionResult.Failed);
             expect(testInjector.logger.warn).not.called;
@@ -315,12 +313,10 @@ describe(MutantTestMatcher.name, () => {
           });
 
           it('should add all test results to the mutant that is covered by the baseline', async () => {
-            const expectedTestSelection = [{ id: 0, name: 'test one' }, { id: 1, name: 'test two' }];
-
             const result = await sut.matchWithMutants(mutants);
 
-            expect(result[0].selectedTests).deep.eq(expectedTestSelection);
-            expect(result[1].selectedTests).deep.eq(expectedTestSelection);
+            expect(result[0].runAllTests).true;
+            expect(result[1].runAllTests).true;
           });
         });
       });
@@ -458,12 +454,11 @@ describe(MutantTestMatcher.name, () => {
     it('should match all mutants to all tests and log a warning when there is no coverage data', async () => {
       mutants.push(mutant({ fileName: 'fileWithMutantOne' }), mutant({ fileName: 'fileWithMutantTwo' }));
       initialRunResult.runResult.tests.push(testResult(), testResult());
-      const expectedTestSelection: TestSelection[] = [{ id: 0, name: 'name' }, { id: 1, name: 'name' }];
 
       const result = await sut.matchWithMutants(mutants);
 
-      expect(result[0].selectedTests).deep.eq(expectedTestSelection);
-      expect(result[1].selectedTests).deep.eq(expectedTestSelection);
+      expect(result[0].runAllTests).true;
+      expect(result[1].runAllTests).true;
       expect(result[0].testSelectionResult).deep.eq(TestSelectionResult.FailedButAlreadyReported);
       expect(result[1].testSelectionResult).deep.eq(TestSelectionResult.FailedButAlreadyReported);
       expect(testInjector.logger.warn).to.have.been.calledWith(
@@ -537,12 +532,11 @@ describe(MutantTestMatcher.name, () => {
     it('should match all mutants to all tests', async () => {
       mutants.push(mutant({ fileName: 'fileWithMutantOne' }), mutant({ fileName: 'fileWithMutantTwo' }));
       initialRunResult.runResult.tests.push(testResult(), testResult());
-      const expectedTestSelection = [{ id: 0, name: 'name' }, { id: 1, name: 'name' }];
 
       const result = await sut.matchWithMutants(mutants);
 
-      expect(result[0].selectedTests).deep.eq(expectedTestSelection);
-      expect(result[1].selectedTests).deep.eq(expectedTestSelection);
+      expect(result[0].runAllTests).true;
+      expect(result[1].runAllTests).true;
     });
   });
 

--- a/packages/core/test/unit/reporters/ProgressReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressReporter.spec.ts
@@ -57,7 +57,7 @@ describe('ProgressReporter', () => {
 
         sut.onAllMutantsMatchedWithTests(matchedMutants);
       });
-      
+
       it('the total of MatchedMutants in the progress bar should be 2', () => {
         expect(progressBarModule.default).to.have.been.calledWithMatch(progressBarContent, { total: 2 });
       });

--- a/packages/core/test/unit/reporters/ProgressReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressReporter.spec.ts
@@ -51,6 +51,17 @@ describe('ProgressReporter', () => {
         expect(progressBarModule.default).to.have.been.calledWithMatch(progressBarContent, { total: 2 });
       });
     });
+    describe('when mutants match to all tests', () => {
+      beforeEach(() => {
+        matchedMutants = [matchedMutant(0, '0', true), matchedMutant(0, '1', true)];
+
+        sut.onAllMutantsMatchedWithTests(matchedMutants);
+      });
+      
+      it('the total of MatchedMutants in the progress bar should be 2', () => {
+        expect(progressBarModule.default).to.have.been.calledWithMatch(progressBarContent, { total: 2 });
+      });
+    });
   });
 
   describe('onMutantTested()', () => {

--- a/packages/core/test/unit/utils/TemporaryDirectory.spec.ts
+++ b/packages/core/test/unit/utils/TemporaryDirectory.spec.ts
@@ -55,7 +55,7 @@ describe(TemporaryDirectory.name, () => {
   describe('dispose', () => {
     describe('when temp directory is initialized', () => {
       beforeEach(() => sut.initialize());
-      it('should call deleteDir fileApi', () => {
+      it('should call deleteDir fileApi', async () => {
         const expectedPath = path.resolve(tempDirName);
         deleteDirStub.resolves('delResolveStub');
 

--- a/packages/test-helpers/src/factory.ts
+++ b/packages/test-helpers/src/factory.ts
@@ -184,7 +184,7 @@ export function transpiler(): sinon.SinonStubbedInstance<Transpiler> {
   };
 }
 
-export function matchedMutant(numberOfTests: number, mutantId = numberOfTests.toString()): MatchedMutant {
+export function matchedMutant(numberOfTests: number, mutantId = numberOfTests.toString(), runAllTests = false): MatchedMutant {
   const scopedTestIds: number[] = [];
   for (let i = 0; i < numberOfTests; i++) {
     scopedTestIds.push(1);
@@ -193,6 +193,7 @@ export function matchedMutant(numberOfTests: number, mutantId = numberOfTests.to
     fileName: '',
     id: mutantId,
     mutatorName: '',
+    runAllTests,
     replacement: '',
     scopedTestIds,
     timeSpentScopedTests: 0

--- a/packages/wct-runner/test/helpers/initChai.ts
+++ b/packages/wct-runner/test/helpers/initChai.ts
@@ -1,6 +1,5 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as sinonChai from 'sinon-chai';
-
-chai.use(chaiAsPromised);
 chai.use(sinonChai);
+chai.use(chaiAsPromised);


### PR DESCRIPTION
Don't fill an array with all test references
when all tests need to run for a mutant.
Instead, use the `runAllTests` flag on a mutant.

Might fix #1779