### PR TITLE
Remove the unneeded @types/execa devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "devDependencies": {
     "@types/chai": "4.2.5",
     "@types/chai-as-promised": "7.1.2",
-    "@types/execa": "^2.0.0",
     "@types/glob": "^7.1.0",
     "@types/istanbul": "^0.4.29",
     "@types/karma": "^3.0.0",


### PR DESCRIPTION
This fixes a warning when running `npm install`:
~~~~
npm WARN deprecated @types/execa@2.0.0: This is a stub types definition. execa provides its own type definitions, so you do not need this installed.
~~~~