### PR TITLE
build(dev-deps): Downgrade eslint-plugin-import to 2.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cross-env": "^7.0.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.0",
-    "eslint-plugin-import": "2.20.1",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-prettier": "3.1.2",
     "execa": "^3.2.0",
     "glob": "^7.1.1",


### PR DESCRIPTION
Fixes eslint import order errors on Windows systems