### PR TITLE
feat: add object shorthand property mutator

### DIFF
--- a/packages/javascript-mutator/src/mutators/ObjectShorthandPropertyMutator.ts
+++ b/packages/javascript-mutator/src/mutators/ObjectShorthandPropertyMutator.ts
@@ -1,0 +1,23 @@
+import * as types from '@babel/types';
+
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
+import { NodeMutator } from './NodeMutator';
+
+/**
+ * Represents a mutator which can mutate an object shorthand property.
+ */
+export default class ObjectShorthandPropertyMutator implements NodeMutator {
+  public name = 'ObjectShorthandProperty';
+
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
+    return types.isObjectExpression(node)
+      ? node.properties
+          .filter((prop) => types.isObjectProperty(prop) && prop.shorthand)
+          .map((mutateProp) => [
+            node,
+            NodeGenerator.createMutatedCloneWithProperties(node, { properties: node.properties.filter((prop) => prop !== mutateProp) }),
+          ])
+      : [];
+  }
+}

--- a/packages/javascript-mutator/test/unit/mutators/ObjectShorthandPropertyMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/mutators/ObjectShorthandPropertyMutator.spec.ts
@@ -1,0 +1,6 @@
+import { ObjectShorthandPropertyMutatorSpec } from '@stryker-mutator/mutator-specification/src/index';
+
+import ObjectShorthandPropertyMutator from '../../../src/mutators/ObjectShorthandPropertyMutator';
+import { verifySpecification } from '../../helpers/mutatorAssertions';
+
+verifySpecification(ObjectShorthandPropertyMutatorSpec, ObjectShorthandPropertyMutator);

--- a/packages/mutator-specification/src/ObjectShorthandPropertyMutatorSpec.ts
+++ b/packages/mutator-specification/src/ObjectShorthandPropertyMutatorSpec.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+
+import ExpectMutation from './ExpectMutation';
+
+export default function ObjectShorthandPropertyMutatorSpec(name: string, expectMutation: ExpectMutation) {
+  describe('ObjectShorthandPropertyMutator', () => {
+    it('should have name "ObjectShorthandProperty"', () => {
+      expect(name).eq('ObjectShorthandProperty');
+    });
+
+    it('should mutate a single object shorthand property', () => {
+      expectMutation('const o = { bar }', 'const o = {}');
+    });
+
+    it('should mutate multiple object shorthand properties', () => {
+      expectMutation('const o = { bar, baz }', 'const o = { baz }', 'const o = { bar }');
+    });
+
+    it('should only mutate an object shorthand property', () => {
+      expectMutation('const o = { bar, baz: "qux" }', 'const o = { baz: "qux" }');
+    });
+
+    it('shoud not mutate empty object declarations', () => {
+      expectMutation('const o = {}');
+    });
+  });
+}

--- a/packages/mutator-specification/src/index.ts
+++ b/packages/mutator-specification/src/index.ts
@@ -7,6 +7,7 @@ export { default as ConditionalExpressionMutatorSpec } from './ConditionalExpres
 export { default as EqualityOperatorMutatorSpec } from './EqualityOperatorMutatorSpec';
 export { default as LogicalOperatorMutatorSpec } from './LogicalOperatorMutatorSpec';
 export { default as ObjectLiteralMutatorSpec } from './ObjectLiteralMutatorSpec';
+export { default as ObjectShorthandPropertyMutatorSpec } from './ObjectShorthandPropertyMutatorSpec';
 export { default as StringLiteralMutatorSpec } from './StringLiteralMutatorSpec';
 export { default as UnaryOperatorMutatorSpec } from './UnaryOperatorMutatorSpec';
 export { default as UpdateOperatorMutatorSpec } from './UpdateOperatorMutatorSpec';


### PR DESCRIPTION
As I said before, I have been using Stryker pretty heavily and happily in my create-react-native-module utility. I have discovered a few cases over the past year where there were object properties that were simply not needed, sometimes because of functionality removed and sometimes for other reasons. Yes I am the one to be held responsible but think it should be possible for Stryker to help find cases like this.

In short, this is a proposal to try removing shorthand object properties, for example:

- `{ bar, baz: "quz" }` --> `{ baz: "quz" }`

Here are a couple of cleanup fixes that could have been discovered by using this proposal:

- <https://github.com/brodybits/create-react-native-module/pull/276>
- <https://github.com/brodybits/create-react-native-module/pull/328>

I made this proposal on the JavaScript mutator only, would be happy to take a look into the TypeScript version in case there is any interest. I do think it would be ideal to consider using @typescript/eslint-parser which should let us work with the TypeScript parser without having to maintain multiple implementations of the ES mutators.

TODO items __updated__:

- [x] ensure the CI build is green (yes I did check lint & test in my workarea)
- [ ] consider looking for a more succinct name
- [ ] consider if and how this could potentially overlap with other mutations and what we can do
- [ ] add implementation for TypeScript mutator
- [ ] update Stryker Handbook

P.S. I would highly recommend a squash commit merge in case this proposal is accepted.