### PR TITLE
[RFC ...] additional value mutations

### DIFF
--- a/packages/javascript-mutator/src/helpers/NodeGenerator.ts
+++ b/packages/javascript-mutator/src/helpers/NodeGenerator.ts
@@ -5,6 +5,10 @@ export class NodeGenerator {
     return NodeGenerator.createAnyLiteralValueNode(originalNode, 'BooleanLiteral', value) as types.BooleanLiteral;
   }
 
+  public static createStringLiteralNode(originalNode: types.Node, value: string): types.StringLiteral {
+    return NodeGenerator.createAnyLiteralValueNode(originalNode, 'StringLiteral', value) as types.StringLiteral;
+  }
+
   public static createIdentifierNode(originalNode: types.Node, name: string): types.Identifier {
     return NodeGenerator.createMutatedNode(originalNode, 'Identifier', { name }) as types.Identifier;
   }

--- a/packages/javascript-mutator/src/helpers/NodeGenerator.ts
+++ b/packages/javascript-mutator/src/helpers/NodeGenerator.ts
@@ -5,6 +5,10 @@ export class NodeGenerator {
     return NodeGenerator.createAnyLiteralValueNode(originalNode, 'BooleanLiteral', value) as types.BooleanLiteral;
   }
 
+  public static createIdentifierNode(originalNode: types.Node, name: string): types.Identifier {
+    return NodeGenerator.createMutatedNode(originalNode, 'Identifier', { name }) as types.Identifier;
+  }
+
   public static createAnyLiteralValueNode(originalNode: types.Node, type: string, value: any): types.Node {
     return NodeGenerator.createMutatedNode(originalNode, type, { value });
   }

--- a/packages/javascript-mutator/src/helpers/NodeGenerator.ts
+++ b/packages/javascript-mutator/src/helpers/NodeGenerator.ts
@@ -2,6 +2,14 @@ import * as types from '@babel/types';
 
 export class NodeGenerator {
   public static createBooleanLiteralNode(originalNode: types.Node, value: boolean): types.BooleanLiteral {
+    return NodeGenerator.createAnyLiteralValueNode(originalNode, 'BooleanLiteral', value) as types.BooleanLiteral;
+  }
+
+  public static createAnyLiteralValueNode(originalNode: types.Node, type: string, value: any): types.Node {
+    return NodeGenerator.createMutatedNode(originalNode, type, { value });
+  }
+
+  public static createMutatedNode(originalNode: types.Node, type: string, props: any): types.Node {
     return {
       end: originalNode.end,
       innerComments: originalNode.innerComments,
@@ -9,8 +17,8 @@ export class NodeGenerator {
       loc: originalNode.loc,
       start: originalNode.start,
       trailingComments: originalNode.trailingComments,
-      type: 'BooleanLiteral',
-      value
-    };
+      type,
+      ...props
+    } as types.Node;
   }
 }

--- a/packages/javascript-mutator/src/mutators/ArrayDeclarationMutator.ts
+++ b/packages/javascript-mutator/src/mutators/ArrayDeclarationMutator.ts
@@ -1,5 +1,7 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
 import { NodeMutator } from './NodeMutator';
 
 /**
@@ -15,10 +17,12 @@ export default class ArrayDeclarationMutator implements NodeMutator {
       const mutatedNode = copy(node);
       mutatedNode.elements = node.elements.length ? [] : [types.stringLiteral('Stryker was here')];
       nodes.push(mutatedNode);
+      nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));
     } else if ((types.isCallExpression(node) || types.isNewExpression(node)) && types.isIdentifier(node.callee) && node.callee.name === 'Array') {
       const mutatedNode = copy(node);
       mutatedNode.arguments = node.arguments.length ? [] : [types.arrayExpression()];
       nodes.push(mutatedNode);
+      nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));
     }
 
     return nodes;

--- a/packages/javascript-mutator/src/mutators/NumericValueMutator.ts
+++ b/packages/javascript-mutator/src/mutators/NumericValueMutator.ts
@@ -18,16 +18,7 @@ export default class NumericValueMutator implements NodeMutator {
       types.isIdentifier(node.argument) &&
       node.argument.name === 'NaN'
     ) {
-      [0, 1, -1].forEach(v => {
-        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
-      });
-      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
-      nodes.push(
-        NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
-          operator: '-',
-          argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
-        })
-      );
+      NumericValueMutator.pushMutatedValueNodes(nodes, node, NaN);
     }
 
     if (
@@ -37,11 +28,7 @@ export default class NumericValueMutator implements NodeMutator {
       types.isIdentifier(node.argument) &&
       node.argument.name === 'Infinity'
     ) {
-      [0, 1, -1].forEach(v => {
-        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
-      });
-      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
-      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
+      NumericValueMutator.pushMutatedValueNodes(nodes, node, -Infinity);
     }
 
     if (
@@ -52,16 +39,7 @@ export default class NumericValueMutator implements NodeMutator {
       // which is already handled above
       !(types.isUnaryExpression(node.parent) && node.parent.operator === '-')
     ) {
-      [0, 1, -1].forEach(v => {
-        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
-      });
-      nodes.push(
-        NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
-          operator: '-',
-          argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
-        })
-      );
-      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
+      NumericValueMutator.pushMutatedValueNodes(nodes, node, Infinity);
     }
 
     if (
@@ -72,16 +50,7 @@ export default class NumericValueMutator implements NodeMutator {
       // which is already handled above
       !(types.isUnaryExpression(node.parent) && node.parent.operator === '-')
     ) {
-      [0, 1, -1].forEach(v => {
-        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
-      });
-      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
-      nodes.push(
-        NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
-          operator: '-',
-          argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
-        })
-      );
+      NumericValueMutator.pushMutatedValueNodes(nodes, node, NaN);
     }
 
     if (
@@ -90,20 +59,7 @@ export default class NumericValueMutator implements NodeMutator {
       node.operator === '-' &&
       types.isNumericLiteral(node.argument)
     ) {
-      const argument = node.argument;
-      [0, 1, -1].forEach(v => {
-        if (argument.value !== -v) {
-          nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
-        }
-      });
-      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
-      nodes.push(
-        NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
-          operator: '-',
-          argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
-        })
-      );
-      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
+      NumericValueMutator.pushMutatedValueNodes(nodes, node, -node.argument.value);
     }
 
     if (
@@ -113,23 +69,37 @@ export default class NumericValueMutator implements NodeMutator {
       // which is already handled above
       !(types.isUnaryExpression(node.parent) && node.parent.operator === '-')
     ) {
-      [0, 1, -1].forEach(v => {
-        const mutatedNode = copy(node);
-        if (mutatedNode.value !== v) {
-          mutatedNode.value = v;
-          nodes.push(mutatedNode);
-        }
-      });
+      NumericValueMutator.pushMutatedValueNodes(nodes, node, node.value);
+    }
+
+    return nodes;
+  }
+
+  private static pushMutatedValueNodes(nodes: types.Node[], node: types.Node, value: number) {
+    [0, 1, -1].forEach(v => {
+      if (value !== v) {
+        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
+      }
+    });
+
+    if (value !== Infinity) {
       nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
+    }
+
+    if (value !== -Infinity) {
       nodes.push(
         NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
           operator: '-',
           argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
         })
       );
-      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
     }
 
-    return nodes;
+    // TBD Workaround since the condition (value === NaN)
+    // does not seem to do what we want here
+    // (value === NaN)
+    if (!!value || value === 0) {
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
+    }
   }
 }

--- a/packages/javascript-mutator/src/mutators/NumericValueMutator.ts
+++ b/packages/javascript-mutator/src/mutators/NumericValueMutator.ts
@@ -101,5 +101,17 @@ export default class NumericValueMutator implements NodeMutator {
     if (!!value || value === 0) {
       nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
     }
+
+    if (value !== Infinity && value !== -Infinity && !!value) {
+      const incremented = value + 1;
+      if (![0, 1, -1].includes(incremented)) {
+        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', incremented));
+      }
+
+      const decremented = value - 1;
+      if (![0, 1, -1].includes(decremented)) {
+        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', decremented));
+      }
+    }
   }
 }

--- a/packages/javascript-mutator/src/mutators/NumericValueMutator.ts
+++ b/packages/javascript-mutator/src/mutators/NumericValueMutator.ts
@@ -1,0 +1,135 @@
+import * as types from '@babel/types';
+
+import { NodeGenerator } from '../helpers/NodeGenerator';
+import { NodeWithParent } from '../helpers/ParentNode';
+
+import { NodeMutator } from './NodeMutator';
+
+export default class NumericValueMutator implements NodeMutator {
+  public name = 'NumericValue';
+
+  public mutate(node: NodeWithParent, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] {
+    const nodes: types.Node[] = [];
+
+    if (
+      // check for -NaN value expression
+      types.isUnaryExpression(node) &&
+      node.operator === '-' &&
+      types.isIdentifier(node.argument) &&
+      node.argument.name === 'NaN'
+    ) {
+      [0, 1, -1].forEach(v => {
+        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
+      });
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
+      nodes.push(
+        NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
+          operator: '-',
+          argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
+        })
+      );
+    }
+
+    if (
+      // check for -Infinity value expression
+      types.isUnaryExpression(node) &&
+      node.operator === '-' &&
+      types.isIdentifier(node.argument) &&
+      node.argument.name === 'Infinity'
+    ) {
+      [0, 1, -1].forEach(v => {
+        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
+      });
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
+    }
+
+    if (
+      // check for identifier with (positive) Infinity value
+      types.isIdentifier(node) &&
+      node.name === 'Infinity' &&
+      // should not be part of a negated numeric literal value expression,
+      // which is already handled above
+      !(types.isUnaryExpression(node.parent) && node.parent.operator === '-')
+    ) {
+      [0, 1, -1].forEach(v => {
+        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
+      });
+      nodes.push(
+        NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
+          operator: '-',
+          argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
+        })
+      );
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
+    }
+
+    if (
+      // check for identifier with NaN value
+      types.isIdentifier(node) &&
+      node.name === 'NaN' &&
+      // should not be part of a negated numeric literal value expression,
+      // which is already handled above
+      !(types.isUnaryExpression(node.parent) && node.parent.operator === '-')
+    ) {
+      [0, 1, -1].forEach(v => {
+        nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
+      });
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
+      nodes.push(
+        NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
+          operator: '-',
+          argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
+        })
+      );
+    }
+
+    if (
+      // check for negated numeric literal value expression
+      types.isUnaryExpression(node) &&
+      node.operator === '-' &&
+      types.isNumericLiteral(node.argument)
+    ) {
+      const argument = node.argument;
+      [0, 1, -1].forEach(v => {
+        if (argument.value !== -v) {
+          nodes.push(NodeGenerator.createAnyLiteralValueNode(node, 'NumericLiteral', v));
+        }
+      });
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
+      nodes.push(
+        NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
+          operator: '-',
+          argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
+        })
+      );
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
+    }
+
+    if (
+      // non-negated numeric literal value
+      types.isNumericLiteral(node) &&
+      // should not be part of a negated numeric literal value expression,
+      // which is already handled above
+      !(types.isUnaryExpression(node.parent) && node.parent.operator === '-')
+    ) {
+      [0, 1, -1].forEach(v => {
+        const mutatedNode = copy(node);
+        if (mutatedNode.value !== v) {
+          mutatedNode.value = v;
+          nodes.push(mutatedNode);
+        }
+      });
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' }));
+      nodes.push(
+        NodeGenerator.createMutatedNode(node, 'UnaryExpression', {
+          operator: '-',
+          argument: NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'Infinity' })
+        })
+      );
+      nodes.push(NodeGenerator.createMutatedNode(node, 'Identifier', { name: 'NaN' }));
+    }
+
+    return nodes;
+  }
+}

--- a/packages/javascript-mutator/src/mutators/ObjectLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/ObjectLiteralMutator.ts
@@ -1,5 +1,7 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
 import { NodeMutator } from './NodeMutator';
 
 /**
@@ -15,6 +17,10 @@ export default class ObjectLiteralMutator implements NodeMutator {
       const mutatedNode = copy(node);
       mutatedNode.properties = [];
       nodes.push(mutatedNode);
+    }
+
+    if (types.isObjectExpression(node)) {
+      nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));
     }
 
     return nodes;

--- a/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -13,11 +13,7 @@ export default class StringLiteralMutator implements NodeMutator {
 
     if (types.isTemplateLiteral(node)) {
       nodes.push(
-        NodeGenerator.createAnyLiteralValueNode(
-          node,
-          'StringLiteral',
-          node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? 'Stryker was here!' : ''
-        )
+        NodeGenerator.createStringLiteralNode(node, node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? 'Stryker was here!' : '')
       );
       nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));
     } else if ((!node.parent || this.isDeclarationOrJSX(node.parent)) && types.isStringLiteral(node)) {

--- a/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -19,10 +19,14 @@ export default class StringLiteralMutator implements NodeMutator {
           node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? 'Stryker was here!' : ''
         )
       );
+      nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));
     } else if ((!node.parent || this.isDeclarationOrJSX(node.parent)) && types.isStringLiteral(node)) {
       const mutatedNode = copy(node);
       mutatedNode.value = mutatedNode.value.length === 0 ? 'Stryker was here!' : '';
       nodes.push(mutatedNode);
+      if (types.isStringLiteral(node)) {
+        nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));
+      }
     }
 
     return nodes;

--- a/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -5,7 +5,7 @@ import { NodeWithParent } from '../helpers/ParentNode';
 
 import { NodeMutator } from './NodeMutator';
 
-const MUTATED_STRING_CONTENTS = 'Stryker was here!';
+const MUTATED_STRING_CONTENTS = '**Stryker was here!**';
 
 export default class StringLiteralMutator implements NodeMutator {
   public name = 'StringLiteral';

--- a/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -1,5 +1,6 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
 import { NodeWithParent } from '../helpers/ParentNode';
 
 import { NodeMutator } from './NodeMutator';
@@ -11,16 +12,13 @@ export default class StringLiteralMutator implements NodeMutator {
     const nodes: types.Node[] = [];
 
     if (types.isTemplateLiteral(node)) {
-      nodes.push({
-        end: node.end,
-        innerComments: node.innerComments,
-        leadingComments: node.leadingComments,
-        loc: node.loc,
-        start: node.start,
-        trailingComments: node.trailingComments,
-        type: 'StringLiteral',
-        value: node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? 'Stryker was here!' : ''
-      } as types.StringLiteral);
+      nodes.push(
+        NodeGenerator.createAnyLiteralValueNode(
+          node,
+          'StringLiteral',
+          node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? 'Stryker was here!' : ''
+        )
+      );
     } else if ((!node.parent || this.isDeclarationOrJSX(node.parent)) && types.isStringLiteral(node)) {
       const mutatedNode = copy(node);
       mutatedNode.value = mutatedNode.value.length === 0 ? 'Stryker was here!' : '';

--- a/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -5,6 +5,8 @@ import { NodeWithParent } from '../helpers/ParentNode';
 
 import { NodeMutator } from './NodeMutator';
 
+const MUTATED_STRING_CONTENTS = 'Stryker was here!';
+
 export default class StringLiteralMutator implements NodeMutator {
   public name = 'StringLiteral';
 
@@ -13,12 +15,12 @@ export default class StringLiteralMutator implements NodeMutator {
 
     if (types.isTemplateLiteral(node)) {
       nodes.push(
-        NodeGenerator.createStringLiteralNode(node, node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? 'Stryker was here!' : '')
+        NodeGenerator.createStringLiteralNode(node, node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? MUTATED_STRING_CONTENTS : '')
       );
       nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));
     } else if ((!node.parent || this.isDeclarationOrJSX(node.parent)) && types.isStringLiteral(node)) {
       const mutatedNode = copy(node);
-      mutatedNode.value = mutatedNode.value.length === 0 ? 'Stryker was here!' : '';
+      mutatedNode.value = mutatedNode.value.length === 0 ? MUTATED_STRING_CONTENTS : '';
       nodes.push(mutatedNode);
       if (types.isStringLiteral(node)) {
         nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));

--- a/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -14,14 +14,16 @@ export default class StringLiteralMutator implements NodeMutator {
     const nodes: types.Node[] = [];
 
     if (types.isTemplateLiteral(node)) {
-      nodes.push(
-        NodeGenerator.createStringLiteralNode(node, node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? MUTATED_STRING_CONTENTS : '')
-      );
+      if (node.expressions.length !== 0 || node.quasis.length > 1 || (node.quasis.length === 1 && node.quasis[0].value.raw !== '')) {
+        nodes.push(NodeGenerator.createStringLiteralNode(node, ''));
+      }
+      nodes.push(NodeGenerator.createStringLiteralNode(node, MUTATED_STRING_CONTENTS));
       nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));
     } else if ((!node.parent || this.isDeclarationOrJSX(node.parent)) && types.isStringLiteral(node)) {
-      const mutatedNode = copy(node);
-      mutatedNode.value = mutatedNode.value.length === 0 ? MUTATED_STRING_CONTENTS : '';
-      nodes.push(mutatedNode);
+      if (node.value.length !== 0) {
+        nodes.push(NodeGenerator.createStringLiteralNode(node, ''));
+      }
+      nodes.push(NodeGenerator.createStringLiteralNode(node, MUTATED_STRING_CONTENTS));
       if (types.isStringLiteral(node)) {
         nodes.push(NodeGenerator.createIdentifierNode(node, 'null'));
       }

--- a/packages/javascript-mutator/src/mutators/index.ts
+++ b/packages/javascript-mutator/src/mutators/index.ts
@@ -4,6 +4,7 @@ import BlockStatementMutator from './BlockStatementMutator';
 import BooleanLiteralMutator from './BooleanLiteralMutator';
 import ConditionalExpressionMutator from './ConditionalExpressionMutator';
 import EqualityOperatorMutator from './EqualityOperatorMutator';
+import NumericValueMutator from './NumericValueMutator';
 import ObjectLiteralMutator from './ObjectLiteralMutator';
 import StringLiteralMutator from './StringLiteralMutator';
 import LogicalOperatorMutator from './LogicalOperatorMutator';
@@ -18,6 +19,7 @@ export const nodeMutators = Object.freeze([
   new ConditionalExpressionMutator(),
   new EqualityOperatorMutator(),
   new LogicalOperatorMutator(),
+  new NumericValueMutator(),
   new ObjectLiteralMutator(),
   new StringLiteralMutator(),
   new UnaryOperatorMutator(),

--- a/packages/javascript-mutator/test/unit/JavaScriptMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/JavaScriptMutator.spec.ts
@@ -24,7 +24,7 @@ describe('JavaScriptMutator', () => {
 
   it('should generate a correct mutant', () => {
     const mutator = createSut();
-    const files: File[] = [new File('testFile.js', '"use strict"; var a = 1 + 2;')];
+    const files: File[] = [new File('testFile.js', '"use strict"; var a = b + c;')];
 
     const mutants = mutator.mutate(files);
 
@@ -33,7 +33,7 @@ describe('JavaScriptMutator', () => {
       fileName: files[0].name,
       mutatorName: 'ArithmeticOperator',
       range: [22, 27],
-      replacement: '1 - 2'
+      replacement: 'b - c'
     });
   });
 
@@ -168,8 +168,8 @@ describe('JavaScriptMutator', () => {
 
   it('should generate mutants for multiple files', () => {
     const mutator = createSut();
-    const file: File = new File('testFile.js', '"use strict"; var a = 1 + 2;');
-    const file2: File = new File('testFile2.js', '"use strict"; var a = 1 + 2;');
+    const file: File = new File('testFile.js', '"use strict"; var a = b + c;');
+    const file2: File = new File('testFile2.js', '"use strict"; var d = e - f;');
     const mutants = mutator.mutate([file, file2]);
 
     expect(mutants.length).to.equal(2);

--- a/packages/javascript-mutator/test/unit/JavaScriptMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/JavaScriptMutator.spec.ts
@@ -63,7 +63,7 @@ describe('JavaScriptMutator', () => {
 
     const mutants = mutator.mutate(files);
 
-    expect(mutants.length).to.equal(8);
+    expect(mutants.length).to.equal(10);
     expect(mutants).to.deep.include({
       fileName: 'testFile.jsx',
       mutatorName: 'ConditionalExpression',
@@ -126,7 +126,7 @@ describe('JavaScriptMutator', () => {
 
     const mutants = mutator.mutate(files);
 
-    expect(mutants.length).to.equal(6);
+    expect(mutants.length).to.equal(7);
     expect(mutants).to.deep.include({
       fileName: 'testFile.js',
       mutatorName: 'ConditionalExpression',

--- a/packages/javascript-mutator/test/unit/JavaScriptMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/JavaScriptMutator.spec.ts
@@ -63,7 +63,7 @@ describe('JavaScriptMutator', () => {
 
     const mutants = mutator.mutate(files);
 
-    expect(mutants.length).to.equal(6);
+    expect(mutants.length).to.equal(8);
     expect(mutants).to.deep.include({
       fileName: 'testFile.jsx',
       mutatorName: 'ConditionalExpression',
@@ -126,7 +126,7 @@ describe('JavaScriptMutator', () => {
 
     const mutants = mutator.mutate(files);
 
-    expect(mutants.length).to.equal(5);
+    expect(mutants.length).to.equal(6);
     expect(mutants).to.deep.include({
       fileName: 'testFile.js',
       mutatorName: 'ConditionalExpression',

--- a/packages/javascript-mutator/test/unit/mutators/NumericValueMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/mutators/NumericValueMutator.spec.ts
@@ -1,0 +1,6 @@
+import { NumericValueMutatorSpec } from '@stryker-mutator/mutator-specification/src/index';
+
+import NumericValueMutator from '../../../src/mutators/NumericValueMutator';
+import { verifySpecification } from '../../helpers/mutatorAssertions';
+
+verifySpecification(NumericValueMutatorSpec, NumericValueMutator);

--- a/packages/mutator-specification/src/ArrayDeclarationMutatorSpec.ts
+++ b/packages/mutator-specification/src/ArrayDeclarationMutatorSpec.ts
@@ -9,17 +9,17 @@ export default function ArrayDeclarationMutatorSpec(name: string, expectMutation
     });
 
     it('should mutate filled array literals as empty arrays', () => {
-      expectMutation('[a, 1 + 1]', '[]');
-      expectMutation("['val']", '[]');
+      expectMutation('[a, 1 + 1]', '[]', 'null');
+      expectMutation("['val']", '[]', 'null');
     });
 
     it('should mutate empty array literals as a filled array', () => {
-      expectMutation('[]', '["Stryker was here"]');
+      expectMutation('[]', '["Stryker was here"]', 'null');
     });
 
     it('should mutate filled array literals as empty arrays', () => {
-      expectMutation('new Array(a, 1 + 1)', 'new Array()');
-      expectMutation("new Array('val')", 'new Array()');
+      expectMutation('new Array(a, 1 + 1)', 'new Array()', 'null');
+      expectMutation("new Array('val')", 'new Array()', 'null');
     });
 
     it('should not mutate other new expressions', () => {
@@ -28,7 +28,7 @@ export default function ArrayDeclarationMutatorSpec(name: string, expectMutation
     });
 
     it('should mutate empty array literals as a filled array', () => {
-      expectMutation('new Array()', 'new Array([])');
+      expectMutation('new Array()', 'new Array([])', 'null');
     });
   });
 }

--- a/packages/mutator-specification/src/ArrayLiteralMutatorSpec.ts
+++ b/packages/mutator-specification/src/ArrayLiteralMutatorSpec.ts
@@ -13,8 +13,8 @@ export default function ArrayLiteralMutatorSpec(name: string, expectMutation: Ex
     });
 
     it('should mutate filled array literals as empty arrays', () => {
-      expectMutation('[a, 1 + 1]', '[]');
-      expectMutation("['val']", '[]');
+      expectMutation('[a, 1 + 1]', '[]', 'xxx');
+      expectMutation("['val']", '[]', 'xxx');
     });
 
     it('should not mutate array initializers (leave that for ArrayNewExpressionMutator)', () => {
@@ -23,7 +23,7 @@ export default function ArrayLiteralMutatorSpec(name: string, expectMutation: Ex
     });
 
     it('should mutate empty array literals as a filled array', () => {
-      expectMutation('[]', "['Stryker was here']");
+      expectMutation('[]', "['Stryker was here'], 'xxx'");
     });
   });
 }

--- a/packages/mutator-specification/src/NumericValueMutatorSpec.ts
+++ b/packages/mutator-specification/src/NumericValueMutatorSpec.ts
@@ -18,7 +18,9 @@ export default function NumericValueMutatorSpec(name: string, expectMutation: Ex
         'const a = -1;',
         'const a = Infinity;',
         'const a = -Infinity;',
-        'const a = NaN;'
+        'const a = NaN;',
+        'const a = 124.4567;',
+        'const a = 122.4567;'
       );
     });
 
@@ -32,7 +34,9 @@ export default function NumericValueMutatorSpec(name: string, expectMutation: Ex
         'const a = -1;',
         'const a = Infinity;',
         'const a = -Infinity;',
-        'const a = NaN;'
+        'const a = NaN;',
+        'const a = -122.4567;',
+        'const a = -124.4567;'
       );
     });
 
@@ -58,7 +62,8 @@ export default function NumericValueMutatorSpec(name: string, expectMutation: Ex
         'const a = -1;',
         'const a = Infinity;',
         'const a = -Infinity;',
-        'const a = NaN;'
+        'const a = NaN;',
+        'const a = 2;'
       );
     });
 
@@ -71,7 +76,8 @@ export default function NumericValueMutatorSpec(name: string, expectMutation: Ex
         'const a = 1;',
         'const a = Infinity;',
         'const a = -Infinity;',
-        'const a = NaN;'
+        'const a = NaN;',
+        'const a = -2;'
       );
     });
 

--- a/packages/mutator-specification/src/NumericValueMutatorSpec.ts
+++ b/packages/mutator-specification/src/NumericValueMutatorSpec.ts
@@ -1,0 +1,148 @@
+import { expect } from 'chai';
+
+import ExpectMutation from './ExpectMutation';
+
+export default function NumericValueMutatorSpec(name: string, expectMutation: ExpectMutation) {
+  describe('NumericValueMutator', () => {
+    it('should have name "NumericValue"', () => {
+      expect(name).eq('NumericValue');
+    });
+
+    it('should mutate a positive numeric literal 123.4567', () => {
+      expectMutation(
+        // input code:
+        'const a = 123.4567;',
+        // expected mutations:
+        'const a = 0;',
+        'const a = 1;',
+        'const a = -1;',
+        'const a = Infinity;',
+        'const a = -Infinity;',
+        'const a = NaN;'
+      );
+    });
+
+    it('should mutate a negative numeric literal -123.4567', () => {
+      expectMutation(
+        // input code:
+        'const a = -123.4567;',
+        // expected mutations:
+        'const a = 0;',
+        'const a = 1;',
+        'const a = -1;',
+        'const a = Infinity;',
+        'const a = -Infinity;',
+        'const a = NaN;'
+      );
+    });
+
+    it('should not generate extra mutation for numeric literal 0', () => {
+      expectMutation(
+        // input code:
+        'const a = 0;',
+        // expected mutations:
+        'const a = 1;',
+        'const a = -1;',
+        'const a = Infinity;',
+        'const a = -Infinity;',
+        'const a = NaN;'
+      );
+    });
+
+    it('should not generate extra mutation for numeric literal 1', () => {
+      expectMutation(
+        // input code:
+        'const a = 1;',
+        // expected mutations:
+        'const a = 0;',
+        'const a = -1;',
+        'const a = Infinity;',
+        'const a = -Infinity;',
+        'const a = NaN;'
+      );
+    });
+
+    it('should not generate extra mutation for numeric literal -1', () => {
+      expectMutation(
+        // input code:
+        'const a = -1;',
+        // expected mutations:
+        'const a = 0;',
+        'const a = 1;',
+        'const a = Infinity;',
+        'const a = -Infinity;',
+        'const a = NaN;'
+      );
+    });
+
+    it('should not generate extra mutation for numeric literal -0', () => {
+      expectMutation(
+        // input code:
+        'const a = -0;',
+        // expected mutations:
+        'const a = 1;',
+        'const a = -1;',
+        'const a = Infinity;',
+        'const a = -Infinity;',
+        'const a = NaN;'
+      );
+    });
+
+    it('should not generate extra mutation for numeric literal value Infinity', () => {
+      expectMutation(
+        // input code:
+        'const a = Infinity;',
+        // expected mutations:
+        'const a = 0;',
+        'const a = 1;',
+        'const a = -1;',
+        'const a = -Infinity;',
+        'const a = NaN;'
+      );
+    });
+
+    it('should not generate extra mutation for numeric literal value -Infinity', () => {
+      expectMutation(
+        // input code:
+        'const a = -Infinity;',
+        // expected mutations:
+        'const a = 0;',
+        'const a = 1;',
+        'const a = -1;',
+        'const a = Infinity;',
+        'const a = NaN;'
+      );
+    });
+
+    it('should not generate extra NaN mutation for numeric literal value NaN', () => {
+      expectMutation(
+        // input code:
+        'const a = -NaN;',
+        // expected mutations:
+        'const a = 0;',
+        'const a = 1;',
+        'const a = -1;',
+        'const a = Infinity;',
+        'const a = -Infinity;'
+      );
+    });
+
+    it('should not generate extra NaN mutation for numeric literal value -NaN', () => {
+      expectMutation(
+        // input code:
+        'const a = -NaN;',
+        // expected mutations:
+        'const a = 0;',
+        'const a = 1;',
+        'const a = -1;',
+        'const a = Infinity;',
+        'const a = -Infinity;'
+      );
+    });
+
+    it('should not mutate type declarations', () => {
+      expectMutation('let a: Record<"id", 123>;');
+      expectMutation('let a: 123;');
+    });
+  });
+}

--- a/packages/mutator-specification/src/ObjectLiteralMutatorSpec.ts
+++ b/packages/mutator-specification/src/ObjectLiteralMutatorSpec.ts
@@ -8,20 +8,20 @@ export default function ObjectLiteralMutatorSpec(name: string, expectMutation: E
       expect(name).eq('ObjectLiteral');
     });
 
-    it('should empty an object declaration', () => {
-      expectMutation('const o = { foo: "bar" }', 'const o = {}');
+    it('should empty an object declaration and then mutate it as a null value', () => {
+      expectMutation('const o = { foo: "bar" }', 'const o = {}', 'const o = null');
     });
 
-    it('should empty an object declaration of all properties', () => {
-      expectMutation('const o = { foo: "bar", baz: "qux" }', 'const o = {}');
+    it('should empty an object declaration of all properties and then mutate it as a null value', () => {
+      expectMutation('const o = { foo: "bar", baz: "qux" }', 'const o = {}', 'const o = null');
     });
 
-    it('should empty string object keys', () => {
-      expectMutation('const o = { ["foo"]: "bar" }', 'const o = {}');
+    it('should empty string object keys and then mutate it as a null value', () => {
+      expectMutation('const o = { ["foo"]: "bar" }', 'const o = {}', 'const o = null');
     });
 
-    it('shoud not mutate empty object declarations', () => {
-      expectMutation('const o = {}');
+    it('shoud only mutate an empty object declaration as a null value', () => {
+      expectMutation('const o = {}', 'const o = null');
     });
   });
 }

--- a/packages/mutator-specification/src/StringLiteralMutatorSpec.ts
+++ b/packages/mutator-specification/src/StringLiteralMutatorSpec.ts
@@ -27,11 +27,11 @@ export default function StringLiteralMutatorSpec(name: string, expectMutation: E
     });
 
     it('should mutate an empty string as a bogus string and as a null value', () => {
-      expectMutation('const b = "";', 'const b = "Stryker was here!";', 'const b = null;');
+      expectMutation('const b = "";', 'const b = "**Stryker was here!**";', 'const b = null;');
     });
 
     it('should mutate an empty template string as a bogus string and as a null value', () => {
-      expectMutation('const b = ``;', 'const b = "Stryker was here!";', 'const b = null;');
+      expectMutation('const b = ``;', 'const b = "**Stryker was here!**";', 'const b = null;');
     });
 
     it('should not mutate import statements', () => {

--- a/packages/mutator-specification/src/StringLiteralMutatorSpec.ts
+++ b/packages/mutator-specification/src/StringLiteralMutatorSpec.ts
@@ -8,30 +8,30 @@ export default function StringLiteralMutatorSpec(name: string, expectMutation: E
       expect(name).eq('StringLiteral');
     });
 
-    it('should mutate a string literal with double quotes', () => {
-      expectMutation('const b = "Hello world!";', 'const b = "";');
+    it('should mutate a string literal with double quotes as an empty string and as a null value', () => {
+      expectMutation('const b = "Hello world!";', 'const b = "";', 'const b = null;');
     });
 
-    it('should mutate a string literal with single quotes', () => {
-      expectMutation("const b = 'Hello world!';", 'const b = "";');
+    it('should mutate a string literal with single quotes as an empty string and as a null value', () => {
+      expectMutation("const b = 'Hello world!';", 'const b = "";', 'const b = null;');
     });
 
-    it('should mutate a template string', () => {
-      expectMutation('const b = `Hello world!`;', 'const b = "";');
+    it('should mutate a template string as an empty string and as a null value', () => {
+      expectMutation('const b = `Hello world!`;', 'const b = "";', 'const b = null;');
     });
 
-    it('should mutate a template string referencing another variable', () => {
-      expectMutation('const a = 10; const b = `${a} mutations`;', 'const a = 10; const b = "";');
-      expectMutation('const a = 10; const b = `mutations: ${a}`;', 'const a = 10; const b = "";');
-      expectMutation('const a = 10; const b = `mutations: ${a} out of 10`;', 'const a = 10; const b = "";');
+    it('should mutate a template string referencing another variable as an empty string and as a null value', () => {
+      expectMutation('const a = 10; const b = `${a} mutations`;', 'const a = 10; const b = "";', 'const a = 10; const b = null;');
+      expectMutation('const a = 10; const b = `mutations: ${a}`;', 'const a = 10; const b = "";', 'const a = 10; const b = null;');
+      expectMutation('const a = 10; const b = `mutations: ${a} out of 10`;', 'const a = 10; const b = "";', 'const a = 10; const b = null;');
     });
 
-    it('should mutate empty strings', () => {
-      expectMutation('const b = "";', 'const b = "Stryker was here!";');
+    it('should mutate an empty string as a bogus string and as a null value', () => {
+      expectMutation('const b = "";', 'const b = "Stryker was here!";', 'const b = null;');
     });
 
-    it('should mutate empty template strings', () => {
-      expectMutation('const b = ``;', 'const b = "Stryker was here!";');
+    it('should mutate an empty template string as a bogus string and as a null value', () => {
+      expectMutation('const b = ``;', 'const b = "Stryker was here!";', 'const b = null;');
     });
 
     it('should not mutate import statements', () => {
@@ -47,7 +47,7 @@ export default function StringLiteralMutatorSpec(name: string, expectMutation: E
     });
 
     it('should not mutate type declarations', () => {
-      expectMutation('const a: "hello" = "hello";', 'const a: "hello" = "";');
+      expectMutation('const a: "hello" = "hello";', 'const a: "hello" = "";', 'const a: "hello" = null;');
       expectMutation('const a: Record<"id", number> = { id: 10 }');
     });
 

--- a/packages/mutator-specification/src/StringLiteralMutatorSpec.ts
+++ b/packages/mutator-specification/src/StringLiteralMutatorSpec.ts
@@ -9,21 +9,36 @@ export default function StringLiteralMutatorSpec(name: string, expectMutation: E
     });
 
     it('should mutate a string literal with double quotes as an empty string and as a null value', () => {
-      expectMutation('const b = "Hello world!";', 'const b = "";', 'const b = null;');
+      expectMutation('const b = "Hello world!";', 'const b = "";', 'const b = "**Stryker was here!**";', 'const b = null;');
     });
 
     it('should mutate a string literal with single quotes as an empty string and as a null value', () => {
-      expectMutation("const b = 'Hello world!';", 'const b = "";', 'const b = null;');
+      expectMutation("const b = 'Hello world!';", 'const b = "";', 'const b = "**Stryker was here!**";', 'const b = null;');
     });
 
     it('should mutate a template string as an empty string and as a null value', () => {
-      expectMutation('const b = `Hello world!`;', 'const b = "";', 'const b = null;');
+      expectMutation('const b = `Hello world!`;', 'const b = "";', 'const b = "**Stryker was here!**";', 'const b = null;');
     });
 
     it('should mutate a template string referencing another variable as an empty string and as a null value', () => {
-      expectMutation('const a = 10; const b = `${a} mutations`;', 'const a = 10; const b = "";', 'const a = 10; const b = null;');
-      expectMutation('const a = 10; const b = `mutations: ${a}`;', 'const a = 10; const b = "";', 'const a = 10; const b = null;');
-      expectMutation('const a = 10; const b = `mutations: ${a} out of 10`;', 'const a = 10; const b = "";', 'const a = 10; const b = null;');
+      expectMutation(
+        'const a = 10; const b = `mutations: ${a} out of 10`;',
+        'const a = 10; const b = "";',
+        'const a = 10; const b = "**Stryker was here!**";',
+        'const a = 10; const b = null;'
+      );
+      expectMutation(
+        'const a = 10; const b = `mutations: ${a}`;',
+        'const a = 10; const b = "";',
+        'const a = 10; const b = "**Stryker was here!**";',
+        'const a = 10; const b = null;'
+      );
+      expectMutation(
+        'const a = 10; const b = `mutations: ${a} out of 10`;',
+        'const a = 10; const b = "";',
+        'const a = 10; const b = "**Stryker was here!**";',
+        'const a = 10; const b = null;'
+      );
     });
 
     it('should mutate an empty string as a bogus string and as a null value', () => {
@@ -47,7 +62,12 @@ export default function StringLiteralMutatorSpec(name: string, expectMutation: E
     });
 
     it('should not mutate type declarations', () => {
-      expectMutation('const a: "hello" = "hello";', 'const a: "hello" = "";', 'const a: "hello" = null;');
+      expectMutation(
+        'const a: "hello" = "hello";',
+        'const a: "hello" = "";',
+        'const a: "hello" = "**Stryker was here!**";',
+        'const a: "hello" = null;'
+      );
       expectMutation('const a: Record<"id", number> = { id: 10 }');
     });
 

--- a/packages/mutator-specification/src/index.ts
+++ b/packages/mutator-specification/src/index.ts
@@ -19,6 +19,7 @@ export { default as BooleanSubstitutionMutatorSpec } from './BooleanSubstitution
 export { default as DoStatementMutatorSpec } from './DoStatementMutatorSpec';
 export { default as ForStatementMutatorSpec } from './ForStatementMutatorSpec';
 export { default as IfStatementMutatorSpec } from './IfStatementMutatorSpec';
+export { default as NumericValueMutatorSpec } from './NumericValueMutatorSpec';
 export { default as PrefixUnaryExpressionMutatorSpec } from './PrefixUnaryExpressionMutatorSpec';
 export { default as SwitchCaseMutatorSpec } from './SwitchCaseMutatorSpec';
 export { default as WhileStatementMutatorSpec } from './WhileStatementMutatorSpec';

--- a/packages/typescript/src/mutator/ArrayDeclarationMutator.ts
+++ b/packages/typescript/src/mutator/ArrayDeclarationMutator.ts
@@ -12,16 +12,28 @@ export default class ArrayDeclarationMutator extends NodeMutator<ts.ArrayLiteral
   protected identifyReplacements(node: ts.ArrayLiteralExpression | ts.NewExpression, sourceFile: ts.SourceFile): NodeReplacement[] {
     if (node.kind === ts.SyntaxKind.ArrayLiteralExpression) {
       if (node.elements.length) {
-        return [{ node, replacement: '[]' }];
+        return [
+          { node, replacement: '[]' },
+          { node, replacement: 'null' }
+        ];
       } else {
-        return [{ node, replacement: '["Stryker was here"]' }];
+        return [
+          { node, replacement: '["Stryker was here"]' },
+          { node, replacement: 'null' }
+        ];
       }
     } else {
       if (node.expression.getFullText(sourceFile).trim() === 'Array') {
         if (node.arguments && node.arguments.length) {
-          return [{ node, replacement: 'new Array()' }];
+          return [
+            { node, replacement: 'new Array()' },
+            { node, replacement: 'null' }
+          ];
         } else {
-          return [{ node, replacement: 'new Array([])' }];
+          return [
+            { node, replacement: 'new Array([])' },
+            { node, replacement: 'null' }
+          ];
         }
       } else {
         return [];

--- a/packages/typescript/src/mutator/ObjectLiteralMutator.ts
+++ b/packages/typescript/src/mutator/ObjectLiteralMutator.ts
@@ -11,9 +11,12 @@ export default class ObjectLiteralMutator extends NodeMutator<ts.ObjectLiteralEx
 
   protected identifyReplacements(o: ts.ObjectLiteralExpression): NodeReplacement[] {
     if (o.properties.length > 0) {
-      return [{ node: o, replacement: '{}' }];
+      return [
+        { node: o, replacement: '{}' },
+        { node: o, replacement: 'null' }
+      ];
     } else {
-      return [];
+      return [{ node: o, replacement: 'null' }];
     }
   }
 }

--- a/packages/typescript/src/mutator/StringLiteralMutator.ts
+++ b/packages/typescript/src/mutator/StringLiteralMutator.ts
@@ -2,6 +2,8 @@ import * as ts from 'typescript';
 
 import NodeMutator, { NodeReplacement } from './NodeMutator';
 
+const MUTATED_STRING_CONTENTS = 'Stryker was here!';
+
 export type AllStringLiterals =
   // Regular quoted string.
   | ts.StringLiteral
@@ -47,7 +49,7 @@ export default class StringLiteralMutator extends NodeMutator<AllStringLiterals>
 
     if (this.isEmpty(str)) {
       return [
-        { node: str, replacement: '"Stryker was here!"' },
+        { node: str, replacement: `"${MUTATED_STRING_CONTENTS}"` },
         { node: str, replacement: 'null' }
       ];
     } else {

--- a/packages/typescript/src/mutator/StringLiteralMutator.ts
+++ b/packages/typescript/src/mutator/StringLiteralMutator.ts
@@ -46,9 +46,15 @@ export default class StringLiteralMutator extends NodeMutator<AllStringLiterals>
     }
 
     if (this.isEmpty(str)) {
-      return [{ node: str, replacement: '"Stryker was here!"' }];
+      return [
+        { node: str, replacement: '"Stryker was here!"' },
+        { node: str, replacement: 'null' }
+      ];
     } else {
-      return [{ node: str, replacement: '""' }];
+      return [
+        { node: str, replacement: '""' },
+        { node: str, replacement: 'null' }
+      ];
     }
   }
 

--- a/packages/typescript/src/mutator/StringLiteralMutator.ts
+++ b/packages/typescript/src/mutator/StringLiteralMutator.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 
 import NodeMutator, { NodeReplacement } from './NodeMutator';
 
-const MUTATED_STRING_CONTENTS = 'Stryker was here!';
+const MUTATED_STRING_CONTENTS = '**Stryker was here!**';
 
 export type AllStringLiterals =
   // Regular quoted string.

--- a/packages/typescript/src/mutator/StringLiteralMutator.ts
+++ b/packages/typescript/src/mutator/StringLiteralMutator.ts
@@ -55,6 +55,7 @@ export default class StringLiteralMutator extends NodeMutator<AllStringLiterals>
     } else {
       return [
         { node: str, replacement: '""' },
+        { node: str, replacement: `"${MUTATED_STRING_CONTENTS}"` },
         { node: str, replacement: 'null' }
       ];
     }

--- a/packages/typescript/test/integration/sample.it.spec.ts
+++ b/packages/typescript/test/integration/sample.it.spec.ts
@@ -31,7 +31,7 @@ describe('Sample integration', () => {
     // Generate mutants
     const mutator = testInjector.injector.injectFunction(typescriptMutatorFactory);
     const mutants = mutator.mutate(inputFiles);
-    expect(mutants.length).to.eq(5);
+    expect(mutants.length).to.eq(6);
   });
 
   it('should be able to transpile source code', async () => {

--- a/packages/typescript/test/integration/sample.it.spec.ts
+++ b/packages/typescript/test/integration/sample.it.spec.ts
@@ -31,7 +31,7 @@ describe('Sample integration', () => {
     // Generate mutants
     const mutator = testInjector.injector.injectFunction(typescriptMutatorFactory);
     const mutants = mutator.mutate(inputFiles);
-    expect(mutants.length).to.eq(6);
+    expect(mutants.length).to.eq(7);
   });
 
   it('should be able to transpile source code', async () => {

--- a/packages/vue-mutator/test/integration/VueMutator.it.spec.ts
+++ b/packages/vue-mutator/test/integration/VueMutator.it.spec.ts
@@ -52,7 +52,7 @@ describe('VueMutator', () => {
 
       const mutants = sut.mutate(files);
 
-      expect(mutants.filter(m => m.mutatorName === 'StringLiteral').length).to.equal(4);
+      expect(mutants.filter(m => m.mutatorName === 'StringLiteral').length).to.equal(6);
       expect(mutants.filter(m => m.mutatorName === 'BlockStatement').length).to.equal(3);
       expect(mutants.filter(m => m.mutatorName === 'EqualityOperator').length).to.equal(2);
       expect(mutants.filter(m => m.mutatorName === 'ArithmeticOperator').length).to.equal(1);
@@ -93,7 +93,7 @@ describe('VueMutator', () => {
 
       const mutants = sut.mutate(files);
 
-      expect(mutants.filter(m => m.mutatorName === 'StringLiteral').length).to.equal(2);
+      expect(mutants.filter(m => m.mutatorName === 'StringLiteral').length).to.equal(3);
       expect(mutants.filter(m => m.mutatorName === 'BlockStatement').length).to.equal(3);
       expect(mutants.filter(m => m.mutatorName === 'EqualityOperator').length).to.equal(2);
       expect(mutants.filter(m => m.mutatorName === 'ArithmeticOperator').length).to.equal(1);

--- a/packages/vue-mutator/test/integration/VueMutator.it.spec.ts
+++ b/packages/vue-mutator/test/integration/VueMutator.it.spec.ts
@@ -52,7 +52,7 @@ describe('VueMutator', () => {
 
       const mutants = sut.mutate(files);
 
-      expect(mutants.filter(m => m.mutatorName === 'StringLiteral').length).to.equal(2);
+      expect(mutants.filter(m => m.mutatorName === 'StringLiteral').length).to.equal(4);
       expect(mutants.filter(m => m.mutatorName === 'BlockStatement').length).to.equal(3);
       expect(mutants.filter(m => m.mutatorName === 'EqualityOperator').length).to.equal(2);
       expect(mutants.filter(m => m.mutatorName === 'ArithmeticOperator').length).to.equal(1);
@@ -93,7 +93,7 @@ describe('VueMutator', () => {
 
       const mutants = sut.mutate(files);
 
-      expect(mutants.filter(m => m.mutatorName === 'StringLiteral').length).to.equal(1);
+      expect(mutants.filter(m => m.mutatorName === 'StringLiteral').length).to.equal(2);
       expect(mutants.filter(m => m.mutatorName === 'BlockStatement').length).to.equal(3);
       expect(mutants.filter(m => m.mutatorName === 'EqualityOperator').length).to.equal(2);
       expect(mutants.filter(m => m.mutatorName === 'ArithmeticOperator').length).to.equal(1);


### PR DESCRIPTION
- add `null` value mutation for array, object, and string literal values for JavaScript & TypeScript
- add numeric value mutations: `0`, `1`, `-1`, `Infinity`, `-Infinity`, and `NaN` for JavaScript only (for now)
- update the mutated string value to: `**Stryker was here!**`
- include the mutated string value of `**Stryker was here!**` for all string literals, not just empty strings
- add incremented & decremented numeric value mutations
- additional refactoring & cleanup

Open question:

- [ ] I wonder if some of these additional mutations should be moved into new mutators and if they should go behind any new options.

General rationale:

- I do think these changes could help users avoid the trap of the "billion dollar mistake" of using null values
- I have seen cases, mostly related to numeric data values in SQL databases, where the proposed numeric value mutations could help identify some more desired test cases

The numeric value mutations have already helped me find some more tests needed in a private PGP utility that I am not yet ready to publish. Here are some results I found on a couple of public repos:

On https://github.com/jonschlinkert/remove-bom-buffer which seems to be used by Gulp:

- report on Stryker 2.4.0, without this proposal (jonschlinkert/remove-bom-buffer#5): https://chrisbrody.com/remove-bom-buffer-stryker-report/index.html
- report with this proposal: https://chrisbrody.com/remove-bom-buffer-stryker-avm-001/index.html

With this proposal, we can see some more surviving mutants related to a string slice function call.

On https://github.com/ericelliott/riteway (<https://github.com/ericelliott/riteway/pull/193>):

- without this proposal: https://chrisbrody.com/riteway-stryker-report-001/index.html
- with this proposal: https://chrisbrody.com/riteway-stryker-avm-wip001/index.html

Here are a couple more mutants that this proposal identifies on riteway:

```diff
index a68eb08..473d508 100644
--- a/source/riteway.js
+++ b/source/riteway.js
@@ -12,7 +12,7 @@ const withRiteway = TestFunction => test => {
     should = '',
     actual = undefined,
     expected = undefined
-  } = {}) => {
+  } = null) => {
     test.same(
       actual, expected,
       `Given ${given}: should ${should}`
@@ -51,7 +51,7 @@ const createStream = tape.createStream.bind(tape);
  * @param {object} [obj] The object whose keys you wish to count.
  * @returns {number}
  */
-const countKeys = (obj = {}) => Object.keys(obj).length;
+const countKeys = (obj = null) => Object.keys(obj).length;
 
 export default describe;
 export { describe, Try, createStream, countKeys };
```

I have verified that the mocha test continues to pass on JavaScript, TypeScript, and Vue mutators.

TODO items:

- [ ] When I pushed my work to GitHub, it seemed to report some e2e test failures. It looks like there is a Stryker run as well. I have not been able to run e2e test on my mac or a Ubuntu node on the cloud. Any pointers would be much appreciated.
- [ ] If this project is ready to accept the proposed numeric value mutations, I would be happy to try adding them for TypeScript as well.