### PR TITLE
feat(Dashboard reporter): upload full html report by default

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -63,7 +63,7 @@
         "reportType": {
           "description": "Indicates wether to send a full report (inc. source code and mutant results) or only the mutation score.",
           "$ref": "#/definitions/reportType",
-          "default": "mutationScore"
+          "default": "full"
         }
       }
     },

--- a/packages/api/src/config/Config.ts
+++ b/packages/api/src/config/Config.ts
@@ -47,7 +47,7 @@ export default class Config implements StrykerOptions {
    */
   public dashboard: DashboardOptions = {
     baseUrl: 'https://dashboard.stryker-mutator.io/api/reports',
-    reportType: ReportType.MutationScore
+    reportType: ReportType.Full
   };
   public tempDirName: string = defaultTempDirName;
 

--- a/packages/api/test/unit/config/Config.spec.ts
+++ b/packages/api/test/unit/config/Config.spec.ts
@@ -40,7 +40,7 @@ describe('Config', () => {
       });
       const expected: DashboardOptions = {
         baseUrl: 'https://dashboard.stryker-mutator.io/api/reports',
-        reportType: ReportType.MutationScore,
+        reportType: ReportType.Full,
         project: 'my-pet-shop'
       };
       expect(sut.dashboard).deep.eq(expected);

--- a/packages/api/testResources/module/useCore.ts
+++ b/packages/api/testResources/module/useCore.ts
@@ -21,7 +21,7 @@ const optionsAllArgs: StrykerOptions = {
   transpilers: [],
   dashboard: {
     baseUrl: 'baseUrl',
-    reportType: ReportType.MutationScore,
+    reportType: ReportType.Full,
     module: 'module',
     project: 'project',
     version: 'version'


### PR DESCRIPTION
Uploads the entire source code of your app to the dashboard, in the form of a html report, by default because the default `reportType` for the dashboard reporter is now `full`. Switch to `mutationScore` to only update the score.

Fixes #2018 
