### PR TITLE
Clean up code - provide more accurate types, fix small issues

### DIFF
--- a/e2e/tasks/run-e2e-tests.ts
+++ b/e2e/tasks/run-e2e-tests.ts
@@ -4,7 +4,7 @@ import execa from 'execa';
 import * as semver from 'semver';
 import * as os from 'os';
 import { from, defer } from 'rxjs';
-import { tap, mergeAll, map, filter } from 'rxjs/operators';
+import { tap, mergeAll, map } from 'rxjs/operators';
 
 const testRootDir = path.resolve(__dirname, '..', 'test');
 
@@ -24,14 +24,10 @@ const mutationSwitchingTempWhiteList = [
 ]
 
 function runE2eTests() {
-  const testDirs = fs.readdirSync(testRootDir);
+  const testDirs = fs.readdirSync(testRootDir).filter(dir => fs.statSync(path.join(testRootDir, dir)).isDirectory()).filter(dir => mutationSwitchingTempWhiteList.includes(dir));
 
   // Create test$, an observable of test runs
-  const test$ = from(testDirs).pipe(
-    filter(dir => fs.statSync(path.join(testRootDir, dir)).isDirectory()),
-    filter(dir => mutationSwitchingTempWhiteList.includes(dir)),
-    map(testDir => defer(() => runTest(testDir)))
-  );
+  const test$ = from(testDirs).pipe(map(testDir => defer(() => runTest(testDir))));
 
   let testsRan = 0;
   return test$.pipe(

--- a/e2e/test/angular-project/stryker.conf.js
+++ b/e2e/test/angular-project/stryker.conf.js
@@ -17,7 +17,7 @@ module.exports = function (config) {
     },
     reporters: ['event-recorder'],
     coverageAnalysis: 'off',
-    maxConcurrentTestRunners: 1,
+    concurrency: 1,
     timeoutMS: 60000
   });
 };

--- a/e2e/test/command/stryker.conf.json
+++ b/e2e/test/command/stryker.conf.json
@@ -9,7 +9,7 @@
     "event-recorder"
   ],
   "mutator": "javascript",
-  "maxConcurrentTestRunners": 2,
+  "concurrency": 2,
   "commandRunner": {
     "command": "npm run mocha"
   },

--- a/e2e/test/exit-prematurely/stryker.conf.js
+++ b/e2e/test/exit-prematurely/stryker.conf.js
@@ -11,7 +11,7 @@ module.exports = {
   ],
   timeoutMS: 60000,
   reporters: ['clear-text', 'html', 'event-recorder'],
-  maxConcurrentTestRunners: 2,
+  concurrency: 2,
   logLevel: 'info',
   fileLogLevel: 'info'
 }

--- a/e2e/test/grunt-stryker-test/Gruntfile.js
+++ b/e2e/test/grunt-stryker-test/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function (grunt) {
           testFramework: 'jasmine',
           testRunner: 'karma',
           logLevel: 'info',
-          maxConcurrentTestRunners: 2,
+          concurrency: 2,
           tempDirName: '.stryker-tmp-2'
         },
       },

--- a/e2e/test/grunt-stryker-test/stryker.conf.js
+++ b/e2e/test/grunt-stryker-test/stryker.conf.js
@@ -9,6 +9,6 @@ module.exports = function (config) {
     testFramework: 'jasmine',
     testRunner: 'karma',
     logLevel: 'info',
-    maxConcurrentTestRunners: 2
+    concurrency: 2
   });
 }

--- a/e2e/test/jasmine-jasmine/stryker.conf.js
+++ b/e2e/test/jasmine-jasmine/stryker.conf.js
@@ -6,7 +6,7 @@ module.exports = function (config) {
     testFramework: 'jasmine',
     testRunner: 'jasmine',
     reporters: ['clear-text', 'event-recorder'],
-    maxConcurrentTestRunners: 2,
+    concurrency: 2,
     jasmineConfigFile: 'spec/support/jasmine.json',
     fileLogLevel: 'debug',
     plugins: ['@stryker-mutator/jasmine-runner']

--- a/e2e/test/jest-node/stryker.conf.json
+++ b/e2e/test/jest-node/stryker.conf.json
@@ -5,7 +5,7 @@
   "testRunner": "jest",
   "tempDirName": "stryker-tmp",
   "transpilers": [],
-  "maxConcurrentTestRunners": 2,
+  "concurrency": 2,
   "coverageAnalysis": "off",
   "reporters": [
     "clear-text",

--- a/e2e/test/jest-react-ts/stryker.conf.json
+++ b/e2e/test/jest-react-ts/stryker.conf.json
@@ -8,7 +8,7 @@
     "src/App/TodoList/Item/index.tsx",
     "src/NotFound.tsx"
   ],
-  "maxConcurrentTestRunners": 2,
+  "concurrency": 2,
   "coverageAnalysis": "off",
   "reporters": [
     "event-recorder"

--- a/e2e/test/jest-react/stryker.conf.js
+++ b/e2e/test/jest-react/stryker.conf.js
@@ -8,7 +8,7 @@ module.exports = function (config) {
     coverageAnalysis: "off",
     timeoutMS: 60000, // High timeout to survive high build server load. Mutants created here should never timeout
     mutate: ["src/{Alert,Badge,Breadcrumb}.js"],
-    maxConcurrentTestRunners: 2,
+    concurrency: 2,
     jest: {
       projectType: 'create-react-app'
     }

--- a/e2e/test/jest-with-ts/stryker.conf.json
+++ b/e2e/test/jest-with-ts/stryker.conf.json
@@ -8,7 +8,7 @@
   "testRunner": "jest",
   "tempDirName": "stryker-tmp",
   "transpilers": [],
-  "maxConcurrentTestRunners": 2,
+  "concurrency": 2,
   "coverageAnalysis": "off",
   "reporters": [
     "event-recorder"

--- a/e2e/test/karma-jasmine/stryker.conf.js
+++ b/e2e/test/karma-jasmine/stryker.conf.js
@@ -4,7 +4,7 @@ module.exports = function (config) {
     testFramework: 'jasmine',
     testRunner: 'karma',
     reporters: ['clear-text', 'html', 'event-recorder'],
-    maxConcurrentTestRunners: 2,
+    concurrency: 2,
     karma: {
       config: {
         files: ['src/*.js', 'test/*.js'],

--- a/e2e/test/karma-mocha/stryker.conf.js
+++ b/e2e/test/karma-mocha/stryker.conf.js
@@ -12,7 +12,7 @@ module.exports = function (config) {
       }
     },
     timeoutMS: 60000,
-    maxConcurrentTestRunners: 2,
+    concurrency: 2,
     coverageAnalysis: 'perTest',
     plugins: ['@stryker-mutator/karma-runner']
   });

--- a/e2e/test/polymer-project/stryker.conf.js
+++ b/e2e/test/polymer-project/stryker.conf.js
@@ -10,7 +10,7 @@ module.exports = function(config) {
     wct: {
       npm: true
     },
-    maxConcurrentTestRunners: 2,
+    concurrency: 2,
     timeoutMS: 30000
   });
 };

--- a/e2e/test/vue-cli-javascript-jest/stryker.conf.json
+++ b/e2e/test/vue-cli-javascript-jest/stryker.conf.json
@@ -8,7 +8,7 @@
   "tempDirName": "stryker-tmp",
   "packageManager": "npm",
   "testRunner": "jest",
-  "maxConcurrentTestRunners": 2,
+  "concurrency": 2,
   "coverageAnalysis": "off",
   "reporters": [
     "event-recorder",

--- a/packages/api/src/report/Reporter.ts
+++ b/packages/api/src/report/Reporter.ts
@@ -51,7 +51,7 @@ interface Reporter {
    * Stryker will not close until the promise is either resolved or rejected.
    * @return a promise which will resolve when the reporter is done reporting
    */
-  wrapUp?(): void | Promise<void>;
+  wrapUp?(): void | Promise<void> | Promise<void[]>;
 }
 
 export default Reporter;

--- a/packages/core/src/StrykerCli.ts
+++ b/packages/core/src/StrykerCli.ts
@@ -3,6 +3,8 @@ import { getLogger } from 'log4js';
 import { DashboardOptions, ALL_REPORT_TYPES, PartialStrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 
+import { MutantResult } from '@stryker-mutator/api/report';
+
 import { initializerFactory } from './initializer';
 import { LogConfigurator } from './logging';
 import Stryker from './Stryker';
@@ -152,7 +154,8 @@ export default class StrykerCli {
     };
 
     if (Object.keys(commands).includes(this.command)) {
-      Promise.resolve(commands[this.command as keyof typeof commands]).catch((err) => {
+      const promise: Promise<void | MutantResult[]> = commands[this.command as keyof typeof commands]();
+      promise.catch((err) => {
         const error = retrieveCause(err);
         if (error instanceof ConfigError) {
           this.log.error(error.message);

--- a/packages/core/src/StrykerCli.ts
+++ b/packages/core/src/StrykerCli.ts
@@ -146,13 +146,13 @@ export default class StrykerCli {
       options.dashboard = dashboard;
     }
 
-    const commands: { [cmd: string]: () => Promise<any> } = {
+    const commands = {
       init: () => initializerFactory().initialize(),
       run: () => this.runMutationTest(options),
     };
 
     if (Object.keys(commands).includes(this.command)) {
-      commands[this.command]().catch((err) => {
+      Promise.resolve(commands[this.command as keyof typeof commands]).catch((err) => {
         const error = retrieveCause(err);
         if (error instanceof ConfigError) {
           this.log.error(error.message);

--- a/packages/core/src/child-proxy/ChildProcessProxyWorker.ts
+++ b/packages/core/src/child-proxy/ChildProcessProxyWorker.ts
@@ -52,8 +52,8 @@ export default class ChildProcessProxyWorker {
     this.log = getLogger(ChildProcessProxyWorker.name);
     this.handlePromiseRejections();
     let injector = buildChildProcessInjector(message.options);
-    const locals = message.additionalInjectableValues as any;
-    for (const token of Object.keys(locals)) {
+    const locals = message.additionalInjectableValues as Record<string, unknown>;
+    for (const token in locals) {
       injector = injector.provideValue(token, locals[token]);
     }
     const RealSubjectClass = require(message.requirePath)[message.requireName];

--- a/packages/core/src/config/buildSchemaWithPluginContributions.ts
+++ b/packages/core/src/config/buildSchemaWithPluginContributions.ts
@@ -3,7 +3,7 @@ import { Logger } from '@stryker-mutator/api/logging';
 
 import { coreTokens } from '../di';
 
-function mergedSchema(mainSchema: any, additionalSchemas: any[]): Record<string, unknown> {
+function mergedSchema(mainSchema: Record<string, any>, additionalSchemas: Array<Record<string, any>>): Record<string, unknown> {
   const schema = {
     ...mainSchema,
     properties: {

--- a/packages/core/src/di/PluginLoader.ts
+++ b/packages/core/src/di/PluginLoader.ts
@@ -12,7 +12,7 @@ import * as coreTokens from './coreTokens';
 const IGNORED_PACKAGES = ['core', 'api', 'util'];
 
 interface PluginModule {
-  strykerPlugins: Array<Plugin<any>>;
+  strykerPlugins: Array<Plugin<PluginKind>>;
 }
 
 interface SchemaValidationContribution {
@@ -20,7 +20,7 @@ interface SchemaValidationContribution {
 }
 
 export class PluginLoader implements PluginResolver {
-  private readonly pluginsByKind: Map<PluginKind, Array<Plugin<any>>> = new Map();
+  private readonly pluginsByKind: Map<PluginKind, Array<Plugin<PluginKind>>> = new Map();
   private readonly contributedValidationSchemas: Array<Record<string, unknown>> = [];
 
   public static inject = tokens(commonTokens.logger, coreTokens.pluginDescriptors);
@@ -41,7 +41,7 @@ export class PluginLoader implements PluginResolver {
     if (plugins) {
       const plugin = plugins.find((plugin) => plugin.name.toLowerCase() === name.toLowerCase());
       if (plugin) {
-        return plugin as any;
+        return plugin as Plugins[T];
       } else {
         throw new Error(
           `Cannot load ${kind} plugin "${name}". Did you forget to install it? Loaded ${kind} plugins were: ${plugins.map((p) => p.name).join(', ')}`
@@ -53,8 +53,8 @@ export class PluginLoader implements PluginResolver {
   }
 
   public resolveAll<T extends keyof Plugins>(kind: T): Array<Plugins[T]> {
-    const plugins = this.pluginsByKind.get(kind);
-    return plugins || ([] as any);
+    const plugins = this.pluginsByKind.get(kind) || [];
+    return plugins as Array<Plugins[T]>;
   }
 
   private resolvePluginModules() {
@@ -110,7 +110,7 @@ export class PluginLoader implements PluginResolver {
     }
   }
 
-  private loadPlugin(plugin: Plugin<any>) {
+  private loadPlugin(plugin: Plugin<PluginKind>) {
     let plugins = this.pluginsByKind.get(plugin.kind);
     if (!plugins) {
       plugins = [];

--- a/packages/core/src/initializer/presets/AngularPreset.ts
+++ b/packages/core/src/initializer/presets/AngularPreset.ts
@@ -23,7 +23,7 @@ export class AngularPreset implements Preset {
       },
     },
     reporters: ['progress', 'clear-text', 'html'],
-    maxConcurrentTestRunners: Math.floor(os.cpus().length / 2),
+    concurrency: Math.floor(os.cpus().length / 2),
     // eslint-disable-next-line camelcase
     maxConcurrentTestRunners_comment: 'Recommended to use about half of your available cores when running stryker with angular',
     coverageAnalysis: 'off',

--- a/packages/core/src/reporters/BroadcastReporter.ts
+++ b/packages/core/src/reporters/BroadcastReporter.ts
@@ -48,10 +48,9 @@ export default class BroadcastReporter implements StrictReporter {
     return Promise.all(
       Object.keys(this.reporters).map(async (reporterName) => {
         const reporter = this.reporters[reporterName];
-        const method = reporter[methodName];
-        if (typeof method === 'function') {
+        if (typeof reporter[methodName] === 'function') {
           try {
-            await method(eventArgs);
+            await (reporter[methodName] as any)(eventArgs);
           } catch (error) {
             this.handleError(error, methodName, reporterName);
           }

--- a/packages/core/src/reporters/BroadcastReporter.ts
+++ b/packages/core/src/reporters/BroadcastReporter.ts
@@ -44,13 +44,14 @@ export default class BroadcastReporter implements StrictReporter {
     }
   }
 
-  private broadcast(methodName: keyof Reporter, eventArgs: any): Promise<any> {
+  private broadcast(methodName: keyof Reporter, eventArgs: any): Promise<void[]> {
     return Promise.all(
       Object.keys(this.reporters).map(async (reporterName) => {
         const reporter = this.reporters[reporterName];
-        if (typeof reporter[methodName] === 'function') {
+        const method = reporter[methodName];
+        if (typeof method === 'function') {
           try {
-            await (reporter[methodName] as any)(eventArgs);
+            await method(eventArgs);
           } catch (error) {
             this.handleError(error, methodName, reporterName);
           }

--- a/packages/core/src/reporters/EventRecorderReporter.ts
+++ b/packages/core/src/reporters/EventRecorderReporter.ts
@@ -14,7 +14,7 @@ export default class EventRecorderReporter implements StrictReporter {
   public static readonly inject = tokens(commonTokens.logger, commonTokens.options);
 
   private readonly allWork: Array<Promise<void>> = [];
-  private readonly createBaseFolderTask: Promise<any>;
+  private readonly createBaseFolderTask: Promise<string | undefined>;
   private index = 0;
 
   constructor(private readonly log: Logger, private readonly options: StrykerOptions) {
@@ -65,7 +65,7 @@ export default class EventRecorderReporter implements StrictReporter {
     this.work('onAllMutantsTested', results);
   }
 
-  public async wrapUp(): Promise<any> {
+  public async wrapUp(): Promise<void[]> {
     await this.createBaseFolderTask;
     return Promise.all(this.allWork);
   }

--- a/packages/core/src/test-runner/TestRunnerPool.ts
+++ b/packages/core/src/test-runner/TestRunnerPool.ts
@@ -58,8 +58,8 @@ export class TestRunnerPool implements Disposable {
       numConcurrentRunners--;
     }
     let numConcurrentRunnersSource = 'CPU count';
-    if (numConcurrentRunners > this.options.maxConcurrentTestRunners && this.options.maxConcurrentTestRunners > 0) {
-      numConcurrentRunners = this.options.maxConcurrentTestRunners;
+    if (this.options.concurrency && numConcurrentRunners > this.options.concurrency && this.options.concurrency > 0) {
+      numConcurrentRunners = this.options.concurrency;
       numConcurrentRunnersSource = 'maxConcurrentTestRunners config';
     }
     if (numConcurrentRunners <= 0) {

--- a/packages/core/test/unit/di/buildMainInjector.spec.ts
+++ b/packages/core/test/unit/di/buildMainInjector.spec.ts
@@ -1,4 +1,4 @@
-import { commonTokens } from '@stryker-mutator/api/plugin';
+import { commonTokens, PluginKind } from '@stryker-mutator/api/plugin';
 import { Reporter } from '@stryker-mutator/api/report';
 import { factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
@@ -17,7 +17,7 @@ import currentLogMock from '../../helpers/logMock';
 describe(buildMainInjector.name, () => {
   let pluginLoaderMock: sinon.SinonStubbedInstance<PluginLoader>;
   let configReaderMock: sinon.SinonStubbedInstance<ConfigReader>;
-  let pluginCreatorMock: sinon.SinonStubbedInstance<PluginCreator<any>>;
+  let pluginCreatorMock: sinon.SinonStubbedInstance<PluginCreator<PluginKind>>;
   let broadcastReporterMock: sinon.SinonStubbedInstance<Reporter>;
   let optionsValidatorStub: sinon.SinonStubbedInstance<optionsValidatorModule.OptionsValidator>;
   let expectedConfig: StrykerOptions;

--- a/packages/core/test/unit/logging/MultiAppender.spec.ts
+++ b/packages/core/test/unit/logging/MultiAppender.spec.ts
@@ -28,7 +28,7 @@ describe('MultiAppender', () => {
       categoryName: 'category',
       context: null,
       data: ['foo data'],
-      level: (log4js.levels as any).DEBUG,
+      level: log4js.levels.DEBUG,
       pid: 42,
       startTime: new Date(42),
     };

--- a/packages/core/test/unit/reporters/BroadcastReporter.spec.ts
+++ b/packages/core/test/unit/reporters/BroadcastReporter.spec.ts
@@ -158,14 +158,14 @@ describe('BroadcastReporter', () => {
   }
 
   function captureTTY() {
-    isTTY = (process.stdout as any).isTTY;
+    isTTY = process.stdout.isTTY;
   }
 
   function restoreTTY() {
-    (process.stdout as any).isTTY = isTTY;
+    process.stdout.isTTY = isTTY;
   }
 
   function setTTY(val: boolean) {
-    (process.stdout as any).isTTY = val;
+    process.stdout.isTTY = val;
   }
 });

--- a/packages/core/test/unit/reporters/EventRecorderReporter.spec.ts
+++ b/packages/core/test/unit/reporters/EventRecorderReporter.spec.ts
@@ -34,7 +34,7 @@ describe(EventRecorderReporter.name, () => {
       const arrangeActAssertEvent = (eventName: keyof Reporter) => {
         describe(`${eventName} event`, () => {
           let writeFileRejection: undefined | Error;
-          const expected: any = { some: 'eventData' };
+          const expected = { some: 'eventData' };
 
           const arrange = () =>
             beforeEach(() => {

--- a/packages/core/test/unit/test-runner/TestRunnerDecorator.spec.ts
+++ b/packages/core/test/unit/test-runner/TestRunnerDecorator.spec.ts
@@ -11,7 +11,7 @@ describe('TestRunnerDecorator', () => {
 
   beforeEach(() => {
     testRunner = factory.testRunner();
-    sut = new TestRunnerDecorator(() => testRunner as any);
+    sut = new TestRunnerDecorator(() => testRunner);
   });
 
   function actArrangeAssert(methodName: 'init' | 'dispose' | 'dryRun' | 'mutantRun') {

--- a/packages/grunt-stryker/package.json
+++ b/packages/grunt-stryker/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^14.0.1"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^3.0.0",
+    "@stryker-mutator/core": "^4.0.0",
     "grunt": ">=0.4.5"
   }
 }

--- a/packages/grunt-stryker/package.json
+++ b/packages/grunt-stryker/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^14.0.1"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^4.0.0",
+    "@stryker-mutator/core": "4.0.0-beta.1",
     "grunt": ">=0.4.5"
   }
 }

--- a/packages/jasmine-runner/package.json
+++ b/packages/jasmine-runner/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/stryker-mutator/stryker/tree/master/packages/jasmine-runner#readme",
   "peerDependencies": {
-    "@stryker-mutator/core": "^3.0.0",
+    "@stryker-mutator/core": "^4.0.0",
     "jasmine": ">=2"
   },
   "devDependencies": {

--- a/packages/jasmine-runner/package.json
+++ b/packages/jasmine-runner/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/stryker-mutator/stryker/tree/master/packages/jasmine-runner#readme",
   "peerDependencies": {
-    "@stryker-mutator/core": "^4.0.0",
+    "@stryker-mutator/core": "4.0.0-beta.1",
     "jasmine": ">=2"
   },
   "devDependencies": {

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -48,7 +48,7 @@
     "react-scripts-ts": "~3.1.0"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^3.0.0",
+    "@stryker-mutator/core": "^4.0.0",
     "jest": ">= 22.0.0"
   },
   "dependencies": {

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -48,7 +48,7 @@
     "react-scripts-ts": "~3.1.0"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^4.0.0",
+    "@stryker-mutator/core": "4.0.0-beta.1",
     "jest": ">= 22.0.0"
   },
   "dependencies": {

--- a/packages/jest-runner/src/jestTestAdapters/JestLessThan25Adapter.ts
+++ b/packages/jest-runner/src/jestTestAdapters/JestLessThan25Adapter.ts
@@ -12,7 +12,7 @@ export default class JestLessThan25TestAdapter implements JestTestAdapter {
   public static inject = tokens(commonTokens.logger);
   constructor(private readonly log: Logger) {}
 
-  public run(jestConfig: any, projectRoot: string, fileNameUnderTest?: string): Promise<any> {
+  public run(jestConfig: Record<string, unknown>, projectRoot: string, fileNameUnderTest?: string) {
     jestConfig.reporters = [];
     const config = JSON.stringify(jestConfig);
     this.log.trace(`Invoking Jest with config ${config}`);

--- a/packages/jest-runner/src/utils/createReactJestConfig.ts
+++ b/packages/jest-runner/src/utils/createReactJestConfig.ts
@@ -1,11 +1,11 @@
-const resolveCreateJestConfig = (path: string, loader?: NodeRequire): ((...args: any) => any) => {
+const resolveCreateJestConfig = (path: string, loader?: NodeRequire): ((...args: any[]) => any) => {
   loader = loader || /* istanbul ignore next */ require;
 
   return loader(path);
 };
 
 export function createReactJestConfig(
-  resolve: (...args: any) => any,
+  resolve: (...args: any[]) => any,
   projectRoot: string,
   ejected: boolean,
   loader?: NodeRequire
@@ -14,7 +14,7 @@ export function createReactJestConfig(
 }
 
 export function createReactTsJestConfig(
-  resolve: (...args: any) => any,
+  resolve: (...args: any[]) => any,
   projectRoot: string,
   ejected: boolean,
   loader?: NodeRequire

--- a/packages/karma-runner/package.json
+++ b/packages/karma-runner/package.json
@@ -44,7 +44,7 @@
     "karma-mocha": "^2.0.0"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^4.0.0"
+    "@stryker-mutator/core": "4.0.0-beta.1"
   },
   "dependencies": {
     "@stryker-mutator/api": "4.0.0-beta.1",

--- a/packages/karma-runner/package.json
+++ b/packages/karma-runner/package.json
@@ -44,7 +44,7 @@
     "karma-mocha": "^2.0.0"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^3.0.0"
+    "@stryker-mutator/core": "^4.0.0"
   },
   "dependencies": {
     "@stryker-mutator/api": "4.0.0-beta.1",

--- a/packages/karma-runner/src/starters/stryker-karma.conf.ts
+++ b/packages/karma-runner/src/starters/stryker-karma.conf.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
-import { Config, ConfigOptions, ClientOptions } from 'karma';
+import { Config, ConfigOptions, ClientOptions, InlinePluginType } from 'karma';
 import { noopLogger } from '@stryker-mutator/util';
 
 import StrykerReporter from '../karma-plugins/StrykerReporter';
@@ -94,7 +94,7 @@ function setBasePath(config: Config) {
   }
 }
 
-function addPlugin(karmaConfig: ConfigOptions, karmaPlugin: any) {
+function addPlugin(karmaConfig: ConfigOptions, karmaPlugin: string | Record<string, InlinePluginType>) {
   karmaConfig.plugins = karmaConfig.plugins || ['karma-*'];
   karmaConfig.plugins.push(karmaPlugin);
 }
@@ -109,7 +109,7 @@ function configureTestHooksMiddleware(config: Config) {
   config.files = config.files || [];
 
   config.files.unshift({ pattern: TEST_HOOKS_FILE_NAME, included: true, watched: false, served: false, nocache: true }); // Add a custom hooks file to provide hooks
-  const middleware: string[] = (config as any).beforeMiddleware || ((config as any).beforeMiddleware = []);
+  const middleware: string[] = config.beforeMiddleware || (config.beforeMiddleware = []);
   middleware.unshift(TestHooksMiddleware.name);
 
   TestHooksMiddleware.instance.configureTestFramework(config.frameworks);

--- a/packages/mocha-framework/package.json
+++ b/packages/mocha-framework/package.json
@@ -36,7 +36,7 @@
     "tslib": "~2.0.0"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^3.0.0",
+    "@stryker-mutator/core": "^4.0.0",
     "mocha": ">= 2.3.3 < 8"
   },
   "dependencies": {

--- a/packages/mocha-framework/package.json
+++ b/packages/mocha-framework/package.json
@@ -36,7 +36,7 @@
     "tslib": "~2.0.0"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^4.0.0",
+    "@stryker-mutator/core": "4.0.0-beta.1",
     "mocha": ">= 2.3.3 < 8"
   },
   "dependencies": {

--- a/packages/mocha-runner/package.json
+++ b/packages/mocha-runner/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^14.0.1"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^4.0.0",
+    "@stryker-mutator/core": "4.0.0-beta.1",
     "mocha": ">= 2.3.3 < 9"
   }
 }

--- a/packages/mocha-runner/package.json
+++ b/packages/mocha-runner/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^14.0.1"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^3.0.0",
+    "@stryker-mutator/core": "^4.0.0",
     "mocha": ">= 2.3.3 < 9"
   }
 }

--- a/packages/mocha-runner/src/StrykerMochaReporter.ts
+++ b/packages/mocha-runner/src/StrykerMochaReporter.ts
@@ -31,7 +31,7 @@ export class StrykerMochaReporter {
       StrykerMochaReporter.log.debug('Starting Mocha test run');
     });
 
-    this.runner.on('pass', (test: any) => {
+    this.runner.on('pass', (test: Mocha.Test) => {
       const title: string = test.fullTitle();
       const result: SuccessTestResult = {
         id: title,
@@ -44,7 +44,7 @@ export class StrykerMochaReporter {
       this.timer.reset();
     });
 
-    this.runner.on('fail', (test: any, err: any) => {
+    this.runner.on('fail', (test: Mocha.Test, err: Error) => {
       const title = test.fullTitle();
       const result: FailedTestResult = {
         id: title,

--- a/packages/typescript-checker/package.json
+++ b/packages/typescript-checker/package.json
@@ -39,7 +39,7 @@
     "@types/semver": "^7.2.0"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^4.0.0",
+    "@stryker-mutator/core": "4.0.0-beta.1",
     "typescript": ">=3.6"
   }
 }

--- a/packages/typescript-checker/package.json
+++ b/packages/typescript-checker/package.json
@@ -39,7 +39,7 @@
     "@types/semver": "^7.2.0"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "3.2.4",
+    "@stryker-mutator/core": "^4.0.0",
     "typescript": ">=3.6"
   }
 }

--- a/packages/util/src/Immutable.ts
+++ b/packages/util/src/Immutable.ts
@@ -1,4 +1,4 @@
-type ImmutablePrimitive = undefined | null | boolean | string | number | ((...args: any) => any);
+type ImmutablePrimitive = undefined | null | boolean | string | number | ((...args: any[]) => any);
 
 export type Immutable<T> = T extends ImmutablePrimitive
   ? T

--- a/packages/wct-runner/README.md
+++ b/packages/wct-runner/README.md
@@ -36,7 +36,7 @@ Make sure you set the `testRunner` option to "wct" and set `coverageAnalysis` to
 {
     testRunner: 'wct'
     coverageAnalysis: 'off', // coverage analysis is not supported yet for the @stryker-mutator/wct-runner.
-    maxConcurrentTestRunners: 4, // A maximum of half your CPU's is recommended
+    concurrency: 4, // A maximum of half your CPU's is recommended
     timeoutMS: 10000 // A higher timeout is recommended to allow for browser startup
 }
 ```

--- a/packages/wct-runner/package.json
+++ b/packages/wct-runner/package.json
@@ -35,7 +35,7 @@
     "web-component-tester": "~6.9.2"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^4.0.0",
+    "@stryker-mutator/core": "4.0.0-beta.1",
     "web-component-tester": "^6.9.0"
   },
   "author": "Nico Jansen <jansennico@gmail.com>",

--- a/packages/wct-runner/package.json
+++ b/packages/wct-runner/package.json
@@ -35,7 +35,7 @@
     "web-component-tester": "~6.9.2"
   },
   "peerDependencies": {
-    "@stryker-mutator/core": "^3.0.0",
+    "@stryker-mutator/core": "^4.0.0",
     "web-component-tester": "^6.9.0"
   },
   "author": "Nico Jansen <jansennico@gmail.com>",
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/stryker-mutator/stryker/tree/master/packages/wct-runner#readme",
   "initStrykerConfig": {
     "timeoutMS": 10000,
-    "maxConcurrentTestRunners": 4,
+    "concurrency": 4,
     "coverageAnalysis": "off"
   },
   "engines": {

--- a/packages/wct-runner/src/WctLogger.ts
+++ b/packages/wct-runner/src/WctLogger.ts
@@ -2,6 +2,10 @@ import { EventEmitter } from 'events';
 
 import { Logger } from '@stryker-mutator/api/logging';
 
+const getKeys = <T extends Record<string, unknown>>(object: T) => {
+  return Object.keys(object) as Array<keyof T>;
+};
+
 export default class WctLogger {
   private readonly logProxy = {
     ['log:debug']: this.log.debug.bind(this.log),
@@ -12,13 +16,13 @@ export default class WctLogger {
 
   constructor(private readonly context: EventEmitter, verbose: boolean, private readonly log: Logger) {
     if (verbose) {
-      Object.keys(this.logProxy).forEach((logEvent) => context.on(logEvent, (this.logProxy as any)[logEvent]));
+      getKeys(this.logProxy).forEach((logEvent) => context.on(logEvent, this.logProxy[logEvent]));
     } else {
       this.log.debug('Keeping wct quiet. To enable wct logging, set `wct.verbose` to `true` in your Stryker configuration file.');
     }
   }
 
   public dispose() {
-    Object.keys(this.logProxy).forEach((logEvent) => this.context.removeListener(logEvent, (this.logProxy as any)[logEvent]));
+    getKeys(this.logProxy).forEach((logEvent) => this.context.removeListener(logEvent, this.logProxy[logEvent]));
   }
 }

--- a/perf/test/angular-cli/stryker.conf.js
+++ b/perf/test/angular-cli/stryker.conf.js
@@ -20,7 +20,7 @@ module.exports = function(config) {
     },
     timeoutMS: 60000,
     reporters: ["progress", "clear-text", "html"],
-    maxConcurrentTestRunners: 2,
+    concurrency: 2,
     coverageAnalysis: 'off', // Coverage analysis with a transpiler is not supported a.t.m.
     tsconfigFile: 'tsconfig.json', // Location of your tsconfig.json file
   });

--- a/stryker.parent.conf.js
+++ b/stryker.parent.conf.js
@@ -12,7 +12,7 @@ module.exports = {
   testFramework: 'mocha',
   testRunner: 'mocha',
   reporters: ['progress', 'html', 'dashboard'],
-  maxConcurrentTestRunners: 4,
+  concurrency: 4,
   plugins: [
     require.resolve('./packages/mocha-runner/src/index'),
     require.resolve('./packages/mocha-framework/src/index'),


### PR DESCRIPTION
- Removed many `any` types, while providing better, more accurate type.
- Used concurrency instead of deprecated maxConcurrentTestRunners
- bump up core package version dependency