### PR TITLE
[rfc] progress display time improvements

### DIFF
--- a/packages/core/src/reporters/ProgressAppendOnlyReporter.ts
+++ b/packages/core/src/reporters/ProgressAppendOnlyReporter.ts
@@ -20,7 +20,7 @@ export default class ProgressAppendOnlyReporter extends ProgressKeeper {
 
   private render() {
     process.stdout.write(
-      `Mutation testing ${this.getPercentDone()} (elapsed: ${this.getElapsedTime()}, ETC: ${this.getEtc()}) ` +
+      `Mutation testing ${this.getPercentDone()} (elapsed: ${this.getElapsedTime()}, remaining: ${this.getEtc()}) ` +
         `${this.progress.tested}/${this.progress.total} tested (${this.progress.survived} survived, ${this.progress.timedOut} timed out)` +
         os.EOL
     );

--- a/packages/core/src/reporters/ProgressAppendOnlyReporter.ts
+++ b/packages/core/src/reporters/ProgressAppendOnlyReporter.ts
@@ -20,7 +20,7 @@ export default class ProgressAppendOnlyReporter extends ProgressKeeper {
 
   private render() {
     process.stdout.write(
-      `Mutation testing ${this.getPercentDone()} (ETC ${this.getEtc()}) ` +
+      `Mutation testing ${this.getPercentDone()} (elapsed: ${this.getElapsedTime()}, ETC: ${this.getEtc()}) ` +
         `${this.progress.tested}/${this.progress.total} tested (${this.progress.survived} survived, ${this.progress.timedOut} timed out)` +
         os.EOL
     );

--- a/packages/core/src/reporters/ProgressKeeper.ts
+++ b/packages/core/src/reporters/ProgressKeeper.ts
@@ -32,6 +32,16 @@ abstract class ProgressKeeper implements Reporter {
     }
   }
 
+  protected getElapsedTime() {
+    const elapsedSeconds = this.timer.elapsedSeconds();
+
+    const hours = Math.floor(elapsedSeconds / 3600);
+    const minutes = Math.floor((elapsedSeconds / 60) % 60);
+    const seconds = Math.floor(elapsedSeconds % 60);
+
+    return this.formatEtc(hours, minutes, seconds);
+  }
+
   protected getEtc() {
     const totalSecondsLeft = Math.floor((this.timer.elapsedSeconds() / this.progress.tested) * (this.progress.total - this.progress.tested));
 

--- a/packages/core/src/reporters/ProgressKeeper.ts
+++ b/packages/core/src/reporters/ProgressKeeper.ts
@@ -33,41 +33,29 @@ abstract class ProgressKeeper implements Reporter {
   }
 
   protected getElapsedTime() {
-    const elapsedSeconds = this.timer.elapsedSeconds();
-
-    const hours = Math.floor(elapsedSeconds / 3600);
-    const minutes = Math.floor((elapsedSeconds / 60) % 60);
-    const seconds = Math.floor(elapsedSeconds % 60);
-
-    return this.formatEtc(hours, minutes, seconds);
+    return this.formatTime(this.timer.elapsedSeconds());
   }
 
   protected getEtc() {
     const totalSecondsLeft = Math.floor((this.timer.elapsedSeconds() / this.progress.tested) * (this.progress.total - this.progress.tested));
 
     if (isFinite(totalSecondsLeft) && totalSecondsLeft > 0) {
-      const hours = Math.floor(totalSecondsLeft / 3600);
-      const minutes = Math.floor((totalSecondsLeft / 60) % 60);
-      const seconds = Math.floor(totalSecondsLeft % 60);
-
-      return this.formatEtc(hours, minutes, seconds);
+      return this.formatTime(totalSecondsLeft);
     } else {
       return 'n/a';
     }
   }
 
-  private formatEtc(hours: number, minutes: number, seconds: number) {
-    let output;
+  private formatTime(timeInSeconds: number) {
+    const hours = Math.floor(timeInSeconds / 3600);
 
-    if (hours > 0) {
-      output = `${hours}h, ${minutes}m, ${seconds}s`;
-    } else if (minutes > 0) {
-      output = `${minutes}m, ${seconds}s`;
-    } else {
-      output = `${seconds}s`;
-    }
+    const minutes = Math.floor((timeInSeconds % 3600) / 60);
 
-    return output;
+    return hours > 0 // conditional time formatting
+      ? `~${hours}h ${minutes}m`
+      : minutes > 0
+      ? `~${minutes}m`
+      : '<1m';
   }
 }
 export default ProgressKeeper;

--- a/packages/core/src/reporters/ProgressReporter.ts
+++ b/packages/core/src/reporters/ProgressReporter.ts
@@ -8,7 +8,8 @@ export default class ProgressBarReporter extends ProgressKeeper {
 
   public onAllMutantsMatchedWithTests(matchedMutants: readonly MatchedMutant[]): void {
     super.onAllMutantsMatchedWithTests(matchedMutants);
-    const progressBarContent = 'Mutation testing  [:bar] :percent (ETC :etc) :tested/:total tested (:survived survived, :timedOut timed out)';
+    const progressBarContent =
+      'Mutation testing  [:bar] :percent (elapsed: :et, ETC: :etc) :tested/:total tested (:survived survived, :timedOut timed out)';
 
     this.progressBar = new ProgressBar(progressBarContent, {
       complete: '=',
@@ -23,7 +24,7 @@ export default class ProgressBarReporter extends ProgressKeeper {
     const ticksBefore = this.progress.tested;
     super.onMutantTested(result);
 
-    const progressBarContent = { ...this.progress, etc: this.getEtc() };
+    const progressBarContent = { ...this.progress, et: this.getElapsedTime(), etc: this.getEtc() };
 
     if (ticksBefore < this.progress.tested) {
       this.tick(progressBarContent);

--- a/packages/core/src/reporters/ProgressReporter.ts
+++ b/packages/core/src/reporters/ProgressReporter.ts
@@ -9,7 +9,7 @@ export default class ProgressBarReporter extends ProgressKeeper {
   public onAllMutantsMatchedWithTests(matchedMutants: readonly MatchedMutant[]): void {
     super.onAllMutantsMatchedWithTests(matchedMutants);
     const progressBarContent =
-      'Mutation testing  [:bar] :percent (elapsed: :et, ETC: :etc) :tested/:total tested (:survived survived, :timedOut timed out)';
+      'Mutation testing  [:bar] :percent (elapsed: :et, remaining: :etc) :tested/:total tested (:survived survived, :timedOut timed out)';
 
     this.progressBar = new ProgressBar(progressBarContent, {
       complete: '=',

--- a/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
@@ -33,35 +33,45 @@ describe('ProgressAppendOnlyReporter', () => {
 
     it('should log correct info after ten seconds without completed tests', () => {
       sinon.clock.tick(TEN_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 0% (ETC n/a) 0/3 tested (0 survived, 0 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(
+        `Mutation testing 0% (elapsed: 10s, ETC: n/a) 0/3 tested (0 survived, 0 timed out)${os.EOL}`
+      );
     });
 
     it('should log correct info after ten seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 33% (ETC 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(
+        `Mutation testing 33% (elapsed: 10s, ETC: 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
+      );
     });
 
     it('should log correct info after a hundred seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(HUNDRED_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 33% (ETC 3m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(
+        `Mutation testing 33% (elapsed: 1m, 40s, ETC: 3m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
+      );
     });
 
     it('should log correct info after a thousand seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(THOUSAND_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 33% (ETC 33m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(
+        `Mutation testing 33% (elapsed: 16m, 40s, ETC: 33m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
+      );
     });
 
     it('should log correct info after ten thousand seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.TimedOut }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_THOUSAND_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 33% (ETC 5h, 33m, 20s) 1/3 tested (0 survived, 1 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(
+        `Mutation testing 33% (elapsed: 2h, 46m, 40s, ETC: 5h, 33m, 20s) 1/3 tested (0 survived, 1 timed out)${os.EOL}`
+      );
     });
   });
 });

--- a/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
@@ -22,9 +22,9 @@ describe('ProgressAppendOnlyReporter', () => {
     sinon.stub(process.stdout, 'write');
   });
 
-  describe('onAllMutantsMatchedWithTests() with 2 mutant to test', () => {
+  describe('onAllMutantsMatchedWithTests() with 3 mutants to test', () => {
     beforeEach(() => {
-      sut.onAllMutantsMatchedWithTests([matchedMutant(1), matchedMutant(1)]);
+      sut.onAllMutantsMatchedWithTests([matchedMutant(1), matchedMutant(1), matchedMutant(1)]);
     });
 
     it('should not show show progress directly', () => {
@@ -33,35 +33,35 @@ describe('ProgressAppendOnlyReporter', () => {
 
     it('should log correct info after ten seconds without completed tests', () => {
       sinon.clock.tick(TEN_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith('Mutation testing 0% (ETC n/a) ' + `0/2 tested (0 survived, 0 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 0% (ETC n/a) 0/3 tested (0 survived, 0 timed out)${os.EOL}`);
     });
 
     it('should log correct info after ten seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 50% (ETC 10s) 1/2 tested (0 survived, 0 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 33% (ETC 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`);
     });
 
     it('should log correct info after a hundred seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(HUNDRED_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 50% (ETC 1m, 40s) 1/2 tested (0 survived, 0 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 33% (ETC 3m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`);
     });
 
     it('should log correct info after a thousand seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(THOUSAND_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 50% (ETC 10m, 40s) 1/2 tested (0 survived, 0 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 33% (ETC 33m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`);
     });
 
     it('should log correct info after ten thousand seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.TimedOut }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_THOUSAND_SECONDS);
-      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 50% (ETC 2h, 46m, 40s) 1/2 tested (0 survived, 1 timed out)${os.EOL}`);
+      expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 33% (ETC 5h, 33m, 20s) 1/3 tested (0 survived, 1 timed out)${os.EOL}`);
     });
   });
 });

--- a/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
@@ -34,7 +34,7 @@ describe('ProgressAppendOnlyReporter', () => {
     it('should log correct info after ten seconds without completed tests', () => {
       sinon.clock.tick(TEN_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 0% (elapsed: 10s, ETC: n/a) 0/3 tested (0 survived, 0 timed out)${os.EOL}`
+        `Mutation testing 0% (elapsed: 10s, remaining: n/a) 0/3 tested (0 survived, 0 timed out)${os.EOL}`
       );
     });
 
@@ -43,7 +43,7 @@ describe('ProgressAppendOnlyReporter', () => {
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 33% (elapsed: 10s, ETC: 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
+        `Mutation testing 33% (elapsed: 10s, remaining: 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
       );
     });
 
@@ -52,7 +52,7 @@ describe('ProgressAppendOnlyReporter', () => {
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(HUNDRED_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 33% (elapsed: 1m, 40s, ETC: 3m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
+        `Mutation testing 33% (elapsed: 1m, 40s, remaining: 3m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
       );
     });
 
@@ -61,7 +61,7 @@ describe('ProgressAppendOnlyReporter', () => {
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(THOUSAND_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 33% (elapsed: 16m, 40s, ETC: 33m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
+        `Mutation testing 33% (elapsed: 16m, 40s, remaining: 33m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
       );
     });
 
@@ -70,7 +70,7 @@ describe('ProgressAppendOnlyReporter', () => {
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_THOUSAND_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 33% (elapsed: 2h, 46m, 40s, ETC: 5h, 33m, 20s) 1/3 tested (0 survived, 1 timed out)${os.EOL}`
+        `Mutation testing 33% (elapsed: 2h, 46m, 40s, remaining: 5h, 33m, 20s) 1/3 tested (0 survived, 1 timed out)${os.EOL}`
       );
     });
   });

--- a/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
@@ -31,33 +31,33 @@ describe('ProgressAppendOnlyReporter', () => {
       expect(process.stdout.write).to.not.have.been.called;
     });
 
-    it('should log zero progress after ten seconds without completed tests', () => {
+    it('should log correct info after ten seconds without completed tests', () => {
       sinon.clock.tick(TEN_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith('Mutation testing 0% (ETC n/a) ' + `0/2 tested (0 survived, 0 timed out)${os.EOL}`);
     });
 
-    it('should log 50% with 10s ETC after ten seconds with 1 completed test', () => {
+    it('should log correct info after ten seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 50% (ETC 10s) 1/2 tested (0 survived, 0 timed out)${os.EOL}`);
     });
 
-    it('should log 50% with "1m, 40s" ETC after hundred seconds with 1 completed test', () => {
+    it('should log correct info after a hundred seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(HUNDRED_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 50% (ETC 1m, 40s) 1/2 tested (0 survived, 0 timed out)${os.EOL}`);
     });
 
-    it('should log 50% with "10m, 40s" ETC after thousand seconds with 1 completed test', () => {
+    it('should log correct info after a thousand seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(THOUSAND_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(`Mutation testing 50% (ETC 10m, 40s) 1/2 tested (0 survived, 0 timed out)${os.EOL}`);
     });
 
-    it('should log 50% with "2h, 46m, 40s" ETC after ten thousand seconds with 1 completed test', () => {
+    it('should log correct info after ten thousand seconds with 1 completed test', () => {
       sut.onMutantTested(mutantResult({ status: MutantStatus.TimedOut }));
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_THOUSAND_SECONDS);

--- a/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressAppendOnlyReporter.spec.ts
@@ -34,7 +34,7 @@ describe('ProgressAppendOnlyReporter', () => {
     it('should log correct info after ten seconds without completed tests', () => {
       sinon.clock.tick(TEN_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 0% (elapsed: 10s, remaining: n/a) 0/3 tested (0 survived, 0 timed out)${os.EOL}`
+        `Mutation testing 0% (elapsed: <1m, remaining: n/a) 0/3 tested (0 survived, 0 timed out)${os.EOL}`
       );
     });
 
@@ -43,7 +43,7 @@ describe('ProgressAppendOnlyReporter', () => {
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 33% (elapsed: 10s, remaining: 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
+        `Mutation testing 33% (elapsed: <1m, remaining: <1m) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
       );
     });
 
@@ -52,7 +52,7 @@ describe('ProgressAppendOnlyReporter', () => {
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(HUNDRED_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 33% (elapsed: 1m, 40s, remaining: 3m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
+        `Mutation testing 33% (elapsed: ~1m, remaining: ~3m) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
       );
     });
 
@@ -61,7 +61,7 @@ describe('ProgressAppendOnlyReporter', () => {
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(THOUSAND_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 33% (elapsed: 16m, 40s, remaining: 33m, 20s) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
+        `Mutation testing 33% (elapsed: ~16m, remaining: ~33m) 1/3 tested (0 survived, 0 timed out)${os.EOL}`
       );
     });
 
@@ -70,7 +70,7 @@ describe('ProgressAppendOnlyReporter', () => {
       expect(process.stdout.write).to.not.have.been.called;
       sinon.clock.tick(TEN_THOUSAND_SECONDS);
       expect(process.stdout.write).to.have.been.calledWith(
-        `Mutation testing 33% (elapsed: 2h, 46m, 40s, remaining: 5h, 33m, 20s) 1/3 tested (0 survived, 1 timed out)${os.EOL}`
+        `Mutation testing 33% (elapsed: ~2h 46m, remaining: ~5h 33m) 1/3 tested (0 survived, 1 timed out)${os.EOL}`
       );
     });
   });

--- a/packages/core/test/unit/reporters/ProgressReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressReporter.spec.ts
@@ -94,9 +94,9 @@ describe('ProgressReporter', () => {
     });
   });
 
-  describe('ProgressBar estimate time', () => {
+  describe('ProgressBar estimated time for 3 mutants', () => {
     beforeEach(() => {
-      sut.onAllMutantsMatchedWithTests([matchedMutant(1), matchedMutant(1)]);
+      sut.onAllMutantsMatchedWithTests([matchedMutant(1), matchedMutant(1), matchedMutant(1)]);
     });
 
     it('should show correct time info after ten seconds and 1 mutants tested', () => {
@@ -104,7 +104,7 @@ describe('ProgressReporter', () => {
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
 
-      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '10s' });
+      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '20s' });
     });
 
     it('should show correct time info after a hundred seconds and 1 mutants tested', () => {
@@ -112,7 +112,7 @@ describe('ProgressReporter', () => {
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
 
-      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '1m, 40s' });
+      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '3m, 20s' });
     });
 
     it('should show correct time info after ten thousand seconds and 1 mutants tested', () => {
@@ -120,7 +120,7 @@ describe('ProgressReporter', () => {
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
 
-      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '2h, 46m, 40s' });
+      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '5h, 33m, 20s' });
     });
 
     it('should show correct time info after an hour and 1 mutants tested', () => {
@@ -128,7 +128,7 @@ describe('ProgressReporter', () => {
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
 
-      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '1h, 0m, 0s' });
+      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '2h, 0m, 0s' });
     });
   });
 });

--- a/packages/core/test/unit/reporters/ProgressReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressReporter.spec.ts
@@ -19,7 +19,8 @@ describe('ProgressReporter', () => {
   let sut: ProgressReporter;
   let matchedMutants: MatchedMutant[];
   let progressBar: Mock<ProgressBar>;
-  const progressBarContent = 'Mutation testing  [:bar] :percent (ETC :etc) :tested/:total tested (:survived survived, :timedOut timed out)';
+  const progressBarContent =
+    'Mutation testing  [:bar] :percent (elapsed: :et, ETC: :etc) :tested/:total tested (:survived survived, :timedOut timed out)';
 
   beforeEach(() => {
     sinon.useFakeTimers();

--- a/packages/core/test/unit/reporters/ProgressReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressReporter.spec.ts
@@ -105,7 +105,7 @@ describe('ProgressReporter', () => {
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
 
-      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '20s' });
+      expect(progressBar.tick).to.have.been.calledWithMatch({ et: '<1m', etc: '<1m' });
     });
 
     it('should show correct time info after a hundred seconds and 1 mutants tested', () => {
@@ -113,7 +113,7 @@ describe('ProgressReporter', () => {
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
 
-      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '3m, 20s' });
+      expect(progressBar.tick).to.have.been.calledWithMatch({ et: '~1m', etc: '~3m' });
     });
 
     it('should show correct time info after ten thousand seconds and 1 mutants tested', () => {
@@ -121,7 +121,7 @@ describe('ProgressReporter', () => {
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
 
-      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '5h, 33m, 20s' });
+      expect(progressBar.tick).to.have.been.calledWithMatch({ et: '~2h 46m', etc: '~5h 33m' });
     });
 
     it('should show correct time info after an hour and 1 mutants tested', () => {
@@ -129,7 +129,7 @@ describe('ProgressReporter', () => {
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
 
-      expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '2h, 0m, 0s' });
+      expect(progressBar.tick).to.have.been.calledWithMatch({ et: '~1h 0m', etc: '~2h 0m' });
     });
   });
 });

--- a/packages/core/test/unit/reporters/ProgressReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressReporter.spec.ts
@@ -20,7 +20,7 @@ describe('ProgressReporter', () => {
   let matchedMutants: MatchedMutant[];
   let progressBar: Mock<ProgressBar>;
   const progressBarContent =
-    'Mutation testing  [:bar] :percent (elapsed: :et, ETC: :etc) :tested/:total tested (:survived survived, :timedOut timed out)';
+    'Mutation testing  [:bar] :percent (elapsed: :et, remaining: :etc) :tested/:total tested (:survived survived, :timedOut timed out)';
 
   beforeEach(() => {
     sinon.useFakeTimers();

--- a/packages/core/test/unit/reporters/ProgressReporter.spec.ts
+++ b/packages/core/test/unit/reporters/ProgressReporter.spec.ts
@@ -99,7 +99,7 @@ describe('ProgressReporter', () => {
       sut.onAllMutantsMatchedWithTests([matchedMutant(1), matchedMutant(1)]);
     });
 
-    it('should show to an estimate of "10s" in the progressBar after ten seconds and 1 mutants tested', () => {
+    it('should show correct time info after ten seconds and 1 mutants tested', () => {
       sinon.clock.tick(TEN_SECONDS);
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
@@ -107,7 +107,7 @@ describe('ProgressReporter', () => {
       expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '10s' });
     });
 
-    it('should show to an estimate of "1m, 40s" in the progressBar after hundred seconds and 1 mutants tested', () => {
+    it('should show correct time info after a hundred seconds and 1 mutants tested', () => {
       sinon.clock.tick(HUNDRED_SECONDS);
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
@@ -115,7 +115,7 @@ describe('ProgressReporter', () => {
       expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '1m, 40s' });
     });
 
-    it('should show to an estimate of "2h, 46m, 40s" in the progressBar after ten thousand seconds and 1 mutants tested', () => {
+    it('should show correct time info after ten thousand seconds and 1 mutants tested', () => {
       sinon.clock.tick(TEN_THOUSAND_SECONDS);
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));
@@ -123,7 +123,7 @@ describe('ProgressReporter', () => {
       expect(progressBar.tick).to.have.been.calledWithMatch({ etc: '2h, 46m, 40s' });
     });
 
-    it('should show to an estimate of "1h, 0m, 0s" in the progressBar after an hour and 1 mutants tested', () => {
+    it('should show correct time info after an hour and 1 mutants tested', () => {
       sinon.clock.tick(ONE_HOUR);
 
       sut.onMutantTested(mutantResult({ status: MutantStatus.Killed }));


### PR DESCRIPTION
as a partial solution for #1844 _now updated_:

- show elapsed time in the progress reporters
- change ETC label to `remaining`
- show times _in nicer format with no seconds, see below_ ~~with minutes with up to 2 decimal places, as opposed to seconds~~ (and continue to show hours starting with 60 minutes)
- unit testing of progress time reporting with 3 mutants
- minor test cleanup fixes

I _originally_ tried this with Prettier, with Stryker configured as proposed in brodybits/prettier#16.

Here is some terminal I/O with the default progress reporter _now outdated (see below for updated sample)_:

```sh
$ node --max-old-space-size=100000 ./node_modules/.bin/stryker run
16:25:24 (1853) INFO ConfigReader Using stryker.conf.js in the current working directory.
16:25:25 (1853) INFO InputFileResolver Found 13 of 5926 file(s) to be mutated.
16:25:25 (1853) INFO InitialTestExecutor Starting initial test run. This may take a while.
16:26:58 (1853) INFO InitialTestExecutor Initial test run succeeded. Ran 1 tests in 1 minute 33 seconds (net 92270 ms, overhead 0 ms).
16:26:59 (1853) INFO MutatorFacade 1186 Mutant(s) generated
16:26:59 (1853) INFO SandboxPool Creating 4 test runners (based on CPU count)
Mutation testing  [                                               ] 0% (elapsed: 1.75m) (remaining: 17h, 16m) 2/1186 tested (0 survived, 0 timed out)
```

and with "progress-append-only" reporter _now outdated (see below for updated sample)_:

```sh
$ node --max-old-space-size=100000 ./node_modules/.bin/stryker run | tee progress-log.txt
16:33:20 (2681) INFO ConfigReader Using stryker.conf.js in the current working directory.
16:33:21 (2681) INFO BroadcastReporter Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
16:33:22 (2681) INFO InputFileResolver Found 13 of 5927 file(s) to be mutated.
16:33:22 (2681) INFO InitialTestExecutor Starting initial test run. This may take a while.
16:34:55 (2681) INFO InitialTestExecutor Initial test run succeeded. Ran 1 tests in 1 minute 34 seconds (net 93137 ms, overhead 2 ms).
16:34:56 (2681) INFO MutatorFacade 1186 Mutant(s) generated
16:34:56 (2681) INFO SandboxPool Creating 4 test runners (based on CPU count)
Mutation testing 0% (elapsed: 0.16m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 0.33m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 0.5m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 0.66m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 0.83m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 1m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 1.16m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 1.33m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 1.5m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 1.66m) (remaining: n/a) 0/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 1.83m) (remaining: 18h, 5.33m) 2/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 2m) (remaining: 19h, 44m) 2/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 2.16m) (remaining: 21h, 22.66m) 2/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 2.33m) (remaining: 23h, 1.33m) 2/1186 tested (0 survived, 0 timed out)
Mutation testing 0% (elapsed: 2.5m) (remaining: 24h, 40m) 2/1186 tested (0 survived, 0 timed out)
```

I wanted to move away from using seconds since I think that having elapsed time frozen for a moment at a certain number of seconds is not such good UX (see brodybits/stryker#1).

I can also imagine some even further improvements _someday in the future_, perhaps with help from an external date/time formatting library such as moment.js.