### PR TITLE
JavaScript mutator improvements

### DIFF
--- a/packages/javascript-mutator/package.json
+++ b/packages/javascript-mutator/package.json
@@ -40,7 +40,6 @@
     "@babel/parser": "~7.7.0",
     "@babel/traverse": "~7.7.0",
     "@stryker-mutator/api": "^2.4.0",
-    "lodash.clonedeep": "^4.5.0",
     "tslib": "~1.10.0"
   },
   "peerDependencies": {

--- a/packages/javascript-mutator/src/helpers/NodeGenerator.ts
+++ b/packages/javascript-mutator/src/helpers/NodeGenerator.ts
@@ -1,16 +1,10 @@
 import * as types from '@babel/types';
 
 export class NodeGenerator {
-  public static createBooleanLiteralNode(originalNode: types.Node, value: boolean): types.BooleanLiteral {
+  public static createMutatedCloneWithProperties(originalNode: types.Node, props: { [key: string]: any }): types.Node {
     return {
-      end: originalNode.end,
-      innerComments: originalNode.innerComments,
-      leadingComments: originalNode.leadingComments,
-      loc: originalNode.loc,
-      start: originalNode.start,
-      trailingComments: originalNode.trailingComments,
-      type: 'BooleanLiteral',
-      value
+      ...originalNode,
+      ...props
     };
   }
 }

--- a/packages/javascript-mutator/src/helpers/copy.ts
+++ b/packages/javascript-mutator/src/helpers/copy.ts
@@ -1,3 +1,0 @@
-import cloneDeep = require('lodash.clonedeep');
-
-export default <T>(obj: T, deep?: boolean) => (deep ? cloneDeep(obj) : { ...obj });

--- a/packages/javascript-mutator/src/mutators/ArithmeticOperatorMutator.ts
+++ b/packages/javascript-mutator/src/mutators/ArithmeticOperatorMutator.ts
@@ -1,5 +1,7 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
 import { NodeMutator } from './NodeMutator';
 
 export default class ArithmeticOperatorMutator implements NodeMutator {
@@ -13,7 +15,7 @@ export default class ArithmeticOperatorMutator implements NodeMutator {
 
   public name = 'ArithmeticOperator';
 
-  public mutate(node: types.Node, clone: <T extends types.Node>(node: T, deep?: boolean) => T): types.Node[] {
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
     if (types.isBinaryExpression(node)) {
       let mutatedOperators = this.operators[node.operator];
       if (mutatedOperators) {
@@ -21,11 +23,10 @@ export default class ArithmeticOperatorMutator implements NodeMutator {
           mutatedOperators = [mutatedOperators];
         }
 
-        return mutatedOperators.map<types.Node>(mutatedOperator => {
-          const mutatedNode = clone(node);
-          mutatedNode.operator = mutatedOperator as any;
-          return mutatedNode;
-        });
+        return mutatedOperators.map(mutatedOperator => [
+          node,
+          NodeGenerator.createMutatedCloneWithProperties(node, { operator: mutatedOperator as any })
+        ]);
       }
     }
 

--- a/packages/javascript-mutator/src/mutators/ArrayDeclarationMutator.ts
+++ b/packages/javascript-mutator/src/mutators/ArrayDeclarationMutator.ts
@@ -8,19 +8,20 @@ import { NodeMutator } from './NodeMutator';
 export default class ArrayDeclarationMutator implements NodeMutator {
   public name = 'ArrayDeclaration';
 
-  public mutate(node: types.Node, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] {
-    const nodes: types.Node[] = [];
-
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
     if (types.isArrayExpression(node)) {
-      const mutatedNode = copy(node);
-      mutatedNode.elements = node.elements.length ? [] : [types.stringLiteral('Stryker was here')];
-      nodes.push(mutatedNode);
+      return [
+        // replace [...]
+        node.elements.length
+          ? [node, { raw: '[]' }] // raw string here
+          : [node, { raw: '["Stryker was here"]' }]
+      ];
     } else if ((types.isCallExpression(node) || types.isNewExpression(node)) && types.isIdentifier(node.callee) && node.callee.name === 'Array') {
-      const mutatedNode = copy(node);
-      mutatedNode.arguments = node.arguments.length ? [] : [types.arrayExpression()];
-      nodes.push(mutatedNode);
+      const newPrefix = types.isNewExpression(node) ? 'new ' : '';
+      const mutatedCallArgs = node.arguments && node.arguments.length ? '' : '[]';
+      return [[node, { raw: `${newPrefix}Array(${mutatedCallArgs})` }]];
+    } else {
+      return [];
     }
-
-    return nodes;
   }
 }

--- a/packages/javascript-mutator/src/mutators/ArrowFunctionMutator.ts
+++ b/packages/javascript-mutator/src/mutators/ArrowFunctionMutator.ts
@@ -1,0 +1,16 @@
+import * as types from '@babel/types';
+
+import { NodeMutator } from './NodeMutator';
+
+/**
+ * Represents a mutator which can remove the content of a Object.
+ */
+export default class ArrowFunctionMutator implements NodeMutator {
+  public name = 'ArrowFunction';
+
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
+    return types.isArrowFunctionExpression(node) && !types.isBlockStatement(node.body)
+      ? [[node, { raw: '() => undefined' }]] // raw string replacement
+      : [];
+  }
+}

--- a/packages/javascript-mutator/src/mutators/BlockStatementMutator.ts
+++ b/packages/javascript-mutator/src/mutators/BlockStatementMutator.ts
@@ -1,5 +1,7 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
 import { NodeMutator } from './NodeMutator';
 
 /**
@@ -8,15 +10,11 @@ import { NodeMutator } from './NodeMutator';
 export default class BlockStatementMutator implements NodeMutator {
   public name = 'BlockStatement';
 
-  public mutate(node: types.Node, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] {
-    const nodes: types.Node[] = [];
-
-    if (types.isBlockStatement(node) && node.body.length > 0) {
-      const mutatedNode = copy(node);
-      mutatedNode.body = [];
-      nodes.push(mutatedNode);
-    }
-
-    return nodes;
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
+    return types.isBlockStatement(node) && node.body.length > 0
+      ? [
+          [node, NodeGenerator.createMutatedCloneWithProperties(node, { body: [] })] // `{}`
+        ]
+      : [];
   }
 }

--- a/packages/javascript-mutator/src/mutators/BooleanLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/BooleanLiteralMutator.ts
@@ -1,5 +1,7 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
 import { NodeMutator } from './NodeMutator';
 
 export default class BooleanLiteralMutator implements NodeMutator {
@@ -7,20 +9,14 @@ export default class BooleanLiteralMutator implements NodeMutator {
 
   private readonly unaryBooleanPrefix = '!';
 
-  public mutate(node: types.Node, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] {
-    const nodes: types.Node[] = [];
-
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
     // true -> false or false -> true
     if (types.isBooleanLiteral(node)) {
-      const mutatedNode = copy(node);
-      mutatedNode.value = !mutatedNode.value;
-      nodes.push(mutatedNode);
+      return [[node, NodeGenerator.createMutatedCloneWithProperties(node, { value: !node.value })]];
     } else if (types.isUnaryExpression(node) && node.operator === this.unaryBooleanPrefix && node.prefix) {
-      const mutatedNode = copy(node.argument);
-      mutatedNode.start = node.start;
-      nodes.push(mutatedNode);
+      return [[node, node.argument]];
     }
 
-    return nodes;
+    return [];
   }
 }

--- a/packages/javascript-mutator/src/mutators/EqualityOperatorMutator.ts
+++ b/packages/javascript-mutator/src/mutators/EqualityOperatorMutator.ts
@@ -1,5 +1,7 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
 import { NodeMutator } from './NodeMutator';
 
 export default class EqualityOperatorMutator implements NodeMutator {
@@ -16,7 +18,7 @@ export default class EqualityOperatorMutator implements NodeMutator {
 
   public name = 'EqualityOperator';
 
-  public mutate(node: types.Node, clone: <T extends types.Node>(node: T, deep?: boolean) => T): types.Node[] {
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
     if (types.isBinaryExpression(node)) {
       let mutatedOperators = this.operators[node.operator];
       if (mutatedOperators) {
@@ -24,11 +26,10 @@ export default class EqualityOperatorMutator implements NodeMutator {
           mutatedOperators = [mutatedOperators];
         }
 
-        return mutatedOperators.map<types.Node>(mutatedOperator => {
-          const mutatedNode = clone(node);
-          mutatedNode.operator = mutatedOperator as any;
-          return mutatedNode;
-        });
+        return mutatedOperators.map(mutatedOperator => [
+          node,
+          NodeGenerator.createMutatedCloneWithProperties(node, { operator: mutatedOperator as any })
+        ]);
       }
     }
 

--- a/packages/javascript-mutator/src/mutators/LogicalOperatorMutator.ts
+++ b/packages/javascript-mutator/src/mutators/LogicalOperatorMutator.ts
@@ -1,5 +1,7 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
 import { NodeMutator } from './NodeMutator';
 
 export default class LogicalOperatorMutator implements NodeMutator {
@@ -10,7 +12,7 @@ export default class LogicalOperatorMutator implements NodeMutator {
 
   public name = 'LogicalOperator';
 
-  public mutate(node: types.Node, clone: <T extends types.Node>(node: T, deep?: boolean) => T): types.Node[] {
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
     if (types.isLogicalExpression(node)) {
       let mutatedOperators = this.operators[node.operator];
       if (mutatedOperators) {
@@ -18,11 +20,10 @@ export default class LogicalOperatorMutator implements NodeMutator {
           mutatedOperators = [mutatedOperators];
         }
 
-        return mutatedOperators.map<types.Node>(mutatedOperator => {
-          const mutatedNode = clone(node);
-          mutatedNode.operator = mutatedOperator as any;
-          return mutatedNode;
-        });
+        return mutatedOperators.map(mutatedOperator => [
+          node,
+          NodeGenerator.createMutatedCloneWithProperties(node, { operator: mutatedOperator as any })
+        ]);
       }
     }
 

--- a/packages/javascript-mutator/src/mutators/NodeMutator.ts
+++ b/packages/javascript-mutator/src/mutators/NodeMutator.ts
@@ -15,11 +15,16 @@ export interface NodeMutator {
    * Applies the Mutator to a Node. This can result in one or more mutated Nodes, or null if no mutation was applied.
    * This method will be called on every node of the abstract syntax tree,
    * implementing mutators should decide themselves if they want to mutate this specific node.
-   * If the mutator wants to mutate the node, it should return a clone of the node with mutations,
-   * otherwise null.
+   *
+   * If the mutator wants to mutate the node, it should return a array of mutated nodes,
+   * as an array of tuples that specify which node is replaced and
+   * what it should be replaced with (may be a raw string);
+   * otherwise an empty array.
+   *
+   * A mutated node may be based on a clone of the original node or just a brand new node.
+   *
    * @param node A FROZEN Node which could be cloned and mutated.
-   * @param copy A function to create a copy of an object.
-   * @returns An array of mutated Nodes.
+   * @returns An array of mutations, as tuples.
    */
-  mutate(node: NodeWithParent, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[];
+  mutate(node: NodeWithParent): Array<[types.Node, types.Node | { raw: string }]>;
 }

--- a/packages/javascript-mutator/src/mutators/ObjectLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/ObjectLiteralMutator.ts
@@ -8,15 +8,9 @@ import { NodeMutator } from './NodeMutator';
 export default class ObjectLiteralMutator implements NodeMutator {
   public name = 'ObjectLiteral';
 
-  public mutate(node: types.Node, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] {
-    const nodes: types.Node[] = [];
-
-    if (types.isObjectExpression(node) && node.properties.length > 0) {
-      const mutatedNode = copy(node);
-      mutatedNode.properties = [];
-      nodes.push(mutatedNode);
-    }
-
-    return nodes;
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
+    return types.isObjectExpression(node) && node.properties.length > 0
+      ? [[node, { raw: '{}' }]] // raw string replacement
+      : [];
   }
 }

--- a/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
+++ b/packages/javascript-mutator/src/mutators/StringLiteralMutator.ts
@@ -7,27 +7,21 @@ import { NodeMutator } from './NodeMutator';
 export default class StringLiteralMutator implements NodeMutator {
   public name = 'StringLiteral';
 
-  public mutate(node: NodeWithParent, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] {
-    const nodes: types.Node[] = [];
-
+  public mutate(node: NodeWithParent): Array<[types.Node, types.Node | { raw: string }]> {
     if (types.isTemplateLiteral(node)) {
-      nodes.push({
-        end: node.end,
-        innerComments: node.innerComments,
-        leadingComments: node.leadingComments,
-        loc: node.loc,
-        start: node.start,
-        trailingComments: node.trailingComments,
-        type: 'StringLiteral',
-        value: node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? 'Stryker was here!' : ''
-      } as types.StringLiteral);
+      return [
+        [
+          node,
+          {
+            raw: node.quasis.length === 1 && node.quasis[0].value.raw.length === 0 ? '"Stryker was here!"' : '""'
+          }
+        ]
+      ];
     } else if ((!node.parent || this.isDeclarationOrJSX(node.parent)) && types.isStringLiteral(node)) {
-      const mutatedNode = copy(node);
-      mutatedNode.value = mutatedNode.value.length === 0 ? 'Stryker was here!' : '';
-      nodes.push(mutatedNode);
+      return [[node, { raw: node.value.length === 0 ? '"Stryker was here!"' : '""' }]];
+    } else {
+      return [];
     }
-
-    return nodes;
   }
 
   private isDeclarationOrJSX(parent?: types.Node) {

--- a/packages/javascript-mutator/src/mutators/UnaryOperatorMutator.ts
+++ b/packages/javascript-mutator/src/mutators/UnaryOperatorMutator.ts
@@ -1,5 +1,7 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
 import { NodeMutator } from './NodeMutator';
 
 export default class UnaryOperatorMutator implements NodeMutator {
@@ -11,21 +13,13 @@ export default class UnaryOperatorMutator implements NodeMutator {
     '~': ''
   };
 
-  public mutate(node: types.Node, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] {
-    const nodes: types.Node[] = [];
-
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
     if (types.isUnaryExpression(node) && this.operators[node.operator] !== undefined && node.prefix) {
-      if (this.operators[node.operator].length > 0) {
-        const mutatedNode = copy(node);
-        mutatedNode.operator = this.operators[node.operator] as any;
-        nodes.push(mutatedNode);
-      } else {
-        const mutatedNode = copy(node.argument);
-        mutatedNode.start = node.start;
-        nodes.push(mutatedNode);
-      }
+      return this.operators[node.operator].length > 0
+        ? [[node, NodeGenerator.createMutatedCloneWithProperties(node, { operator: this.operators[node.operator] as any })]]
+        : [[node, node.argument]];
     }
 
-    return nodes;
+    return [];
   }
 }

--- a/packages/javascript-mutator/src/mutators/UpdateOperatorMutator.ts
+++ b/packages/javascript-mutator/src/mutators/UpdateOperatorMutator.ts
@@ -1,5 +1,7 @@
 import * as types from '@babel/types';
 
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
 import { NodeMutator } from './NodeMutator';
 
 export default class UpdateOperatorMutator implements NodeMutator {
@@ -10,15 +12,9 @@ export default class UpdateOperatorMutator implements NodeMutator {
     '--': '++'
   };
 
-  public mutate(node: types.Node, copy: <T extends types.Node>(obj: T, deep?: boolean) => T): types.Node[] {
-    const nodes: types.Node[] = [];
-
-    if (types.isUpdateExpression(node) && this.operators[node.operator] !== undefined) {
-      const mutatedNode = copy(node);
-      mutatedNode.operator = this.operators[node.operator] as any;
-      nodes.push(mutatedNode);
-    }
-
-    return nodes;
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
+    return types.isUpdateExpression(node) && this.operators[node.operator] !== undefined
+      ? [[node, NodeGenerator.createMutatedCloneWithProperties(node, { operator: this.operators[node.operator] as any })]]
+      : [];
   }
 }

--- a/packages/javascript-mutator/src/mutators/index.ts
+++ b/packages/javascript-mutator/src/mutators/index.ts
@@ -1,5 +1,6 @@
 import ArithmeticOperatorMutator from './ArithmeticOperatorMutator';
 import ArrayDeclarationMutator from './ArrayDeclarationMutator';
+import ArrowFunctionMutator from './ArrowFunctionMutator';
 import BlockStatementMutator from './BlockStatementMutator';
 import BooleanLiteralMutator from './BooleanLiteralMutator';
 import ConditionalExpressionMutator from './ConditionalExpressionMutator';
@@ -13,6 +14,7 @@ import UpdateOperatorMutator from './UpdateOperatorMutator';
 export const nodeMutators = Object.freeze([
   new ArithmeticOperatorMutator(),
   new ArrayDeclarationMutator(),
+  new ArrowFunctionMutator(),
   new BlockStatementMutator(),
   new BooleanLiteralMutator(),
   new ConditionalExpressionMutator(),

--- a/packages/javascript-mutator/test/unit/JavaScriptMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/JavaScriptMutator.spec.ts
@@ -126,7 +126,7 @@ describe('JavaScriptMutator', () => {
 
     const mutants = mutator.mutate(files);
 
-    expect(mutants.length).to.equal(5);
+    expect(mutants.length).to.equal(6);
     expect(mutants).to.deep.include({
       fileName: 'testFile.js',
       mutatorName: 'ConditionalExpression',

--- a/packages/javascript-mutator/test/unit/mutators/ArrowFunctionMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/mutators/ArrowFunctionMutator.spec.ts
@@ -1,0 +1,6 @@
+import ArrowFunctionMutatorSpec from '@stryker-mutator/mutator-specification/src/ArrowFunctionMutatorSpec';
+
+import ArrowFunctionMutator from '../../../src/mutators/ArrowFunctionMutator';
+import { verifySpecification } from '../../helpers/mutatorAssertions';
+
+verifySpecification(ArrowFunctionMutatorSpec, ArrowFunctionMutator);


### PR DESCRIPTION
* JavaScript mutator code improvements
  - use raw string mutations *internally* whenever possible
  - generate some of the mutations as AST nodes from the Babel types API
  - use some ternaries
  - remove some intermediate const declarations no longer needed
  - remove a couple of internal utility functions no longer needed
* add Arrow Function Mutator for JavaScript (already supported by the existing TypeScript mutator)
* remove `lodash.clonedeep` from dependencies in packages/javascript-mutator/package.json

These improvements should help reduce the amount of consistency between the JavaScript and TypeScript mutators that I raised in #1893.

/cc @kmdrGroch