### PR TITLE
feat: add arrow function property mutator

### DIFF
--- a/packages/javascript-mutator/src/mutators/ArrowFunctionPropertyMutator.ts
+++ b/packages/javascript-mutator/src/mutators/ArrowFunctionPropertyMutator.ts
@@ -1,0 +1,25 @@
+import * as types from '@babel/types';
+
+import { NodeGenerator } from '../helpers/NodeGenerator';
+
+import { NodeMutator } from './NodeMutator';
+
+/**
+ * Represents a mutator which can mutate an object shorthand property.
+ */
+export default class ArrowFunctionPropertyMutator implements NodeMutator {
+  public name = 'ArrowFunctionProperty';
+
+  public mutate(node: types.Node): Array<[types.Node, types.Node | { raw: string }]> {
+    return types.isObjectPattern(node)
+      ? node.properties
+          .filter((prop) => types.isObjectProperty(prop) && prop.shorthand)
+          .map((mutateProp) => [
+            node,
+            NodeGenerator.createMutatedCloneWithProperties(node, {
+              properties: node.properties.filter((prop) => prop !== mutateProp),
+            }),
+          ])
+      : [];
+  }
+}

--- a/packages/javascript-mutator/src/mutators/index.ts
+++ b/packages/javascript-mutator/src/mutators/index.ts
@@ -1,6 +1,7 @@
 import ArithmeticOperatorMutator from './ArithmeticOperatorMutator';
 import ArrayDeclarationMutator from './ArrayDeclarationMutator';
 import ArrowFunctionMutator from './ArrowFunctionMutator';
+import ArrowFunctionPropertyMutator from './ArrowFunctionPropertyMutator';
 import BlockStatementMutator from './BlockStatementMutator';
 import BooleanLiteralMutator from './BooleanLiteralMutator';
 import ConditionalExpressionMutator from './ConditionalExpressionMutator';
@@ -15,6 +16,7 @@ export const nodeMutators = Object.freeze([
   new ArithmeticOperatorMutator(),
   new ArrayDeclarationMutator(),
   new ArrowFunctionMutator(),
+  new ArrowFunctionPropertyMutator(),
   new BlockStatementMutator(),
   new BooleanLiteralMutator(),
   new ConditionalExpressionMutator(),

--- a/packages/javascript-mutator/test/unit/mutators/ArrowFunctionPropertyMutator.spec.ts
+++ b/packages/javascript-mutator/test/unit/mutators/ArrowFunctionPropertyMutator.spec.ts
@@ -1,0 +1,6 @@
+import ArrowFunctionPropertyMutatorSpec from '@stryker-mutator/mutator-specification/src/ArrowFunctionPropertyMutatorSpec';
+
+import ArrowFunctionPropertyMutator from '../../../src/mutators/ArrowFunctionPropertyMutator';
+import { verifySpecification } from '../../helpers/mutatorAssertions';
+
+verifySpecification(ArrowFunctionPropertyMutatorSpec, ArrowFunctionPropertyMutator);

--- a/packages/mutator-specification/src/ArrowFunctionPropertyMutatorSpec.ts
+++ b/packages/mutator-specification/src/ArrowFunctionPropertyMutatorSpec.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+
+import ExpectMutation from './ExpectMutation';
+
+export default function ArrowFunctionPropertyMutatorSpec(name: string, expectMutation: ExpectMutation) {
+  describe('ArrowFunctionPropertyMutator', () => {
+    it('should have name "ArrowFunctionProperty"', () => {
+      expect(name).eq('ArrowFunctionProperty');
+    });
+
+    it('should mutate a single object property in an arrow function expression', () => {
+      expectMutation('({ bar }) => baz', '({}) => baz');
+    });
+
+    it('should mutate multiple object shorthand properties in an arrow function expression', () => {
+      expectMutation('({ bar, baz = "qux" }) => baz', '({ baz = "qux" }) => baz', '({ bar }) => baz');
+    });
+
+    it('shoud not mutate empty properties in an arrow function expression', () => {
+      expectMutation('({}) => baz');
+    });
+  });
+}

--- a/packages/mutator-specification/src/index.ts
+++ b/packages/mutator-specification/src/index.ts
@@ -1,6 +1,7 @@
 export { default as ArithmeticOperatorMutatorSpec } from './ArithmeticOperatorMutatorSpec';
 export { default as ArrayDeclarationMutatorSpec } from './ArrayDeclarationMutatorSpec';
 export { default as ArrowFunctionMutatorSpec } from './ArrowFunctionMutatorSpec';
+export { default as ArrowFunctionPropertyMutatorSpec } from './ArrowFunctionPropertyMutatorSpec';
 export { default as BlockStatementMutatorSpec } from './BlockStatementMutatorSpec';
 export { default as BooleanLiteralMutatorSpec } from './BooleanLiteralMutatorSpec';
 export { default as ConditionalExpressionMutatorSpec } from './ConditionalExpressionMutatorSpec';


### PR DESCRIPTION
Similar to my proposal in #2175 - mutate arrow function properties, for example:

- `({ bar }) => baz` --> `({}) => baz`
- `({ bar, baz = "qux" }) => baz` -->
  - `({ baz = "qux" }) => baz`
  - `({ bar }) => baz`

This proposal could have automatically discovered the following opportunities for cleanup fixes:

- https://github.com/brodybits/create-react-native-module/pull/329
- https://github.com/brodybits/create-react-native-module/pull/330

I have only made this on the JavaScript mutator, would be happy to look into the TypeScript version if there is interest in this proposal.

Some TODO items in case of interest in this proposal:

- [ ] ensure the CI build is green
- [ ] consider looking for a more succinct name
 - [ ] consider if and how this could potentially overlap with other mutations and what we can do
 - [ ] add implementation for TypeScript mutator
 - [ ] update Stryker Handbook

I do think this proposal should be merged in a squash commit, if accepted.