### PR TITLE
chore(eslint): add `internal` group to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier', 'import'],
   rules: {
     'import/newline-after-import': 1,
-    'import/order': ["error", {"newlines-between": "always"}],
+    'import/order': ["error", { "newlines-between": "always", "groups": ["builtin", ["external", "internal"], "parent", "sibling", "index"] }],
     'prettier/prettier': ['error'],
     'sort-imports': 'off', // No auto-fix!
     'no-case-declarations': 'off',


### PR DESCRIPTION
Symlinked modules are now seen as `internal` imports (since latest eslint-plugin-import version). Add that to the eslint config.