### PR TITLE
fix(karma-runner): mocha filtering with `/`

### DIFF
--- a/packages/karma-runner/src/karma-plugins/TestHooksMiddleware.ts
+++ b/packages/karma-runner/src/karma-plugins/TestHooksMiddleware.ts
@@ -4,7 +4,7 @@ import * as url from 'url';
 import { RequestHandler } from 'express';
 import { CoverageAnalysis } from '@stryker-mutator/api/core';
 import { MutantRunOptions } from '@stryker-mutator/api/test_runner2';
-import { escapeRegExp } from '@stryker-mutator/util';
+import { escapeRegExpLiteral } from '@stryker-mutator/util';
 
 export const TEST_HOOKS_FILE_NAME = __filename;
 
@@ -62,7 +62,7 @@ export default class TestHooksMiddleware {
           }})`;
           break;
         case 'mocha':
-          const metaRegExp = testFilter.map((testId) => `(${escapeRegExp(testId)})`).join('|');
+          const metaRegExp = testFilter.map((testId) => `(${escapeRegExpLiteral(testId)})`).join('|');
           this.currentTestHooks += `mocha.grep(/${metaRegExp}/)`;
           break;
       }

--- a/packages/karma-runner/test/unit/karma-plugins/TestHooksMiddleware.spec.ts
+++ b/packages/karma-runner/test/unit/karma-plugins/TestHooksMiddleware.spec.ts
@@ -85,6 +85,15 @@ describe(TestHooksMiddleware.name, () => {
       sut.configureActiveMutant(factory.mutantRunOptions({ testFilter: ['foo.spec', 'bar?spec'] }));
       expect(sut.currentTestHooks).contains('mocha.grep(/(foo\\.spec)|(bar\\?spec)/)');
     });
+    it('should escape `/` in the regex literal', () => {
+      sut.configureTestFramework(['mocha']);
+      sut.configureActiveMutant(
+        factory.mutantRunOptions({ testFilter: ['MutationTestReportTotalsComponent should show N/A when no mutation score is available'] })
+      );
+      expect(sut.currentTestHooks).contains(
+        'mocha.grep(/(MutationTestReportTotalsComponent should show N\\/A when no mutation score is available)/)'
+      );
+    });
   });
 
   describe('handler', () => {

--- a/packages/util/src/stringUtils.ts
+++ b/packages/util/src/stringUtils.ts
@@ -21,6 +21,6 @@ export function propertyPath<T>(prop: keyof Pick<T, KnownKeys<T>>, prop2?: keyof
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
  */
-export function escapeRegExp(input: string) {
-  return input.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+export function escapeRegExpLiteral(input: string) {
+  return input.replace(/[.*+\-?^${}()|[\]\\/]/g, '\\$&'); // $& means the whole matched string
 }

--- a/packages/util/test/unit/stringUtils.spec.ts
+++ b/packages/util/test/unit/stringUtils.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { normalizeWhitespaces, propertyPath, escapeRegExp } from '../../src';
+import { normalizeWhitespaces, propertyPath, escapeRegExpLiteral } from '../../src';
 
 describe('stringUtils', () => {
   describe(normalizeWhitespaces.name, () => {
@@ -29,14 +29,14 @@ describe('stringUtils', () => {
     });
   });
 
-  describe(escapeRegExp.name, () => {
+  describe(escapeRegExpLiteral.name, () => {
     it('should return input if no special chars are found', () => {
-      expect(escapeRegExp('something normal')).eq('something normal');
+      expect(escapeRegExpLiteral('something normal')).eq('something normal');
     });
 
-    for (const letter of '.*+-?^${}()|[]\\') {
+    for (const letter of '.*+-?^${}()|[]\\/') {
       it(`should escape "${letter}"`, () => {
-        expect(escapeRegExp(letter)).eq(`\\${letter}`);
+        expect(escapeRegExpLiteral(letter)).eq(`\\${letter}`);
       });
     }
   });


### PR DESCRIPTION
When a test name contains a `/`, correctly escape it. Stryker blows up in your face without it.