### PR TITLE
fix(reporter): report event order

### DIFF
--- a/packages/core/src/reporters/MutationTestReportHelper.ts
+++ b/packages/core/src/reporters/MutationTestReportHelper.ts
@@ -57,8 +57,8 @@ export class MutationTestReportHelper {
 
   public reportAll(results: MutantResult[]) {
     const report = this.mutationTestReport(results);
-    this.reporter.onMutationTestReportReady(report);
     this.reporter.onAllMutantsTested(results);
+    this.reporter.onMutationTestReportReady(report);
     this.determineExitCode(report);
   }
 

--- a/packages/core/test/unit/reporters/MutationTestReportHelper.spec.ts
+++ b/packages/core/test/unit/reporters/MutationTestReportHelper.spec.ts
@@ -51,6 +51,16 @@ describe(MutationTestReportHelper.name, () => {
       expect(reporterMock.onMutationTestReportReady).calledOnce;
     });
 
+    it('should report "onAllMutantsTested"', () => {
+      sut.reportAll([]);
+      expect(reporterMock.onAllMutantsTested).calledOnce;
+    });
+
+    it('should report "onAllMutantsTested" before mutationTestReportReady', () => {
+      sut.reportAll([]);
+      expect(reporterMock.onAllMutantsTested).calledBefore(reporterMock.onMutationTestReportReady);
+    });
+
     it('should copy thresholds', () => {
       const actualReport = actReportAll();
       expect(actualReport.thresholds).eq(testInjector.options.thresholds);


### PR DESCRIPTION
Report `onAllMutantsTested` before `onMutationTestReportReady`