### PR TITLE
fix(typescript-checker): support empty files

### DIFF
--- a/e2e/test/vue-cli-typescript-mocha/stryker.conf.json
+++ b/e2e/test/vue-cli-typescript-mocha/stryker.conf.json
@@ -8,6 +8,7 @@
   "testRunner": "mocha",
   "concurrency": 2,
   "coverageAnalysis": "perTest",
+  "symlinkNodeModules": false,
   "reporters": ["progress", "clear-text", "event-recorder"],
   "buildCommand": "webpack --config webpack.test.config.js",
   "mochaOptions": {
@@ -21,5 +22,8 @@
   "plugins": [
     "@stryker-mutator/mocha-runner",
     "@stryker-mutator/typescript-checker"
+  ],
+  "checkers": [
+    "typescript"
   ]
 }

--- a/e2e/test/vue-cli-typescript-mocha/verify/verify.ts
+++ b/e2e/test/vue-cli-typescript-mocha/verify/verify.ts
@@ -4,13 +4,13 @@ describe('Verify stryker has ran correctly', () => {
 
   it('should report correct score', async () => {
     await expectMetrics({
-      killed: 4,
+      killed: 2,
       survived: 1,
-      noCoverage: 12,
-      compileErrors: 0,
+      noCoverage: 11,
+      compileErrors: 3,
       runtimeErrors: 0,
       timeout: 0,
-      mutationScore: 23.53
+      mutationScore: 14.29
     });
   });
 });

--- a/packages/typescript-checker/src/fs/hybrid-file-system.ts
+++ b/packages/typescript-checker/src/fs/hybrid-file-system.ts
@@ -53,7 +53,7 @@ export class HybridFileSystem {
     fileName = toTSFileName(fileName);
     if (!this.files.has(fileName)) {
       let content = ts.sys.readFile(fileName);
-      if (content) {
+      if (typeof content === 'string') {
         let modifiedTime = ts.sys.getModifiedTime!(fileName)!;
         this.files.set(fileName, new ScriptFile(content, fileName, modifiedTime));
       } else {

--- a/packages/typescript-checker/test/unit/fs/hybrid-file-system.spec.ts
+++ b/packages/typescript-checker/test/unit/fs/hybrid-file-system.spec.ts
@@ -68,6 +68,15 @@ describe('fs', () => {
         expect(helper.getModifiedTimeStub).calledWith('test/foo/a.js');
       });
 
+      it('should support empty files', () => {
+        helper.readFileStub.returns('');
+        helper.getModifiedTimeStub.returns(new Date(2010, 1, 1));
+        const actual = sut.getFile('foo.js');
+        expect(actual).ok;
+        expect(actual!.fileName).eq('foo.js');
+        expect(actual!.content).eq('');
+      });
+
       it("should cache a file that doesn't exists", () => {
         sut.getFile('not-exists.js');
         sut.getFile('not-exists.js');


### PR DESCRIPTION
Fix for `inner error: TypeError: Cannot read property 'modifiedTime' of undefined` error.