### PR TITLE
add `ignored: 0` to metrics factoryMethod in test-helpers

### DIFF
--- a/packages/test-helpers/src/factory.ts
+++ b/packages/test-helpers/src/factory.ts
@@ -85,6 +85,7 @@ export const metrics = factoryMethod<Metrics>(() => ({
   runtimeErrors: 0,
   survived: 0,
   timeout: 0,
+  ignored: 0,
   totalCovered: 0,
   totalDetected: 0,
   totalInvalid: 0,


### PR DESCRIPTION
should help fix one of the test failures