### PR TITLE
feat: add regexp mutator

### DIFF
--- a/packages/javascript-mutator/src/mutators/RegExpMutator.ts
+++ b/packages/javascript-mutator/src/mutators/RegExpMutator.ts
@@ -1,0 +1,25 @@
+import * as types from '@babel/types';
+
+import { NodeMutator } from './NodeMutator';
+
+/**
+ * Represents a mutator which can mutate RegExp literal or constructor function call
+ */
+export default class RegExpMutator implements NodeMutator {
+  public name = 'RegExp';
+
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
+    if (types.isRegExpLiteral(node)) {
+      return [[node, { raw: "new RegExp('')" }]];
+    } else if ((types.isCallExpression(node) || types.isNewExpression(node)) && types.isIdentifier(node.callee) && node.callee.name === 'RegExp') {
+      const args = node.arguments;
+      return [
+        args && args.length && !(types.isStringLiteral(args[0]) && args[0].value.length == 0)
+          ? [node, { raw: "new RegExp('')" }]
+          : [node, { raw: '/Hello from Stryker/' }],
+      ];
+    } else {
+      return [];
+    }
+  }
+}

--- a/packages/javascript-mutator/src/mutators/index.ts
+++ b/packages/javascript-mutator/src/mutators/index.ts
@@ -8,6 +8,7 @@ import EqualityOperatorMutator from './EqualityOperatorMutator';
 import ObjectLiteralMutator from './ObjectLiteralMutator';
 import StringLiteralMutator from './StringLiteralMutator';
 import LogicalOperatorMutator from './LogicalOperatorMutator';
+import RegExpMutator from './RegExpMutator';
 import UnaryOperatorMutator from './UnaryOperatorMutator';
 import UpdateOperatorMutator from './UpdateOperatorMutator';
 
@@ -21,6 +22,7 @@ export const nodeMutators = Object.freeze([
   new EqualityOperatorMutator(),
   new LogicalOperatorMutator(),
   new ObjectLiteralMutator(),
+  new RegExpMutator(),
   new StringLiteralMutator(),
   new UnaryOperatorMutator(),
   new UpdateOperatorMutator(),

--- a/packages/javascript-mutator/test/unit/mutators/RegExpMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/mutators/RegExpMutator.spec.ts
@@ -1,4 +1,5 @@
-import { RegExpMutatorSpec } from '../../../../mutator-specification/src';
+import { RegExpMutatorSpec } from '@stryker-mutator/mutator-specification/src/index';
+
 import RegExpMutator from '../../../src/mutators/RegExpMutator';
 import { verifySpecification } from '../../helpers/mutatorAssertions';
 

--- a/packages/javascript-mutator/test/unit/mutators/RegExpMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/mutators/RegExpMutator.spec.ts
@@ -1,0 +1,5 @@
+import { RegExpMutatorSpec } from '../../../../mutator-specification/src';
+import RegExpMutator from '../../../src/mutators/RegExpMutator';
+import { verifySpecification } from '../../helpers/mutatorAssertions';
+
+verifySpecification(RegExpMutatorSpec, RegExpMutator);

--- a/packages/mutator-specification/src/RegExpMutatorSpec.ts
+++ b/packages/mutator-specification/src/RegExpMutatorSpec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+
+import ExpectMutation from './ExpectMutation';
+
+export default function RegExpMutatorSpec(name: string, expectMutation: ExpectMutation) {
+  describe('RegExpMutator', () => {
+    it('should have name "RegExp"', () => {
+      expect(name).eq('RegExp');
+    });
+
+    it('should mutate each filled RegExp literal as an empty regex', () => {
+      expectMutation('/hello/g', "new RegExp('')");
+      expectMutation('/$^/', "new RegExp('')");
+    });
+
+    it('should mutate filled RegExp constructor calls as empty arrays', () => {
+      expectMutation('new RegExp(a, b)', "new RegExp('')");
+      expectMutation("new RegExp('val')", "new RegExp('')");
+      expectMutation("RegExp('val')", "new RegExp('')");
+      expectMutation('RegExp(a, b)', "new RegExp('')");
+    });
+
+    it('should mutate empty array constructor call as a filled array', () => {
+      expectMutation('new RegExp()', '/Hello from Stryker/');
+      expectMutation('RegExp()', '/Hello from Stryker/');
+    });
+
+    it('should not mutate other function call expressions', () => {
+      expectMutation('window.RegExp(21, 2)');
+      expectMutation('window["RegExp"](21, 2)');
+    });
+  });
+}

--- a/packages/mutator-specification/src/index.ts
+++ b/packages/mutator-specification/src/index.ts
@@ -7,6 +7,7 @@ export { default as ConditionalExpressionMutatorSpec } from './ConditionalExpres
 export { default as EqualityOperatorMutatorSpec } from './EqualityOperatorMutatorSpec';
 export { default as LogicalOperatorMutatorSpec } from './LogicalOperatorMutatorSpec';
 export { default as ObjectLiteralMutatorSpec } from './ObjectLiteralMutatorSpec';
+export { default as RegExpMutatorSpec } from './RegExpMutatorSpec';
 export { default as StringLiteralMutatorSpec } from './StringLiteralMutatorSpec';
 export { default as UnaryOperatorMutatorSpec } from './UnaryOperatorMutatorSpec';
 export { default as UpdateOperatorMutatorSpec } from './UpdateOperatorMutatorSpec';

--- a/packages/typescript/src/mutator/RegExpMutator.ts
+++ b/packages/typescript/src/mutator/RegExpMutator.ts
@@ -1,0 +1,35 @@
+import * as ts from 'typescript';
+
+import NodeMutator, { NodeReplacement } from './NodeMutator';
+
+export default class RegExpMutator extends NodeMutator<ts.RegularExpressionLiteral | ts.CallExpression | ts.NewExpression> {
+  public name = 'RegExp';
+
+  public guard(node: ts.Node): node is ts.RegularExpressionLiteral | ts.CallExpression | ts.NewExpression {
+    return (
+      node.kind === ts.SyntaxKind.RegularExpressionLiteral || node.kind === ts.SyntaxKind.CallExpression || node.kind === ts.SyntaxKind.NewExpression
+    );
+  }
+
+  protected identifyReplacements(
+    node: ts.RegularExpressionLiteral | ts.CallExpression | ts.NewExpression,
+    sourceFile: ts.SourceFile
+  ): NodeReplacement[] {
+    if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {
+      return [{ node, replacement: "new RegExp('')" }];
+    } else if (node.kind === ts.SyntaxKind.CallExpression && node.expression.kind !== ts.SyntaxKind.Identifier) {
+      // extra guard in case of a function call expression
+      return [];
+    } else {
+      if (node.expression.getFullText(sourceFile).trim() === 'RegExp') {
+        return node.arguments &&
+          node.arguments.length &&
+          !(node.arguments[0].kind === ts.SyntaxKind.StringLiteral && (node.arguments[0] as ts.StringLiteral).text === '')
+          ? [{ node, replacement: "new RegExp('')" }]
+          : [{ node, replacement: '/Hello from Stryker/' }];
+      } else {
+        return [];
+      }
+    }
+  }
+}

--- a/packages/typescript/src/mutator/index.ts
+++ b/packages/typescript/src/mutator/index.ts
@@ -8,6 +8,7 @@ import EqualityOperatorMutator from './EqualityOperatorMutator';
 import ObjectLiteralMutator from './ObjectLiteralMutator';
 import StringLiteralMutator from './StringLiteralMutator';
 import LogicalOperatorMutator from './LogicalOperatorMutator';
+import RegExpMutator from './RegExpMutator';
 import UnaryOperatorMutator from './UnaryOperatorMutator';
 import UpdateOperatorMutator from './UpdateOperatorMutator';
 import NodeMutator from './NodeMutator';
@@ -21,6 +22,7 @@ export const nodeMutators: readonly NodeMutator[] = [
   new EqualityOperatorMutator(),
   new LogicalOperatorMutator(),
   new ObjectLiteralMutator(),
+  new RegExpMutator(),
   new StringLiteralMutator(),
   new UnaryOperatorMutator(),
   new UpdateOperatorMutator(),

--- a/packages/typescript/test/unit/mutator/RegExpMutator.spec.ts
+++ b/packages/typescript/test/unit/mutator/RegExpMutator.spec.ts
@@ -1,0 +1,6 @@
+import { RegExpMutatorSpec } from '../../../../mutator-specification/src';
+import RegExpMutator from '../../../src/mutator/RegExpMutator';
+
+import { verifySpecification } from './mutatorAssertions';
+
+verifySpecification(RegExpMutatorSpec, RegExpMutator);

--- a/packages/typescript/test/unit/mutator/RegExpMutator.spec.ts
+++ b/packages/typescript/test/unit/mutator/RegExpMutator.spec.ts
@@ -1,4 +1,5 @@
-import { RegExpMutatorSpec } from '../../../../mutator-specification/src';
+import { RegExpMutatorSpec } from '@stryker-mutator/mutator-specification/src/index';
+
 import RegExpMutator from '../../../src/mutator/RegExpMutator';
 
 import { verifySpecification } from './mutatorAssertions';


### PR DESCRIPTION
In parallel to the Array literal mutator and string literal mutator, I would like to propose a RegExp mutator that mutates regex literals and RegExp constructor function calls to help ensure that use of expressions is properly tested.

In case of a non-empty regexp such as `/my-pattern/`, `/my-pattern/g`, `new RegExp('my-pattern')`, or `RegExp(argument)`, mutate as: `new RegExp('')`

In case of an empty regexp such as `new RegExp()` or `RegExp('')`, mutate as: `/Hello from Stryker/`

I hope I do not offend anyone by raising this proposal as a PR. My idea is that the implementation should hopefully explain exactly what I think we should do.

I would like to leave it open for discussion whether or not there is anything we should do with regex flags.

P.S. TODO item is to:

- [ ] document this in the Stryker Handbook, if it will be accepted.

P.S. 2: I would strongly favor getting this proposal merged in a single squash commit, if accepted.