### PR TITLE
[nit] chore: remove trailing space from deprecated.conf.js

### DIFF
--- a/packages/core/testResources/config-reader/deprecated.conf.js
+++ b/packages/core/testResources/config-reader/deprecated.conf.js
@@ -19,5 +19,5 @@ module.exports = function(config){
         'ArrowFunctionMutator'
       ]
     }
-  });  
+  });
 };


### PR DESCRIPTION
Adding this to the list of artifacts that need to be automatically checked for formatting errors in #1878