### PR TITLE
test(e2e): improve e2e stability

### DIFF
--- a/e2e/test/karma-jasmine/stryker.conf.js
+++ b/e2e/test/karma-jasmine/stryker.conf.js
@@ -9,7 +9,7 @@ module.exports = function (config) {
       config: {
         files: ['src/*.js', 'test/*.js'],
         client: {
-          clearContext: true
+          clearContext: false
         }
       }
     },

--- a/e2e/test/karma-jasmine/stryker.conf.js
+++ b/e2e/test/karma-jasmine/stryker.conf.js
@@ -7,7 +7,10 @@ module.exports = function (config) {
     maxConcurrentTestRunners: 2,
     karma: {
       config: {
-        files: ['src/*.js', 'test/*.js']
+        files: ['src/*.js', 'test/*.js'],
+        client: {
+          clearContext: true
+        }
       }
     },
     mutator: 'javascript'

--- a/e2e/test/karma-mocha/stryker.conf.js
+++ b/e2e/test/karma-mocha/stryker.conf.js
@@ -8,7 +8,10 @@ module.exports = function (config) {
     karma: {
       config: {
         frameworks: ['mocha', 'chai'],
-        files: ['src/*.js', 'test/*.js']
+        files: ['src/*.js', 'test/*.js'],
+        client: {
+          clearContext: false
+        }
       }
     },
     maxConcurrentTestRunners: 2,


### PR DESCRIPTION
Disable `client.clearContext` for karma e2e tests

Temporary fix for #2049