### PR TITLE
feat(command): Support command test runner with mutation switching

### DIFF
--- a/e2e/tasks/run-e2e-tests.ts
+++ b/e2e/tasks/run-e2e-tests.ts
@@ -20,6 +20,7 @@ const mutationSwitchingTempWhiteList = [
   'mocha-ts-node',
   'babel-transpiling',
   'typescript-transpiling',
+  'command',
   'vue-cli-typescript-mocha'
 ]
 

--- a/e2e/test/command/stryker.conf.json
+++ b/e2e/test/command/stryker.conf.json
@@ -1,14 +1,9 @@
 {
-  "mutate": [
-    "src/*.js"
-  ],
-  "testFramework": "mocha",
-  "coverageAnalysis": "off",
+  "$schema": "../../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "reporters": [
     "clear-text",
     "event-recorder"
   ],
-  "mutator": "javascript",
   "concurrency": 2,
   "commandRunner": {
     "command": "npm run mocha"

--- a/e2e/test/command/verify/verify.ts
+++ b/e2e/test/command/verify/verify.ts
@@ -22,8 +22,9 @@ describe('After running stryker with the command test runner', () => {
 
   it('should write to a log file', async () => {
     const strykerLog = await fs.readFile('./stryker.log', 'utf8');
-    expect(strykerLog).contains('INFO InitialTestExecutor Initial test run succeeded. Ran 1 test');
-    expect(strykerLog).matches(/Stryker Done in \d+/);
+    expect(strykerLog).contains('INFO DryRunExecutor Initial test run succeeded. Ran 1 test');
+    expect(strykerLog).matches(/MutationTestExecutor Done in \d+/);
     expect(strykerLog).not.contains('ERROR');
+    expect(strykerLog).not.contains('WARN');
   });
 });

--- a/packages/api/src/core/instrument.ts
+++ b/packages/api/src/core/instrument.ts
@@ -6,4 +6,5 @@ export const INSTRUMENTER_CONSTANTS = Object.freeze({
   MUTATION_COVERAGE_OBJECT: '__mutantCoverage__',
   COVER_MUTANT_HELPER_METHOD: '__coverMutant__',
   ACTIVE_MUTANT: '__activeMutant__',
+  ACTIVE_MUTANT_ENV_VARIABLE: '__STRYKER_ACTIVE_MUTANT__',
 } as const);

--- a/packages/core/src/test-runner/CommandTestRunner.ts
+++ b/packages/core/src/test-runner/CommandTestRunner.ts
@@ -1,9 +1,20 @@
 import { exec } from 'child_process';
 import * as os from 'os';
 
-import { StrykerOptions, CommandRunnerOptions } from '@stryker-mutator/api/core';
-import { RunResult, RunStatus, TestRunner, TestStatus } from '@stryker-mutator/api/test_runner';
-import { errorToString } from '@stryker-mutator/util';
+import { StrykerOptions, CommandRunnerOptions, INSTRUMENTER_CONSTANTS } from '@stryker-mutator/api/core';
+import {
+  TestRunner2,
+  TestStatus,
+  DryRunOptions,
+  MutantRunOptions,
+  DryRunResult,
+  MutantRunResult,
+  DryRunStatus,
+  ErrorDryRunResult,
+  CompleteDryRunResult,
+  toMutantRunResult,
+} from '@stryker-mutator/api/test_runner2';
+import { errorToString, StrykerError } from '@stryker-mutator/util';
 
 import { kill } from '../utils/objectUtils';
 import Timer from '../utils/Timer';
@@ -14,7 +25,7 @@ import Timer from '../utils/Timer';
  * instead, it mimics a simple test result based on the exit code.
  * The command can be configured, but defaults to `npm test`.
  */
-export default class CommandTestRunner implements TestRunner {
+export default class CommandTestRunner implements TestRunner2 {
   /**
    * "command"
    */
@@ -24,7 +35,7 @@ export default class CommandTestRunner implements TestRunner {
    * Determines whether a given name is "command" (ignore case)
    * @param name Maybe "command", maybe not
    */
-  public static is(name: string): boolean {
+  public static is(name: string): name is 'command' {
     return this.runnerName === name.toLowerCase();
   }
 
@@ -36,11 +47,29 @@ export default class CommandTestRunner implements TestRunner {
     this.settings = options.commandRunner;
   }
 
-  public run(): Promise<RunResult> {
+  public async dryRun({ coverageAnalysis }: Pick<DryRunOptions, 'coverageAnalysis'>): Promise<DryRunResult> {
+    if (coverageAnalysis !== 'off') {
+      throw new StrykerError(
+        `The "${CommandTestRunner.runnerName}" test runner does not support coverageAnalysis "${coverageAnalysis}". Please set "coverageAnalysis": "off".`
+      );
+    }
+    return this.run({});
+  }
+
+  public async mutantRun({ activeMutant }: Pick<MutantRunOptions, 'activeMutant'>): Promise<MutantRunResult> {
+    const result = await this.run({ activeMutantId: activeMutant.id });
+    return toMutantRunResult(result);
+  }
+
+  private run({ activeMutantId }: { activeMutantId?: number }): Promise<DryRunResult> {
     return new Promise((res, rej) => {
       const timer = new Timer();
       const output: Array<string | Buffer> = [];
-      const childProcess = exec(this.settings.command, { cwd: this.workingDir });
+      const env =
+        activeMutantId === undefined
+          ? process.env
+          : { ...process.env, [INSTRUMENTER_CONSTANTS.ACTIVE_MUTANT_ENV_VARIABLE]: activeMutantId.toString() };
+      const childProcess = exec(this.settings.command, { cwd: this.workingDir, env });
       childProcess.on('error', (error) => {
         kill(childProcess.pid)
           .then(() => handleResolve(errorResult(error)))
@@ -58,11 +87,11 @@ export default class CommandTestRunner implements TestRunner {
       });
 
       this.timeoutHandler = async () => {
-        handleResolve({ status: RunStatus.Timeout, tests: [] });
+        handleResolve({ status: DryRunStatus.Timeout });
         await kill(childProcess.pid);
       };
 
-      const handleResolve = (runResult: RunResult) => {
+      const handleResolve = (runResult: DryRunResult) => {
         removeAllListeners();
         this.timeoutHandler = undefined;
         res(runResult);
@@ -74,21 +103,21 @@ export default class CommandTestRunner implements TestRunner {
         childProcess.removeAllListeners();
       }
 
-      function errorResult(error: Error): RunResult {
+      function errorResult(error: Error): ErrorDryRunResult {
         return {
-          errorMessages: [errorToString(error)],
-          status: RunStatus.Error,
-          tests: [],
+          errorMessage: errorToString(error),
+          status: DryRunStatus.Error,
         };
       }
 
-      function completeResult(exitCode: number | null, timer: Timer): RunResult {
+      function completeResult(exitCode: number | null, timer: Timer): CompleteDryRunResult {
         const duration = timer.elapsedMs();
         if (exitCode === 0) {
           return {
-            status: RunStatus.Complete,
+            status: DryRunStatus.Complete,
             tests: [
               {
+                id: 'all',
                 name: 'All tests',
                 status: TestStatus.Success,
                 timeSpentMs: duration,
@@ -97,10 +126,11 @@ export default class CommandTestRunner implements TestRunner {
           };
         } else {
           return {
-            status: RunStatus.Complete,
+            status: DryRunStatus.Complete,
             tests: [
               {
-                failureMessages: [output.map((buf) => buf.toString()).join(os.EOL)],
+                id: 'all',
+                failureMessage: output.map((buf) => buf.toString()).join(os.EOL),
                 name: 'All tests',
                 status: TestStatus.Failed,
                 timeSpentMs: duration,

--- a/packages/core/src/test-runner/index.ts
+++ b/packages/core/src/test-runner/index.ts
@@ -9,6 +9,7 @@ import { Sandbox } from '../sandbox/sandbox';
 import RetryDecorator from './RetryDecorator';
 import TimeoutDecorator from './TimeoutDecorator';
 import ChildProcessTestRunnerDecorator from './ChildProcessTestRunnerDecorator';
+import CommandTestRunner from './CommandTestRunner';
 
 createTestRunnerFactory.inject = tokens(commonTokens.options, coreTokens.sandbox, coreTokens.loggingContext);
 export function createTestRunnerFactory(
@@ -16,13 +17,13 @@ export function createTestRunnerFactory(
   sandbox: Pick<Sandbox, 'sandboxFileNames' | 'workingDirectory'>,
   loggingContext: LoggingClientContext
 ): () => Required<TestRunner2> {
-  // if (CommandTestRunner.is(options.testRunner)) {
-  //   return new RetryDecorator(() => new TimeoutDecorator(() => new CommandTestRunner(sandboxWorkingDirectory, options)));
-  // } else {
-  return () =>
-    new RetryDecorator(
-      () =>
-        new TimeoutDecorator(() => new ChildProcessTestRunnerDecorator(options, sandbox.sandboxFileNames, sandbox.workingDirectory, loggingContext))
-    );
-  // }
+  if (CommandTestRunner.is(options.testRunner)) {
+    return () => new RetryDecorator(() => new TimeoutDecorator(() => new CommandTestRunner(sandbox.workingDirectory, options)));
+  } else {
+    return () =>
+      new RetryDecorator(
+        () =>
+          new TimeoutDecorator(() => new ChildProcessTestRunnerDecorator(options, sandbox.sandboxFileNames, sandbox.workingDirectory, loggingContext))
+      );
+  }
 }

--- a/packages/core/test/integration/command-test-runner/CommandTestRunner.it.spec.ts
+++ b/packages/core/test/integration/command-test-runner/CommandTestRunner.it.spec.ts
@@ -1,10 +1,12 @@
 import * as path from 'path';
 
-import { RunStatus, TestStatus } from '@stryker-mutator/api/test_runner';
+import { TestStatus, DryRunStatus } from '@stryker-mutator/api/test_runner2';
 import { factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { CommandRunnerOptions } from '@stryker-mutator/api/core';
+
+import { assertions } from '@stryker-mutator/test-helpers';
 
 import CommandTestRunner from '../../../src/test-runner/CommandTestRunner';
 import * as objectUtils from '../../../src/utils/objectUtils';
@@ -12,41 +14,58 @@ import * as objectUtils from '../../../src/utils/objectUtils';
 describe(`${CommandTestRunner.name} integration`, () => {
   const workingDir = path.resolve(__dirname, '..', '..', '..', 'testResources', 'command-runner');
 
-  it('should report test as successful', async () => {
-    const sut = createSut();
-    const result = await sut.run();
-    expect(RunStatus[result.status]).eq(RunStatus[RunStatus.Complete]);
-    expect(result.tests).lengthOf(1);
-    expect(TestStatus[result.tests[0].status]).eq(TestStatus[TestStatus.Success]);
-    expect(result.tests[0].name).eq('All tests');
-    expect(result.tests[0].timeSpentMs).greaterThan(1);
+  describe(CommandTestRunner.prototype.dryRun.name, () => {
+    it('should report test as successful', async () => {
+      const sut = createSut();
+      const result = await sut.dryRun({ coverageAnalysis: 'off' });
+      assertions.expectCompleted(result);
+      expect(result.tests).lengthOf(1);
+      expect(result.tests[0].status).eq(TestStatus.Success);
+      expect(result.tests[0].id).eq('all');
+      expect(result.tests[0].name).eq('All tests');
+      expect(result.tests[0].timeSpentMs).greaterThan(1);
+    });
+
+    it('should report test as failed if exit code != 0', async () => {
+      const sut = createSut({ command: 'npm run fail' });
+      const result = await sut.dryRun({ coverageAnalysis: 'off' });
+      assertions.expectCompleted(result);
+      expect(result.tests).lengthOf(1);
+      expect(TestStatus[result.tests[0].status]).eq(TestStatus[TestStatus.Failed]);
+      expect(result.tests[0].name).eq('All tests');
+      assertions.expectFailed(result.tests[0]);
+      expect(result.tests[0].failureMessage).includes('Test 2 - NOK');
+      expect(result.tests[0].timeSpentMs).greaterThan(1);
+    });
+
+    it('should kill the child process and timeout the run result if dispose is called', async () => {
+      // Arrange
+      const killSpy = sinon.spy(objectUtils, 'kill');
+      const sut = createSut({ command: 'npm run wait' });
+      const runPromise = sut.dryRun({ coverageAnalysis: 'off' });
+
+      // Act
+      await sut.dispose();
+      const result = await runPromise;
+
+      // Assert
+      expect(result.status).eq(DryRunStatus.Timeout);
+      expect(killSpy).called;
+    });
   });
 
-  it('should report test as failed if exit code != 0', async () => {
-    const sut = createSut({ command: 'npm run fail' });
-    const result = await sut.run();
-    expect(RunStatus[result.status]).eq(RunStatus[RunStatus.Complete]);
-    expect(result.tests).lengthOf(1);
-    expect(TestStatus[result.tests[0].status]).eq(TestStatus[TestStatus.Failed]);
-    expect(result.tests[0].name).eq('All tests');
-    expect(result.tests[0].failureMessages).lengthOf(1);
-    expect((result.tests[0].failureMessages as string[])[0]).includes('Test 2 - NOK');
-    expect(result.tests[0].timeSpentMs).greaterThan(1);
-  });
-
-  it('should kill the child process and timeout the run result if dispose is called', async () => {
-    // Arrange
-    const killSpy = sinon.spy(objectUtils, 'kill');
-    const sut = createSut({ command: 'npm run wait' });
-    const runPromise = sut.run();
-
-    // Act
-    await sut.dispose();
-    const result = await runPromise;
-
-    // Assert
-    expect(RunStatus[result.status]).eq(RunStatus[RunStatus.Timeout]);
-    expect(killSpy).called;
+  describe(CommandTestRunner.prototype.mutantRun.name, () => {
+    it('should report mutant as survived if the process exits with 0', async () => {
+      const sut = createSut({ command: 'npm run mutant' });
+      const result = await sut.mutantRun({ activeMutant: factory.mutant({ id: 41 }) });
+      assertions.expectSurvived(result);
+    });
+    it('should report mutant as killed if the process exits with 1', async () => {
+      const sut = createSut({ command: 'npm run mutant' });
+      const result = await sut.mutantRun({ activeMutant: factory.mutant({ id: 42 /* 42 should fail */ }) });
+      assertions.expectKilled(result);
+      expect(result.killedBy).eq('all');
+    });
   });
 
   function createSut(settings?: CommandRunnerOptions) {

--- a/packages/core/testResources/command-runner/mutant.js
+++ b/packages/core/testResources/command-runner/mutant.js
@@ -1,0 +1,4 @@
+console.log(`Current active mutant = ${process.env.__STRYKER_ACTIVE_MUTANT__}`);
+if (process.env.__STRYKER_ACTIVE_MUTANT__ === '42') {
+  throw new Error('Expected error when process.env.__STRYKER_ACTIVE_MUTANT__ is 42');
+}

--- a/packages/core/testResources/command-runner/package.json
+++ b/packages/core/testResources/command-runner/package.json
@@ -2,6 +2,7 @@
     "scripts": {
         "test": "node ok.js",
         "fail": "node nok.js",
-        "wait": "node wait.js"
+        "wait": "node wait.js",
+        "mutant": "node mutant.js"
     }
 }

--- a/packages/instrumenter/src/util/syntax-helpers.ts
+++ b/packages/instrumenter/src/util/syntax-helpers.ts
@@ -11,6 +11,9 @@ export { ID };
  * Returns syntax for the global header
  */
 export const declareGlobal = parse(`var ${ID.GLOBAL} = (function(g){
+  if (g.${ID.ACTIVE_MUTANT} === undefined && g.process && g.process.env && g.process.env.${ID.ACTIVE_MUTANT_ENV_VARIABLE}) {
+    g.${ID.ACTIVE_MUTANT} = Number(g.process.env.${ID.ACTIVE_MUTANT_ENV_VARIABLE});
+  }
   g.${ID.MUTATION_COVERAGE_OBJECT} = g.${ID.MUTATION_COVERAGE_OBJECT} || { static: {}, perTest: {} };
   g.${ID.COVER_MUTANT_HELPER_METHOD} = g.${ID.COVER_MUTANT_HELPER_METHOD} || function () {
     var c = g.${ID.MUTATION_COVERAGE_OBJECT}.static;

--- a/packages/instrumenter/test/integration/transformers.it.spec.js.snap
+++ b/packages/instrumenter/test/integration/transformers.it.spec.js.snap
@@ -24,7 +24,7 @@ Object {
         Node {
           "declarations": Array [
             Node {
-              "end": 521,
+              "end": 714,
               "id": Node {
                 "end": 19,
                 "loc": SourceLocation {
@@ -49,7 +49,7 @@ Object {
                     "callee": Node {
                       "arguments": Array [
                         Node {
-                          "end": 517,
+                          "end": 710,
                           "extra": Object {
                             "raw": "\\"return this\\"",
                             "rawValue": "return this",
@@ -57,61 +57,61 @@ Object {
                           "loc": SourceLocation {
                             "end": Position {
                               "column": 29,
-                              "line": 14,
+                              "line": 17,
                             },
                             "start": Position {
                               "column": 16,
-                              "line": 14,
+                              "line": 17,
                             },
                           },
-                          "start": 504,
+                          "start": 697,
                           "type": "StringLiteral",
                           "value": "return this",
                         },
                       ],
                       "callee": Node {
-                        "end": 503,
+                        "end": 696,
                         "loc": SourceLocation {
                           "end": Position {
                             "column": 15,
-                            "line": 14,
+                            "line": 17,
                           },
                           "identifierName": "Function",
                           "start": Position {
                             "column": 7,
-                            "line": 14,
+                            "line": 17,
                           },
                         },
                         "name": "Function",
-                        "start": 495,
+                        "start": 688,
                         "type": "Identifier",
                       },
-                      "end": 518,
+                      "end": 711,
                       "loc": SourceLocation {
                         "end": Position {
                           "column": 30,
-                          "line": 14,
+                          "line": 17,
                         },
                         "start": Position {
                           "column": 3,
-                          "line": 14,
+                          "line": 17,
                         },
                       },
-                      "start": 491,
+                      "start": 684,
                       "type": "NewExpression",
                     },
-                    "end": 520,
+                    "end": 713,
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 32,
-                        "line": 14,
+                        "line": 17,
                       },
                       "start": Position {
                         "column": 3,
-                        "line": 14,
+                        "line": 17,
                       },
                     },
-                    "start": 491,
+                    "start": 684,
                     "type": "CallExpression",
                   },
                 ],
@@ -120,262 +120,261 @@ Object {
                   "body": Node {
                     "body": Array [
                       Node {
-                        "end": 113,
-                        "expression": Node {
-                          "end": 112,
-                          "left": Node {
-                            "computed": false,
-                            "end": 58,
-                            "loc": SourceLocation {
-                              "end": Position {
-                                "column": 22,
-                                "line": 2,
+                        "alternate": null,
+                        "consequent": Node {
+                          "body": Array [
+                            Node {
+                              "end": 224,
+                              "expression": Node {
+                                "end": 223,
+                                "left": Node {
+                                  "computed": false,
+                                  "end": 173,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 22,
+                                      "line": 3,
+                                    },
+                                    "start": Position {
+                                      "column": 4,
+                                      "line": 3,
+                                    },
+                                  },
+                                  "object": Node {
+                                    "end": 156,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 5,
+                                        "line": 3,
+                                      },
+                                      "identifierName": "g",
+                                      "start": Position {
+                                        "column": 4,
+                                        "line": 3,
+                                      },
+                                    },
+                                    "name": "g",
+                                    "start": 155,
+                                    "type": "Identifier",
+                                  },
+                                  "property": Node {
+                                    "end": 173,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 22,
+                                        "line": 3,
+                                      },
+                                      "identifierName": "__activeMutant__",
+                                      "start": Position {
+                                        "column": 6,
+                                        "line": 3,
+                                      },
+                                    },
+                                    "name": "__activeMutant__",
+                                    "start": 157,
+                                    "type": "Identifier",
+                                  },
+                                  "start": 155,
+                                  "type": "MemberExpression",
+                                },
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 72,
+                                    "line": 3,
+                                  },
+                                  "start": Position {
+                                    "column": 4,
+                                    "line": 3,
+                                  },
+                                },
+                                "operator": "=",
+                                "right": Node {
+                                  "arguments": Array [
+                                    Node {
+                                      "computed": false,
+                                      "end": 222,
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 71,
+                                          "line": 3,
+                                        },
+                                        "start": Position {
+                                          "column": 32,
+                                          "line": 3,
+                                        },
+                                      },
+                                      "object": Node {
+                                        "computed": false,
+                                        "end": 196,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 45,
+                                            "line": 3,
+                                          },
+                                          "start": Position {
+                                            "column": 32,
+                                            "line": 3,
+                                          },
+                                        },
+                                        "object": Node {
+                                          "computed": false,
+                                          "end": 192,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 41,
+                                              "line": 3,
+                                            },
+                                            "start": Position {
+                                              "column": 32,
+                                              "line": 3,
+                                            },
+                                          },
+                                          "object": Node {
+                                            "end": 184,
+                                            "loc": SourceLocation {
+                                              "end": Position {
+                                                "column": 33,
+                                                "line": 3,
+                                              },
+                                              "identifierName": "g",
+                                              "start": Position {
+                                                "column": 32,
+                                                "line": 3,
+                                              },
+                                            },
+                                            "name": "g",
+                                            "start": 183,
+                                            "type": "Identifier",
+                                          },
+                                          "property": Node {
+                                            "end": 192,
+                                            "loc": SourceLocation {
+                                              "end": Position {
+                                                "column": 41,
+                                                "line": 3,
+                                              },
+                                              "identifierName": "process",
+                                              "start": Position {
+                                                "column": 34,
+                                                "line": 3,
+                                              },
+                                            },
+                                            "name": "process",
+                                            "start": 185,
+                                            "type": "Identifier",
+                                          },
+                                          "start": 183,
+                                          "type": "MemberExpression",
+                                        },
+                                        "property": Node {
+                                          "end": 196,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 45,
+                                              "line": 3,
+                                            },
+                                            "identifierName": "env",
+                                            "start": Position {
+                                              "column": 42,
+                                              "line": 3,
+                                            },
+                                          },
+                                          "name": "env",
+                                          "start": 193,
+                                          "type": "Identifier",
+                                        },
+                                        "start": 183,
+                                        "type": "MemberExpression",
+                                      },
+                                      "property": Node {
+                                        "end": 222,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 71,
+                                            "line": 3,
+                                          },
+                                          "identifierName": "__STRYKER_ACTIVE_MUTANT__",
+                                          "start": Position {
+                                            "column": 46,
+                                            "line": 3,
+                                          },
+                                        },
+                                        "name": "__STRYKER_ACTIVE_MUTANT__",
+                                        "start": 197,
+                                        "type": "Identifier",
+                                      },
+                                      "start": 183,
+                                      "type": "MemberExpression",
+                                    },
+                                  ],
+                                  "callee": Node {
+                                    "end": 182,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 31,
+                                        "line": 3,
+                                      },
+                                      "identifierName": "Number",
+                                      "start": Position {
+                                        "column": 25,
+                                        "line": 3,
+                                      },
+                                    },
+                                    "name": "Number",
+                                    "start": 176,
+                                    "type": "Identifier",
+                                  },
+                                  "end": 223,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 72,
+                                      "line": 3,
+                                    },
+                                    "start": Position {
+                                      "column": 25,
+                                      "line": 3,
+                                    },
+                                  },
+                                  "start": 176,
+                                  "type": "CallExpression",
+                                },
+                                "start": 155,
+                                "type": "AssignmentExpression",
                               },
-                              "start": Position {
-                                "column": 2,
-                                "line": 2,
-                              },
-                            },
-                            "object": Node {
-                              "end": 39,
                               "loc": SourceLocation {
                                 "end": Position {
-                                  "column": 3,
-                                  "line": 2,
+                                  "column": 73,
+                                  "line": 3,
                                 },
-                                "identifierName": "g",
-                                "start": Position {
-                                  "column": 2,
-                                  "line": 2,
-                                },
-                              },
-                              "name": "g",
-                              "start": 38,
-                              "type": "Identifier",
-                            },
-                            "property": Node {
-                              "end": 58,
-                              "loc": SourceLocation {
-                                "end": Position {
-                                  "column": 22,
-                                  "line": 2,
-                                },
-                                "identifierName": "__mutantCoverage__",
                                 "start": Position {
                                   "column": 4,
-                                  "line": 2,
+                                  "line": 3,
                                 },
                               },
-                              "name": "__mutantCoverage__",
-                              "start": 40,
-                              "type": "Identifier",
+                              "start": 155,
+                              "type": "ExpressionStatement",
                             },
-                            "start": 38,
-                            "type": "MemberExpression",
-                          },
+                          ],
+                          "directives": Array [],
+                          "end": 228,
                           "loc": SourceLocation {
                             "end": Position {
-                              "column": 76,
-                              "line": 2,
+                              "column": 3,
+                              "line": 4,
                             },
                             "start": Position {
-                              "column": 2,
+                              "column": 113,
                               "line": 2,
                             },
                           },
-                          "operator": "=",
-                          "right": Node {
-                            "end": 112,
-                            "left": Node {
-                              "computed": false,
-                              "end": 81,
-                              "loc": SourceLocation {
-                                "end": Position {
-                                  "column": 45,
-                                  "line": 2,
-                                },
-                                "start": Position {
-                                  "column": 25,
-                                  "line": 2,
-                                },
-                              },
-                              "object": Node {
-                                "end": 62,
-                                "loc": SourceLocation {
-                                  "end": Position {
-                                    "column": 26,
-                                    "line": 2,
-                                  },
-                                  "identifierName": "g",
-                                  "start": Position {
-                                    "column": 25,
-                                    "line": 2,
-                                  },
-                                },
-                                "name": "g",
-                                "start": 61,
-                                "type": "Identifier",
-                              },
-                              "property": Node {
-                                "end": 81,
-                                "loc": SourceLocation {
-                                  "end": Position {
-                                    "column": 45,
-                                    "line": 2,
-                                  },
-                                  "identifierName": "__mutantCoverage__",
-                                  "start": Position {
-                                    "column": 27,
-                                    "line": 2,
-                                  },
-                                },
-                                "name": "__mutantCoverage__",
-                                "start": 63,
-                                "type": "Identifier",
-                              },
-                              "start": 61,
-                              "type": "MemberExpression",
-                            },
-                            "loc": SourceLocation {
-                              "end": Position {
-                                "column": 76,
-                                "line": 2,
-                              },
-                              "start": Position {
-                                "column": 25,
-                                "line": 2,
-                              },
-                            },
-                            "operator": "||",
-                            "right": Node {
-                              "end": 112,
-                              "loc": SourceLocation {
-                                "end": Position {
-                                  "column": 76,
-                                  "line": 2,
-                                },
-                                "start": Position {
-                                  "column": 49,
-                                  "line": 2,
-                                },
-                              },
-                              "properties": Array [
-                                Node {
-                                  "computed": false,
-                                  "end": 97,
-                                  "key": Node {
-                                    "end": 93,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 57,
-                                        "line": 2,
-                                      },
-                                      "identifierName": "static",
-                                      "start": Position {
-                                        "column": 51,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "name": "static",
-                                    "start": 87,
-                                    "type": "Identifier",
-                                  },
-                                  "loc": SourceLocation {
-                                    "end": Position {
-                                      "column": 61,
-                                      "line": 2,
-                                    },
-                                    "start": Position {
-                                      "column": 51,
-                                      "line": 2,
-                                    },
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "start": 87,
-                                  "type": "ObjectProperty",
-                                  "value": Node {
-                                    "end": 97,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 61,
-                                        "line": 2,
-                                      },
-                                      "start": Position {
-                                        "column": 59,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "properties": Array [],
-                                    "start": 95,
-                                    "type": "ObjectExpression",
-                                  },
-                                },
-                                Node {
-                                  "computed": false,
-                                  "end": 110,
-                                  "key": Node {
-                                    "end": 106,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 70,
-                                        "line": 2,
-                                      },
-                                      "identifierName": "perTest",
-                                      "start": Position {
-                                        "column": 63,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "name": "perTest",
-                                    "start": 99,
-                                    "type": "Identifier",
-                                  },
-                                  "loc": SourceLocation {
-                                    "end": Position {
-                                      "column": 74,
-                                      "line": 2,
-                                    },
-                                    "start": Position {
-                                      "column": 63,
-                                      "line": 2,
-                                    },
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "start": 99,
-                                  "type": "ObjectProperty",
-                                  "value": Node {
-                                    "end": 110,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 74,
-                                        "line": 2,
-                                      },
-                                      "start": Position {
-                                        "column": 72,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "properties": Array [],
-                                    "start": 108,
-                                    "type": "ObjectExpression",
-                                  },
-                                },
-                              ],
-                              "start": 85,
-                              "type": "ObjectExpression",
-                            },
-                            "start": 61,
-                            "type": "LogicalExpression",
-                          },
-                          "start": 38,
-                          "type": "AssignmentExpression",
+                          "start": 149,
+                          "type": "BlockStatement",
                         },
+                        "end": 228,
                         "loc": SourceLocation {
                           "end": Position {
-                            "column": 77,
-                            "line": 2,
+                            "column": 3,
+                            "line": 4,
                           },
                           "start": Position {
                             "column": 2,
@@ -383,133 +382,779 @@ Object {
                           },
                         },
                         "start": 38,
-                        "type": "ExpressionStatement",
-                      },
-                      Node {
-                        "end": 475,
-                        "expression": Node {
-                          "end": 474,
+                        "test": Node {
+                          "end": 147,
                           "left": Node {
-                            "computed": false,
-                            "end": 133,
+                            "end": 104,
+                            "left": Node {
+                              "end": 87,
+                              "left": Node {
+                                "end": 74,
+                                "left": Node {
+                                  "computed": false,
+                                  "end": 60,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 24,
+                                      "line": 2,
+                                    },
+                                    "start": Position {
+                                      "column": 6,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "object": Node {
+                                    "end": 43,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 7,
+                                        "line": 2,
+                                      },
+                                      "identifierName": "g",
+                                      "start": Position {
+                                        "column": 6,
+                                        "line": 2,
+                                      },
+                                    },
+                                    "name": "g",
+                                    "start": 42,
+                                    "type": "Identifier",
+                                  },
+                                  "property": Node {
+                                    "end": 60,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 24,
+                                        "line": 2,
+                                      },
+                                      "identifierName": "__activeMutant__",
+                                      "start": Position {
+                                        "column": 8,
+                                        "line": 2,
+                                      },
+                                    },
+                                    "name": "__activeMutant__",
+                                    "start": 44,
+                                    "type": "Identifier",
+                                  },
+                                  "start": 42,
+                                  "type": "MemberExpression",
+                                },
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 38,
+                                    "line": 2,
+                                  },
+                                  "start": Position {
+                                    "column": 6,
+                                    "line": 2,
+                                  },
+                                },
+                                "operator": "===",
+                                "right": Node {
+                                  "end": 74,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 38,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "undefined",
+                                    "start": Position {
+                                      "column": 29,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "undefined",
+                                  "start": 65,
+                                  "type": "Identifier",
+                                },
+                                "start": 42,
+                                "type": "BinaryExpression",
+                              },
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 51,
+                                  "line": 2,
+                                },
+                                "start": Position {
+                                  "column": 6,
+                                  "line": 2,
+                                },
+                              },
+                              "operator": "&&",
+                              "right": Node {
+                                "computed": false,
+                                "end": 87,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 51,
+                                    "line": 2,
+                                  },
+                                  "start": Position {
+                                    "column": 42,
+                                    "line": 2,
+                                  },
+                                },
+                                "object": Node {
+                                  "end": 79,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 43,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "g",
+                                    "start": Position {
+                                      "column": 42,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "g",
+                                  "start": 78,
+                                  "type": "Identifier",
+                                },
+                                "property": Node {
+                                  "end": 87,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 51,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "process",
+                                    "start": Position {
+                                      "column": 44,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "process",
+                                  "start": 80,
+                                  "type": "Identifier",
+                                },
+                                "start": 78,
+                                "type": "MemberExpression",
+                              },
+                              "start": 42,
+                              "type": "LogicalExpression",
+                            },
                             "loc": SourceLocation {
                               "end": Position {
-                                "column": 19,
-                                "line": 3,
+                                "column": 68,
+                                "line": 2,
                               },
                               "start": Position {
-                                "column": 2,
-                                "line": 3,
+                                "column": 6,
+                                "line": 2,
+                              },
+                            },
+                            "operator": "&&",
+                            "right": Node {
+                              "computed": false,
+                              "end": 104,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 68,
+                                  "line": 2,
+                                },
+                                "start": Position {
+                                  "column": 55,
+                                  "line": 2,
+                                },
+                              },
+                              "object": Node {
+                                "computed": false,
+                                "end": 100,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 64,
+                                    "line": 2,
+                                  },
+                                  "start": Position {
+                                    "column": 55,
+                                    "line": 2,
+                                  },
+                                },
+                                "object": Node {
+                                  "end": 92,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 56,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "g",
+                                    "start": Position {
+                                      "column": 55,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "g",
+                                  "start": 91,
+                                  "type": "Identifier",
+                                },
+                                "property": Node {
+                                  "end": 100,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 64,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "process",
+                                    "start": Position {
+                                      "column": 57,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "process",
+                                  "start": 93,
+                                  "type": "Identifier",
+                                },
+                                "start": 91,
+                                "type": "MemberExpression",
+                              },
+                              "property": Node {
+                                "end": 104,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 68,
+                                    "line": 2,
+                                  },
+                                  "identifierName": "env",
+                                  "start": Position {
+                                    "column": 65,
+                                    "line": 2,
+                                  },
+                                },
+                                "name": "env",
+                                "start": 101,
+                                "type": "Identifier",
+                              },
+                              "start": 91,
+                              "type": "MemberExpression",
+                            },
+                            "start": 42,
+                            "type": "LogicalExpression",
+                          },
+                          "loc": SourceLocation {
+                            "end": Position {
+                              "column": 111,
+                              "line": 2,
+                            },
+                            "start": Position {
+                              "column": 6,
+                              "line": 2,
+                            },
+                          },
+                          "operator": "&&",
+                          "right": Node {
+                            "computed": false,
+                            "end": 147,
+                            "loc": SourceLocation {
+                              "end": Position {
+                                "column": 111,
+                                "line": 2,
+                              },
+                              "start": Position {
+                                "column": 72,
+                                "line": 2,
                               },
                             },
                             "object": Node {
-                              "end": 117,
+                              "computed": false,
+                              "end": 121,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 85,
+                                  "line": 2,
+                                },
+                                "start": Position {
+                                  "column": 72,
+                                  "line": 2,
+                                },
+                              },
+                              "object": Node {
+                                "computed": false,
+                                "end": 117,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 81,
+                                    "line": 2,
+                                  },
+                                  "start": Position {
+                                    "column": 72,
+                                    "line": 2,
+                                  },
+                                },
+                                "object": Node {
+                                  "end": 109,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 73,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "g",
+                                    "start": Position {
+                                      "column": 72,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "g",
+                                  "start": 108,
+                                  "type": "Identifier",
+                                },
+                                "property": Node {
+                                  "end": 117,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 81,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "process",
+                                    "start": Position {
+                                      "column": 74,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "process",
+                                  "start": 110,
+                                  "type": "Identifier",
+                                },
+                                "start": 108,
+                                "type": "MemberExpression",
+                              },
+                              "property": Node {
+                                "end": 121,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 85,
+                                    "line": 2,
+                                  },
+                                  "identifierName": "env",
+                                  "start": Position {
+                                    "column": 82,
+                                    "line": 2,
+                                  },
+                                },
+                                "name": "env",
+                                "start": 118,
+                                "type": "Identifier",
+                              },
+                              "start": 108,
+                              "type": "MemberExpression",
+                            },
+                            "property": Node {
+                              "end": 147,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 111,
+                                  "line": 2,
+                                },
+                                "identifierName": "__STRYKER_ACTIVE_MUTANT__",
+                                "start": Position {
+                                  "column": 86,
+                                  "line": 2,
+                                },
+                              },
+                              "name": "__STRYKER_ACTIVE_MUTANT__",
+                              "start": 122,
+                              "type": "Identifier",
+                            },
+                            "start": 108,
+                            "type": "MemberExpression",
+                          },
+                          "start": 42,
+                          "type": "LogicalExpression",
+                        },
+                        "type": "IfStatement",
+                      },
+                      Node {
+                        "end": 306,
+                        "expression": Node {
+                          "end": 305,
+                          "left": Node {
+                            "computed": false,
+                            "end": 251,
+                            "loc": SourceLocation {
+                              "end": Position {
+                                "column": 22,
+                                "line": 5,
+                              },
+                              "start": Position {
+                                "column": 2,
+                                "line": 5,
+                              },
+                            },
+                            "object": Node {
+                              "end": 232,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 3,
-                                  "line": 3,
+                                  "line": 5,
                                 },
                                 "identifierName": "g",
                                 "start": Position {
                                   "column": 2,
-                                  "line": 3,
+                                  "line": 5,
                                 },
                               },
                               "name": "g",
-                              "start": 116,
+                              "start": 231,
                               "type": "Identifier",
                             },
                             "property": Node {
-                              "end": 133,
+                              "end": 251,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 22,
+                                  "line": 5,
+                                },
+                                "identifierName": "__mutantCoverage__",
+                                "start": Position {
+                                  "column": 4,
+                                  "line": 5,
+                                },
+                              },
+                              "name": "__mutantCoverage__",
+                              "start": 233,
+                              "type": "Identifier",
+                            },
+                            "start": 231,
+                            "type": "MemberExpression",
+                          },
+                          "loc": SourceLocation {
+                            "end": Position {
+                              "column": 76,
+                              "line": 5,
+                            },
+                            "start": Position {
+                              "column": 2,
+                              "line": 5,
+                            },
+                          },
+                          "operator": "=",
+                          "right": Node {
+                            "end": 305,
+                            "left": Node {
+                              "computed": false,
+                              "end": 274,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 45,
+                                  "line": 5,
+                                },
+                                "start": Position {
+                                  "column": 25,
+                                  "line": 5,
+                                },
+                              },
+                              "object": Node {
+                                "end": 255,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 26,
+                                    "line": 5,
+                                  },
+                                  "identifierName": "g",
+                                  "start": Position {
+                                    "column": 25,
+                                    "line": 5,
+                                  },
+                                },
+                                "name": "g",
+                                "start": 254,
+                                "type": "Identifier",
+                              },
+                              "property": Node {
+                                "end": 274,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 45,
+                                    "line": 5,
+                                  },
+                                  "identifierName": "__mutantCoverage__",
+                                  "start": Position {
+                                    "column": 27,
+                                    "line": 5,
+                                  },
+                                },
+                                "name": "__mutantCoverage__",
+                                "start": 256,
+                                "type": "Identifier",
+                              },
+                              "start": 254,
+                              "type": "MemberExpression",
+                            },
+                            "loc": SourceLocation {
+                              "end": Position {
+                                "column": 76,
+                                "line": 5,
+                              },
+                              "start": Position {
+                                "column": 25,
+                                "line": 5,
+                              },
+                            },
+                            "operator": "||",
+                            "right": Node {
+                              "end": 305,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 76,
+                                  "line": 5,
+                                },
+                                "start": Position {
+                                  "column": 49,
+                                  "line": 5,
+                                },
+                              },
+                              "properties": Array [
+                                Node {
+                                  "computed": false,
+                                  "end": 290,
+                                  "key": Node {
+                                    "end": 286,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 57,
+                                        "line": 5,
+                                      },
+                                      "identifierName": "static",
+                                      "start": Position {
+                                        "column": 51,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "name": "static",
+                                    "start": 280,
+                                    "type": "Identifier",
+                                  },
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 61,
+                                      "line": 5,
+                                    },
+                                    "start": Position {
+                                      "column": 51,
+                                      "line": 5,
+                                    },
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "start": 280,
+                                  "type": "ObjectProperty",
+                                  "value": Node {
+                                    "end": 290,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 61,
+                                        "line": 5,
+                                      },
+                                      "start": Position {
+                                        "column": 59,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "properties": Array [],
+                                    "start": 288,
+                                    "type": "ObjectExpression",
+                                  },
+                                },
+                                Node {
+                                  "computed": false,
+                                  "end": 303,
+                                  "key": Node {
+                                    "end": 299,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 70,
+                                        "line": 5,
+                                      },
+                                      "identifierName": "perTest",
+                                      "start": Position {
+                                        "column": 63,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "name": "perTest",
+                                    "start": 292,
+                                    "type": "Identifier",
+                                  },
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 74,
+                                      "line": 5,
+                                    },
+                                    "start": Position {
+                                      "column": 63,
+                                      "line": 5,
+                                    },
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "start": 292,
+                                  "type": "ObjectProperty",
+                                  "value": Node {
+                                    "end": 303,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 74,
+                                        "line": 5,
+                                      },
+                                      "start": Position {
+                                        "column": 72,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "properties": Array [],
+                                    "start": 301,
+                                    "type": "ObjectExpression",
+                                  },
+                                },
+                              ],
+                              "start": 278,
+                              "type": "ObjectExpression",
+                            },
+                            "start": 254,
+                            "type": "LogicalExpression",
+                          },
+                          "start": 231,
+                          "type": "AssignmentExpression",
+                        },
+                        "loc": SourceLocation {
+                          "end": Position {
+                            "column": 77,
+                            "line": 5,
+                          },
+                          "start": Position {
+                            "column": 2,
+                            "line": 5,
+                          },
+                        },
+                        "start": 231,
+                        "type": "ExpressionStatement",
+                      },
+                      Node {
+                        "end": 668,
+                        "expression": Node {
+                          "end": 667,
+                          "left": Node {
+                            "computed": false,
+                            "end": 326,
+                            "loc": SourceLocation {
+                              "end": Position {
+                                "column": 19,
+                                "line": 6,
+                              },
+                              "start": Position {
+                                "column": 2,
+                                "line": 6,
+                              },
+                            },
+                            "object": Node {
+                              "end": 310,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 3,
+                                  "line": 6,
+                                },
+                                "identifierName": "g",
+                                "start": Position {
+                                  "column": 2,
+                                  "line": 6,
+                                },
+                              },
+                              "name": "g",
+                              "start": 309,
+                              "type": "Identifier",
+                            },
+                            "property": Node {
+                              "end": 326,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 19,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                                 "identifierName": "__coverMutant__",
                                 "start": Position {
                                   "column": 4,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                               },
                               "name": "__coverMutant__",
-                              "start": 118,
+                              "start": 311,
                               "type": "Identifier",
                             },
-                            "start": 116,
+                            "start": 309,
                             "type": "MemberExpression",
                           },
                           "loc": SourceLocation {
                             "end": Position {
                               "column": 3,
-                              "line": 12,
+                              "line": 15,
                             },
                             "start": Position {
                               "column": 2,
-                              "line": 3,
+                              "line": 6,
                             },
                           },
                           "operator": "=",
                           "right": Node {
-                            "end": 474,
+                            "end": 667,
                             "left": Node {
                               "computed": false,
-                              "end": 153,
+                              "end": 346,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 39,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                                 "start": Position {
                                   "column": 22,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                               },
                               "object": Node {
-                                "end": 137,
+                                "end": 330,
                                 "loc": SourceLocation {
                                   "end": Position {
                                     "column": 23,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                   "identifierName": "g",
                                   "start": Position {
                                     "column": 22,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                 },
                                 "name": "g",
-                                "start": 136,
+                                "start": 329,
                                 "type": "Identifier",
                               },
                               "property": Node {
-                                "end": 153,
+                                "end": 346,
                                 "loc": SourceLocation {
                                   "end": Position {
                                     "column": 39,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                   "identifierName": "__coverMutant__",
                                   "start": Position {
                                     "column": 24,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                 },
                                 "name": "__coverMutant__",
-                                "start": 138,
+                                "start": 331,
                                 "type": "Identifier",
                               },
-                              "start": 136,
+                              "start": 329,
                               "type": "MemberExpression",
                             },
                             "loc": SourceLocation {
                               "end": Position {
                                 "column": 3,
-                                "line": 12,
+                                "line": 15,
                               },
                               "start": Position {
                                 "column": 22,
-                                "line": 3,
+                                "line": 6,
                               },
                             },
                             "operator": "||",
@@ -520,134 +1165,134 @@ Object {
                                   Node {
                                     "declarations": Array [
                                       Node {
-                                        "end": 210,
+                                        "end": 403,
                                         "id": Node {
-                                          "end": 180,
+                                          "end": 373,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 9,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                             "identifierName": "c",
                                             "start": Position {
                                               "column": 8,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                           },
                                           "name": "c",
-                                          "start": 179,
+                                          "start": 372,
                                           "type": "Identifier",
                                         },
                                         "init": Node {
                                           "computed": false,
-                                          "end": 210,
+                                          "end": 403,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 39,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                             "start": Position {
                                               "column": 12,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                           },
                                           "object": Node {
                                             "computed": false,
-                                            "end": 203,
+                                            "end": 396,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 32,
-                                                "line": 4,
+                                                "line": 7,
                                               },
                                               "start": Position {
                                                 "column": 12,
-                                                "line": 4,
+                                                "line": 7,
                                               },
                                             },
                                             "object": Node {
-                                              "end": 184,
+                                              "end": 377,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 13,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                                 "identifierName": "g",
                                                 "start": Position {
                                                   "column": 12,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                               },
                                               "name": "g",
-                                              "start": 183,
+                                              "start": 376,
                                               "type": "Identifier",
                                             },
                                             "property": Node {
-                                              "end": 203,
+                                              "end": 396,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 32,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                                 "identifierName": "__mutantCoverage__",
                                                 "start": Position {
                                                   "column": 14,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                               },
                                               "name": "__mutantCoverage__",
-                                              "start": 185,
+                                              "start": 378,
                                               "type": "Identifier",
                                             },
-                                            "start": 183,
+                                            "start": 376,
                                             "type": "MemberExpression",
                                           },
                                           "property": Node {
-                                            "end": 210,
+                                            "end": 403,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 39,
-                                                "line": 4,
+                                                "line": 7,
                                               },
                                               "identifierName": "static",
                                               "start": Position {
                                                 "column": 33,
-                                                "line": 4,
+                                                "line": 7,
                                               },
                                             },
                                             "name": "static",
-                                            "start": 204,
+                                            "start": 397,
                                             "type": "Identifier",
                                           },
-                                          "start": 183,
+                                          "start": 376,
                                           "type": "MemberExpression",
                                         },
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 39,
-                                            "line": 4,
+                                            "line": 7,
                                           },
                                           "start": Position {
                                             "column": 8,
-                                            "line": 4,
+                                            "line": 7,
                                           },
                                         },
-                                        "start": 179,
+                                        "start": 372,
                                         "type": "VariableDeclarator",
                                       },
                                     ],
-                                    "end": 211,
+                                    "end": 404,
                                     "kind": "var",
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 40,
-                                        "line": 4,
+                                        "line": 7,
                                       },
                                       "start": Position {
                                         "column": 4,
-                                        "line": 4,
+                                        "line": 7,
                                       },
                                     },
-                                    "start": 175,
+                                    "start": 368,
                                     "type": "VariableDeclaration",
                                   },
                                   Node {
@@ -655,475 +1300,475 @@ Object {
                                     "consequent": Node {
                                       "body": Array [
                                         Node {
-                                          "end": 362,
+                                          "end": 555,
                                           "expression": Node {
-                                            "end": 361,
+                                            "end": 554,
                                             "left": Node {
-                                              "end": 250,
+                                              "end": 443,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 7,
-                                                  "line": 6,
+                                                  "line": 9,
                                                 },
                                                 "identifierName": "c",
                                                 "start": Position {
                                                   "column": 6,
-                                                  "line": 6,
+                                                  "line": 9,
                                                 },
                                               },
                                               "name": "c",
-                                              "start": 249,
+                                              "start": 442,
                                               "type": "Identifier",
                                             },
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 118,
-                                                "line": 6,
+                                                "line": 9,
                                               },
                                               "start": Position {
                                                 "column": 6,
-                                                "line": 6,
+                                                "line": 9,
                                               },
                                             },
                                             "operator": "=",
                                             "right": Node {
-                                              "end": 361,
+                                              "end": 554,
                                               "left": Node {
                                                 "computed": true,
-                                                "end": 302,
+                                                "end": 495,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 59,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                   "start": Position {
                                                     "column": 10,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                 },
                                                 "object": Node {
                                                   "computed": false,
-                                                  "end": 281,
+                                                  "end": 474,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 38,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                     "start": Position {
                                                       "column": 10,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                   },
                                                   "object": Node {
                                                     "computed": false,
-                                                    "end": 273,
+                                                    "end": 466,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 30,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "start": Position {
                                                         "column": 10,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "object": Node {
-                                                      "end": 254,
+                                                      "end": 447,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 11,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "g",
                                                         "start": Position {
                                                           "column": 10,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "g",
-                                                      "start": 253,
+                                                      "start": 446,
                                                       "type": "Identifier",
                                                     },
                                                     "property": Node {
-                                                      "end": 273,
+                                                      "end": 466,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 30,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "__mutantCoverage__",
                                                         "start": Position {
                                                           "column": 12,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "__mutantCoverage__",
-                                                      "start": 255,
+                                                      "start": 448,
                                                       "type": "Identifier",
                                                     },
-                                                    "start": 253,
+                                                    "start": 446,
                                                     "type": "MemberExpression",
                                                   },
                                                   "property": Node {
-                                                    "end": 281,
+                                                    "end": 474,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 38,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "identifierName": "perTest",
                                                       "start": Position {
                                                         "column": 31,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "name": "perTest",
-                                                    "start": 274,
+                                                    "start": 467,
                                                     "type": "Identifier",
                                                   },
-                                                  "start": 253,
+                                                  "start": 446,
                                                   "type": "MemberExpression",
                                                 },
                                                 "property": Node {
                                                   "computed": false,
-                                                  "end": 301,
+                                                  "end": 494,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 58,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                     "start": Position {
                                                       "column": 39,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                   },
                                                   "object": Node {
-                                                    "end": 283,
+                                                    "end": 476,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 40,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "identifierName": "g",
                                                       "start": Position {
                                                         "column": 39,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "name": "g",
-                                                    "start": 282,
+                                                    "start": 475,
                                                     "type": "Identifier",
                                                   },
                                                   "property": Node {
-                                                    "end": 301,
+                                                    "end": 494,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 58,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "identifierName": "__currentTestId__",
                                                       "start": Position {
                                                         "column": 41,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "name": "__currentTestId__",
-                                                    "start": 284,
+                                                    "start": 477,
                                                     "type": "Identifier",
                                                   },
-                                                  "start": 282,
+                                                  "start": 475,
                                                   "type": "MemberExpression",
                                                 },
-                                                "start": 253,
+                                                "start": 446,
                                                 "type": "MemberExpression",
                                               },
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 118,
-                                                  "line": 6,
+                                                  "line": 9,
                                                 },
                                                 "start": Position {
                                                   "column": 10,
-                                                  "line": 6,
+                                                  "line": 9,
                                                 },
                                               },
                                               "operator": "=",
                                               "right": Node {
-                                                "end": 361,
+                                                "end": 554,
                                                 "left": Node {
                                                   "computed": true,
-                                                  "end": 355,
+                                                  "end": 548,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 112,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                     "start": Position {
                                                       "column": 63,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                   },
                                                   "object": Node {
                                                     "computed": false,
-                                                    "end": 334,
+                                                    "end": 527,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 91,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "start": Position {
                                                         "column": 63,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "object": Node {
                                                       "computed": false,
-                                                      "end": 326,
+                                                      "end": 519,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 83,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "start": Position {
                                                           "column": 63,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "object": Node {
-                                                        "end": 307,
+                                                        "end": 500,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 64,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                           "identifierName": "g",
                                                           "start": Position {
                                                             "column": 63,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                         },
                                                         "name": "g",
-                                                        "start": 306,
+                                                        "start": 499,
                                                         "type": "Identifier",
                                                       },
                                                       "property": Node {
-                                                        "end": 326,
+                                                        "end": 519,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 83,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                           "identifierName": "__mutantCoverage__",
                                                           "start": Position {
                                                             "column": 65,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                         },
                                                         "name": "__mutantCoverage__",
-                                                        "start": 308,
+                                                        "start": 501,
                                                         "type": "Identifier",
                                                       },
-                                                      "start": 306,
+                                                      "start": 499,
                                                       "type": "MemberExpression",
                                                     },
                                                     "property": Node {
-                                                      "end": 334,
+                                                      "end": 527,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 91,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "perTest",
                                                         "start": Position {
                                                           "column": 84,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "perTest",
-                                                      "start": 327,
+                                                      "start": 520,
                                                       "type": "Identifier",
                                                     },
-                                                    "start": 306,
+                                                    "start": 499,
                                                     "type": "MemberExpression",
                                                   },
                                                   "property": Node {
                                                     "computed": false,
-                                                    "end": 354,
+                                                    "end": 547,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 111,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "start": Position {
                                                         "column": 92,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "object": Node {
-                                                      "end": 336,
+                                                      "end": 529,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 93,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "g",
                                                         "start": Position {
                                                           "column": 92,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "g",
-                                                      "start": 335,
+                                                      "start": 528,
                                                       "type": "Identifier",
                                                     },
                                                     "property": Node {
-                                                      "end": 354,
+                                                      "end": 547,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 111,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "__currentTestId__",
                                                         "start": Position {
                                                           "column": 94,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "__currentTestId__",
-                                                      "start": 337,
+                                                      "start": 530,
                                                       "type": "Identifier",
                                                     },
-                                                    "start": 335,
+                                                    "start": 528,
                                                     "type": "MemberExpression",
                                                   },
-                                                  "start": 306,
+                                                  "start": 499,
                                                   "type": "MemberExpression",
                                                 },
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 118,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                   "start": Position {
                                                     "column": 63,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                 },
                                                 "operator": "||",
                                                 "right": Node {
-                                                  "end": 361,
+                                                  "end": 554,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 118,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                     "start": Position {
                                                       "column": 116,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                   },
                                                   "properties": Array [],
-                                                  "start": 359,
+                                                  "start": 552,
                                                   "type": "ObjectExpression",
                                                 },
-                                                "start": 306,
+                                                "start": 499,
                                                 "type": "LogicalExpression",
                                               },
-                                              "start": 253,
+                                              "start": 446,
                                               "type": "AssignmentExpression",
                                             },
-                                            "start": 249,
+                                            "start": 442,
                                             "type": "AssignmentExpression",
                                           },
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 119,
-                                              "line": 6,
+                                              "line": 9,
                                             },
                                             "start": Position {
                                               "column": 6,
-                                              "line": 6,
+                                              "line": 9,
                                             },
                                           },
-                                          "start": 249,
+                                          "start": 442,
                                           "type": "ExpressionStatement",
                                         },
                                       ],
                                       "directives": Array [],
-                                      "end": 368,
+                                      "end": 561,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 5,
-                                          "line": 7,
+                                          "line": 10,
                                         },
                                         "start": Position {
                                           "column": 29,
-                                          "line": 5,
+                                          "line": 8,
                                         },
                                       },
-                                      "start": 241,
+                                      "start": 434,
                                       "type": "BlockStatement",
                                     },
-                                    "end": 368,
+                                    "end": 561,
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 5,
-                                        "line": 7,
+                                        "line": 10,
                                       },
                                       "start": Position {
                                         "column": 4,
-                                        "line": 5,
+                                        "line": 8,
                                       },
                                     },
-                                    "start": 216,
+                                    "start": 409,
                                     "test": Node {
                                       "computed": false,
-                                      "end": 239,
+                                      "end": 432,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 27,
-                                          "line": 5,
+                                          "line": 8,
                                         },
                                         "start": Position {
                                           "column": 8,
-                                          "line": 5,
+                                          "line": 8,
                                         },
                                       },
                                       "object": Node {
-                                        "end": 221,
+                                        "end": 414,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 9,
-                                            "line": 5,
+                                            "line": 8,
                                           },
                                           "identifierName": "g",
                                           "start": Position {
                                             "column": 8,
-                                            "line": 5,
+                                            "line": 8,
                                           },
                                         },
                                         "name": "g",
-                                        "start": 220,
+                                        "start": 413,
                                         "type": "Identifier",
                                       },
                                       "property": Node {
-                                        "end": 239,
+                                        "end": 432,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 27,
-                                            "line": 5,
+                                            "line": 8,
                                           },
                                           "identifierName": "__currentTestId__",
                                           "start": Position {
                                             "column": 10,
-                                            "line": 5,
+                                            "line": 8,
                                           },
                                         },
                                         "name": "__currentTestId__",
-                                        "start": 222,
+                                        "start": 415,
                                         "type": "Identifier",
                                       },
-                                      "start": 220,
+                                      "start": 413,
                                       "type": "MemberExpression",
                                     },
                                     "type": "IfStatement",
@@ -1131,275 +1776,275 @@ Object {
                                   Node {
                                     "declarations": Array [
                                       Node {
-                                        "end": 390,
+                                        "end": 583,
                                         "id": Node {
-                                          "end": 378,
+                                          "end": 571,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 9,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                             "identifierName": "a",
                                             "start": Position {
                                               "column": 8,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                           },
                                           "name": "a",
-                                          "start": 377,
+                                          "start": 570,
                                           "type": "Identifier",
                                         },
                                         "init": Node {
-                                          "end": 390,
+                                          "end": 583,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 21,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                             "identifierName": "arguments",
                                             "start": Position {
                                               "column": 12,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                           },
                                           "name": "arguments",
-                                          "start": 381,
+                                          "start": 574,
                                           "type": "Identifier",
                                         },
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 21,
-                                            "line": 8,
+                                            "line": 11,
                                           },
                                           "start": Position {
                                             "column": 8,
-                                            "line": 8,
+                                            "line": 11,
                                           },
                                         },
-                                        "start": 377,
+                                        "start": 570,
                                         "type": "VariableDeclarator",
                                       },
                                     ],
-                                    "end": 391,
+                                    "end": 584,
                                     "kind": "var",
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 22,
-                                        "line": 8,
+                                        "line": 11,
                                       },
                                       "start": Position {
                                         "column": 4,
-                                        "line": 8,
+                                        "line": 11,
                                       },
                                     },
-                                    "start": 373,
+                                    "start": 566,
                                     "type": "VariableDeclaration",
                                   },
                                   Node {
                                     "body": Node {
                                       "body": Array [
                                         Node {
-                                          "end": 464,
+                                          "end": 657,
                                           "expression": Node {
-                                            "end": 463,
+                                            "end": 656,
                                             "left": Node {
                                               "computed": true,
-                                              "end": 442,
+                                              "end": 635,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 13,
-                                                  "line": 10,
+                                                  "line": 13,
                                                 },
                                                 "start": Position {
                                                   "column": 6,
-                                                  "line": 10,
+                                                  "line": 13,
                                                 },
                                               },
                                               "object": Node {
-                                                "end": 436,
+                                                "end": 629,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 7,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                   "identifierName": "c",
                                                   "start": Position {
                                                     "column": 6,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                 },
                                                 "name": "c",
-                                                "start": 435,
+                                                "start": 628,
                                                 "type": "Identifier",
                                               },
                                               "property": Node {
                                                 "computed": true,
-                                                "end": 441,
+                                                "end": 634,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 12,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                   "start": Position {
                                                     "column": 8,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                 },
                                                 "object": Node {
-                                                  "end": 438,
+                                                  "end": 631,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 9,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                     "identifierName": "a",
                                                     "start": Position {
                                                       "column": 8,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                   },
                                                   "name": "a",
-                                                  "start": 437,
+                                                  "start": 630,
                                                   "type": "Identifier",
                                                 },
                                                 "property": Node {
-                                                  "end": 440,
+                                                  "end": 633,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 11,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                     "identifierName": "i",
                                                     "start": Position {
                                                       "column": 10,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                   },
                                                   "name": "i",
-                                                  "start": 439,
+                                                  "start": 632,
                                                   "type": "Identifier",
                                                 },
-                                                "start": 437,
+                                                "start": 630,
                                                 "type": "MemberExpression",
                                               },
-                                              "start": 435,
+                                              "start": 628,
                                               "type": "MemberExpression",
                                             },
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 34,
-                                                "line": 10,
+                                                "line": 13,
                                               },
                                               "start": Position {
                                                 "column": 6,
-                                                "line": 10,
+                                                "line": 13,
                                               },
                                             },
                                             "operator": "=",
                                             "right": Node {
-                                              "end": 463,
+                                              "end": 656,
                                               "left": Node {
-                                                "end": 458,
+                                                "end": 651,
                                                 "extra": Object {
-                                                  "parenStart": 445,
+                                                  "parenStart": 638,
                                                   "parenthesized": true,
                                                 },
                                                 "left": Node {
                                                   "computed": true,
-                                                  "end": 453,
+                                                  "end": 646,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 24,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                     "start": Position {
                                                       "column": 17,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                   },
                                                   "object": Node {
-                                                    "end": 447,
+                                                    "end": 640,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 18,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                       "identifierName": "c",
                                                       "start": Position {
                                                         "column": 17,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                     },
                                                     "name": "c",
-                                                    "start": 446,
+                                                    "start": 639,
                                                     "type": "Identifier",
                                                   },
                                                   "property": Node {
                                                     "computed": true,
-                                                    "end": 452,
+                                                    "end": 645,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 23,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                       "start": Position {
                                                         "column": 19,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                     },
                                                     "object": Node {
-                                                      "end": 449,
+                                                      "end": 642,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 20,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                         "identifierName": "a",
                                                         "start": Position {
                                                           "column": 19,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                       },
                                                       "name": "a",
-                                                      "start": 448,
+                                                      "start": 641,
                                                       "type": "Identifier",
                                                     },
                                                     "property": Node {
-                                                      "end": 451,
+                                                      "end": 644,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 22,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                         "identifierName": "i",
                                                         "start": Position {
                                                           "column": 21,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                       },
                                                       "name": "i",
-                                                      "start": 450,
+                                                      "start": 643,
                                                       "type": "Identifier",
                                                     },
-                                                    "start": 448,
+                                                    "start": 641,
                                                     "type": "MemberExpression",
                                                   },
-                                                  "start": 446,
+                                                  "start": 639,
                                                   "type": "MemberExpression",
                                                 },
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 29,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                   "start": Position {
                                                     "column": 17,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                 },
                                                 "operator": "||",
                                                 "right": Node {
-                                                  "end": 458,
+                                                  "end": 651,
                                                   "extra": Object {
                                                     "raw": "0",
                                                     "rawValue": 0,
@@ -1407,33 +2052,33 @@ Object {
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 29,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                     "start": Position {
                                                       "column": 28,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                   },
-                                                  "start": 457,
+                                                  "start": 650,
                                                   "type": "NumericLiteral",
                                                   "value": 0,
                                                 },
-                                                "start": 446,
+                                                "start": 639,
                                                 "type": "LogicalExpression",
                                               },
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 34,
-                                                  "line": 10,
+                                                  "line": 13,
                                                 },
                                                 "start": Position {
                                                   "column": 16,
-                                                  "line": 10,
+                                                  "line": 13,
                                                 },
                                               },
                                               "operator": "+",
                                               "right": Node {
-                                                "end": 463,
+                                                "end": 656,
                                                 "extra": Object {
                                                   "raw": "1",
                                                   "rawValue": 1,
@@ -1441,76 +2086,76 @@ Object {
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 34,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                   "start": Position {
                                                     "column": 33,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                 },
-                                                "start": 462,
+                                                "start": 655,
                                                 "type": "NumericLiteral",
                                                 "value": 1,
                                               },
-                                              "start": 445,
+                                              "start": 638,
                                               "type": "BinaryExpression",
                                             },
-                                            "start": 435,
+                                            "start": 628,
                                             "type": "AssignmentExpression",
                                           },
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 35,
-                                              "line": 10,
+                                              "line": 13,
                                             },
                                             "start": Position {
                                               "column": 6,
-                                              "line": 10,
+                                              "line": 13,
                                             },
                                           },
-                                          "start": 435,
+                                          "start": 628,
                                           "type": "ExpressionStatement",
                                         },
                                       ],
                                       "directives": Array [],
-                                      "end": 470,
+                                      "end": 663,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 5,
-                                          "line": 11,
+                                          "line": 14,
                                         },
                                         "start": Position {
                                           "column": 35,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                       },
-                                      "start": 427,
+                                      "start": 620,
                                       "type": "BlockStatement",
                                     },
-                                    "end": 470,
+                                    "end": 663,
                                     "init": Node {
                                       "declarations": Array [
                                         Node {
-                                          "end": 407,
+                                          "end": 600,
                                           "id": Node {
-                                            "end": 405,
+                                            "end": 598,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 13,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                               "identifierName": "i",
                                               "start": Position {
                                                 "column": 12,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                             },
                                             "name": "i",
-                                            "start": 404,
+                                            "start": 597,
                                             "type": "Identifier",
                                           },
                                           "init": Node {
-                                            "end": 407,
+                                            "end": 600,
                                             "extra": Object {
                                               "raw": "0",
                                               "rawValue": 0,
@@ -1518,267 +2163,267 @@ Object {
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 15,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                               "start": Position {
                                                 "column": 14,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                             },
-                                            "start": 406,
+                                            "start": 599,
                                             "type": "NumericLiteral",
                                             "value": 0,
                                           },
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 15,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                             "start": Position {
                                               "column": 12,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                           },
-                                          "start": 404,
+                                          "start": 597,
                                           "type": "VariableDeclarator",
                                         },
                                       ],
-                                      "end": 407,
+                                      "end": 600,
                                       "kind": "var",
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 15,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                         "start": Position {
                                           "column": 8,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                       },
-                                      "start": 400,
+                                      "start": 593,
                                       "type": "VariableDeclaration",
                                     },
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 5,
-                                        "line": 11,
+                                        "line": 14,
                                       },
                                       "start": Position {
                                         "column": 4,
-                                        "line": 9,
+                                        "line": 12,
                                       },
                                     },
-                                    "start": 396,
+                                    "start": 589,
                                     "test": Node {
-                                      "end": 421,
+                                      "end": 614,
                                       "left": Node {
-                                        "end": 410,
+                                        "end": 603,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 18,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                           "identifierName": "i",
                                           "start": Position {
                                             "column": 17,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                         },
                                         "name": "i",
-                                        "start": 409,
+                                        "start": 602,
                                         "type": "Identifier",
                                       },
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 29,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                         "start": Position {
                                           "column": 17,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                       },
                                       "operator": "<",
                                       "right": Node {
                                         "computed": false,
-                                        "end": 421,
+                                        "end": 614,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 29,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                           "start": Position {
                                             "column": 21,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                         },
                                         "object": Node {
-                                          "end": 414,
+                                          "end": 607,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 22,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                             "identifierName": "a",
                                             "start": Position {
                                               "column": 21,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                           },
                                           "name": "a",
-                                          "start": 413,
+                                          "start": 606,
                                           "type": "Identifier",
                                         },
                                         "property": Node {
-                                          "end": 421,
+                                          "end": 614,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 29,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                             "identifierName": "length",
                                             "start": Position {
                                               "column": 23,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                           },
                                           "name": "length",
-                                          "start": 415,
+                                          "start": 608,
                                           "type": "Identifier",
                                         },
-                                        "start": 413,
+                                        "start": 606,
                                         "type": "MemberExpression",
                                       },
-                                      "start": 409,
+                                      "start": 602,
                                       "type": "BinaryExpression",
                                     },
                                     "type": "ForStatement",
                                     "update": Node {
                                       "argument": Node {
-                                        "end": 424,
+                                        "end": 617,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 32,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                           "identifierName": "i",
                                           "start": Position {
                                             "column": 31,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                         },
                                         "name": "i",
-                                        "start": 423,
+                                        "start": 616,
                                         "type": "Identifier",
                                       },
-                                      "end": 426,
+                                      "end": 619,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 34,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                         "start": Position {
                                           "column": 31,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                       },
                                       "operator": "++",
                                       "prefix": false,
-                                      "start": 423,
+                                      "start": 616,
                                       "type": "UpdateExpression",
                                     },
                                   },
                                 ],
                                 "directives": Array [],
-                                "end": 474,
+                                "end": 667,
                                 "loc": SourceLocation {
                                   "end": Position {
                                     "column": 3,
-                                    "line": 12,
+                                    "line": 15,
                                   },
                                   "start": Position {
                                     "column": 55,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                 },
-                                "start": 169,
+                                "start": 362,
                                 "type": "BlockStatement",
                               },
-                              "end": 474,
+                              "end": 667,
                               "generator": false,
                               "id": null,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 3,
-                                  "line": 12,
+                                  "line": 15,
                                 },
                                 "start": Position {
                                   "column": 43,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                               },
                               "params": Array [],
-                              "start": 157,
+                              "start": 350,
                               "type": "FunctionExpression",
                             },
-                            "start": 136,
+                            "start": 329,
                             "type": "LogicalExpression",
                           },
-                          "start": 116,
+                          "start": 309,
                           "type": "AssignmentExpression",
                         },
                         "loc": SourceLocation {
                           "end": Position {
                             "column": 4,
-                            "line": 12,
+                            "line": 15,
                           },
                           "start": Position {
                             "column": 2,
-                            "line": 3,
+                            "line": 6,
                           },
                         },
-                        "start": 116,
+                        "start": 309,
                         "type": "ExpressionStatement",
                       },
                       Node {
                         "argument": Node {
-                          "end": 486,
+                          "end": 679,
                           "loc": SourceLocation {
                             "end": Position {
                               "column": 10,
-                              "line": 13,
+                              "line": 16,
                             },
                             "identifierName": "g",
                             "start": Position {
                               "column": 9,
-                              "line": 13,
+                              "line": 16,
                             },
                           },
                           "name": "g",
-                          "start": 485,
+                          "start": 678,
                           "type": "Identifier",
                         },
-                        "end": 487,
+                        "end": 680,
                         "loc": SourceLocation {
                           "end": Position {
                             "column": 11,
-                            "line": 13,
+                            "line": 16,
                           },
                           "start": Position {
                             "column": 2,
-                            "line": 13,
+                            "line": 16,
                           },
                         },
-                        "start": 478,
+                        "start": 671,
                         "type": "ReturnStatement",
                       },
                     ],
                     "directives": Array [],
-                    "end": 489,
+                    "end": 682,
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 1,
-                        "line": 14,
+                        "line": 17,
                       },
                       "start": Position {
                         "column": 34,
@@ -1788,7 +2433,7 @@ Object {
                     "start": 34,
                     "type": "BlockStatement",
                   },
-                  "end": 489,
+                  "end": 682,
                   "extra": Object {
                     "parenStart": 22,
                     "parenthesized": true,
@@ -1798,7 +2443,7 @@ Object {
                   "loc": SourceLocation {
                     "end": Position {
                       "column": 1,
-                      "line": 14,
+                      "line": 17,
                     },
                     "start": Position {
                       "column": 23,
@@ -1827,11 +2472,11 @@ Object {
                   "start": 23,
                   "type": "FunctionExpression",
                 },
-                "end": 521,
+                "end": 714,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 33,
-                    "line": 14,
+                    "line": 17,
                   },
                   "start": Position {
                     "column": 22,
@@ -1844,7 +2489,7 @@ Object {
               "loc": SourceLocation {
                 "end": Position {
                   "column": 33,
-                  "line": 14,
+                  "line": 17,
                 },
                 "start": Position {
                   "column": 4,
@@ -1855,12 +2500,12 @@ Object {
               "type": "VariableDeclarator",
             },
           ],
-          "end": 521,
+          "end": 714,
           "kind": "var",
           "loc": SourceLocation {
             "end": Position {
               "column": 33,
-              "line": 14,
+              "line": 17,
             },
             "start": Position {
               "column": 0,
@@ -2140,7 +2785,7 @@ Object {
         Node {
           "declarations": Array [
             Node {
-              "end": 521,
+              "end": 714,
               "id": Node {
                 "end": 19,
                 "loc": SourceLocation {
@@ -2165,7 +2810,7 @@ Object {
                     "callee": Node {
                       "arguments": Array [
                         Node {
-                          "end": 517,
+                          "end": 710,
                           "extra": Object {
                             "raw": "\\"return this\\"",
                             "rawValue": "return this",
@@ -2173,61 +2818,61 @@ Object {
                           "loc": SourceLocation {
                             "end": Position {
                               "column": 29,
-                              "line": 14,
+                              "line": 17,
                             },
                             "start": Position {
                               "column": 16,
-                              "line": 14,
+                              "line": 17,
                             },
                           },
-                          "start": 504,
+                          "start": 697,
                           "type": "StringLiteral",
                           "value": "return this",
                         },
                       ],
                       "callee": Node {
-                        "end": 503,
+                        "end": 696,
                         "loc": SourceLocation {
                           "end": Position {
                             "column": 15,
-                            "line": 14,
+                            "line": 17,
                           },
                           "identifierName": "Function",
                           "start": Position {
                             "column": 7,
-                            "line": 14,
+                            "line": 17,
                           },
                         },
                         "name": "Function",
-                        "start": 495,
+                        "start": 688,
                         "type": "Identifier",
                       },
-                      "end": 518,
+                      "end": 711,
                       "loc": SourceLocation {
                         "end": Position {
                           "column": 30,
-                          "line": 14,
+                          "line": 17,
                         },
                         "start": Position {
                           "column": 3,
-                          "line": 14,
+                          "line": 17,
                         },
                       },
-                      "start": 491,
+                      "start": 684,
                       "type": "NewExpression",
                     },
-                    "end": 520,
+                    "end": 713,
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 32,
-                        "line": 14,
+                        "line": 17,
                       },
                       "start": Position {
                         "column": 3,
-                        "line": 14,
+                        "line": 17,
                       },
                     },
-                    "start": 491,
+                    "start": 684,
                     "type": "CallExpression",
                   },
                 ],
@@ -2236,262 +2881,261 @@ Object {
                   "body": Node {
                     "body": Array [
                       Node {
-                        "end": 113,
-                        "expression": Node {
-                          "end": 112,
-                          "left": Node {
-                            "computed": false,
-                            "end": 58,
-                            "loc": SourceLocation {
-                              "end": Position {
-                                "column": 22,
-                                "line": 2,
+                        "alternate": null,
+                        "consequent": Node {
+                          "body": Array [
+                            Node {
+                              "end": 224,
+                              "expression": Node {
+                                "end": 223,
+                                "left": Node {
+                                  "computed": false,
+                                  "end": 173,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 22,
+                                      "line": 3,
+                                    },
+                                    "start": Position {
+                                      "column": 4,
+                                      "line": 3,
+                                    },
+                                  },
+                                  "object": Node {
+                                    "end": 156,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 5,
+                                        "line": 3,
+                                      },
+                                      "identifierName": "g",
+                                      "start": Position {
+                                        "column": 4,
+                                        "line": 3,
+                                      },
+                                    },
+                                    "name": "g",
+                                    "start": 155,
+                                    "type": "Identifier",
+                                  },
+                                  "property": Node {
+                                    "end": 173,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 22,
+                                        "line": 3,
+                                      },
+                                      "identifierName": "__activeMutant__",
+                                      "start": Position {
+                                        "column": 6,
+                                        "line": 3,
+                                      },
+                                    },
+                                    "name": "__activeMutant__",
+                                    "start": 157,
+                                    "type": "Identifier",
+                                  },
+                                  "start": 155,
+                                  "type": "MemberExpression",
+                                },
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 72,
+                                    "line": 3,
+                                  },
+                                  "start": Position {
+                                    "column": 4,
+                                    "line": 3,
+                                  },
+                                },
+                                "operator": "=",
+                                "right": Node {
+                                  "arguments": Array [
+                                    Node {
+                                      "computed": false,
+                                      "end": 222,
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 71,
+                                          "line": 3,
+                                        },
+                                        "start": Position {
+                                          "column": 32,
+                                          "line": 3,
+                                        },
+                                      },
+                                      "object": Node {
+                                        "computed": false,
+                                        "end": 196,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 45,
+                                            "line": 3,
+                                          },
+                                          "start": Position {
+                                            "column": 32,
+                                            "line": 3,
+                                          },
+                                        },
+                                        "object": Node {
+                                          "computed": false,
+                                          "end": 192,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 41,
+                                              "line": 3,
+                                            },
+                                            "start": Position {
+                                              "column": 32,
+                                              "line": 3,
+                                            },
+                                          },
+                                          "object": Node {
+                                            "end": 184,
+                                            "loc": SourceLocation {
+                                              "end": Position {
+                                                "column": 33,
+                                                "line": 3,
+                                              },
+                                              "identifierName": "g",
+                                              "start": Position {
+                                                "column": 32,
+                                                "line": 3,
+                                              },
+                                            },
+                                            "name": "g",
+                                            "start": 183,
+                                            "type": "Identifier",
+                                          },
+                                          "property": Node {
+                                            "end": 192,
+                                            "loc": SourceLocation {
+                                              "end": Position {
+                                                "column": 41,
+                                                "line": 3,
+                                              },
+                                              "identifierName": "process",
+                                              "start": Position {
+                                                "column": 34,
+                                                "line": 3,
+                                              },
+                                            },
+                                            "name": "process",
+                                            "start": 185,
+                                            "type": "Identifier",
+                                          },
+                                          "start": 183,
+                                          "type": "MemberExpression",
+                                        },
+                                        "property": Node {
+                                          "end": 196,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 45,
+                                              "line": 3,
+                                            },
+                                            "identifierName": "env",
+                                            "start": Position {
+                                              "column": 42,
+                                              "line": 3,
+                                            },
+                                          },
+                                          "name": "env",
+                                          "start": 193,
+                                          "type": "Identifier",
+                                        },
+                                        "start": 183,
+                                        "type": "MemberExpression",
+                                      },
+                                      "property": Node {
+                                        "end": 222,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 71,
+                                            "line": 3,
+                                          },
+                                          "identifierName": "__STRYKER_ACTIVE_MUTANT__",
+                                          "start": Position {
+                                            "column": 46,
+                                            "line": 3,
+                                          },
+                                        },
+                                        "name": "__STRYKER_ACTIVE_MUTANT__",
+                                        "start": 197,
+                                        "type": "Identifier",
+                                      },
+                                      "start": 183,
+                                      "type": "MemberExpression",
+                                    },
+                                  ],
+                                  "callee": Node {
+                                    "end": 182,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 31,
+                                        "line": 3,
+                                      },
+                                      "identifierName": "Number",
+                                      "start": Position {
+                                        "column": 25,
+                                        "line": 3,
+                                      },
+                                    },
+                                    "name": "Number",
+                                    "start": 176,
+                                    "type": "Identifier",
+                                  },
+                                  "end": 223,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 72,
+                                      "line": 3,
+                                    },
+                                    "start": Position {
+                                      "column": 25,
+                                      "line": 3,
+                                    },
+                                  },
+                                  "start": 176,
+                                  "type": "CallExpression",
+                                },
+                                "start": 155,
+                                "type": "AssignmentExpression",
                               },
-                              "start": Position {
-                                "column": 2,
-                                "line": 2,
-                              },
-                            },
-                            "object": Node {
-                              "end": 39,
                               "loc": SourceLocation {
                                 "end": Position {
-                                  "column": 3,
-                                  "line": 2,
+                                  "column": 73,
+                                  "line": 3,
                                 },
-                                "identifierName": "g",
-                                "start": Position {
-                                  "column": 2,
-                                  "line": 2,
-                                },
-                              },
-                              "name": "g",
-                              "start": 38,
-                              "type": "Identifier",
-                            },
-                            "property": Node {
-                              "end": 58,
-                              "loc": SourceLocation {
-                                "end": Position {
-                                  "column": 22,
-                                  "line": 2,
-                                },
-                                "identifierName": "__mutantCoverage__",
                                 "start": Position {
                                   "column": 4,
-                                  "line": 2,
+                                  "line": 3,
                                 },
                               },
-                              "name": "__mutantCoverage__",
-                              "start": 40,
-                              "type": "Identifier",
+                              "start": 155,
+                              "type": "ExpressionStatement",
                             },
-                            "start": 38,
-                            "type": "MemberExpression",
-                          },
+                          ],
+                          "directives": Array [],
+                          "end": 228,
                           "loc": SourceLocation {
                             "end": Position {
-                              "column": 76,
-                              "line": 2,
+                              "column": 3,
+                              "line": 4,
                             },
                             "start": Position {
-                              "column": 2,
+                              "column": 113,
                               "line": 2,
                             },
                           },
-                          "operator": "=",
-                          "right": Node {
-                            "end": 112,
-                            "left": Node {
-                              "computed": false,
-                              "end": 81,
-                              "loc": SourceLocation {
-                                "end": Position {
-                                  "column": 45,
-                                  "line": 2,
-                                },
-                                "start": Position {
-                                  "column": 25,
-                                  "line": 2,
-                                },
-                              },
-                              "object": Node {
-                                "end": 62,
-                                "loc": SourceLocation {
-                                  "end": Position {
-                                    "column": 26,
-                                    "line": 2,
-                                  },
-                                  "identifierName": "g",
-                                  "start": Position {
-                                    "column": 25,
-                                    "line": 2,
-                                  },
-                                },
-                                "name": "g",
-                                "start": 61,
-                                "type": "Identifier",
-                              },
-                              "property": Node {
-                                "end": 81,
-                                "loc": SourceLocation {
-                                  "end": Position {
-                                    "column": 45,
-                                    "line": 2,
-                                  },
-                                  "identifierName": "__mutantCoverage__",
-                                  "start": Position {
-                                    "column": 27,
-                                    "line": 2,
-                                  },
-                                },
-                                "name": "__mutantCoverage__",
-                                "start": 63,
-                                "type": "Identifier",
-                              },
-                              "start": 61,
-                              "type": "MemberExpression",
-                            },
-                            "loc": SourceLocation {
-                              "end": Position {
-                                "column": 76,
-                                "line": 2,
-                              },
-                              "start": Position {
-                                "column": 25,
-                                "line": 2,
-                              },
-                            },
-                            "operator": "||",
-                            "right": Node {
-                              "end": 112,
-                              "loc": SourceLocation {
-                                "end": Position {
-                                  "column": 76,
-                                  "line": 2,
-                                },
-                                "start": Position {
-                                  "column": 49,
-                                  "line": 2,
-                                },
-                              },
-                              "properties": Array [
-                                Node {
-                                  "computed": false,
-                                  "end": 97,
-                                  "key": Node {
-                                    "end": 93,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 57,
-                                        "line": 2,
-                                      },
-                                      "identifierName": "static",
-                                      "start": Position {
-                                        "column": 51,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "name": "static",
-                                    "start": 87,
-                                    "type": "Identifier",
-                                  },
-                                  "loc": SourceLocation {
-                                    "end": Position {
-                                      "column": 61,
-                                      "line": 2,
-                                    },
-                                    "start": Position {
-                                      "column": 51,
-                                      "line": 2,
-                                    },
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "start": 87,
-                                  "type": "ObjectProperty",
-                                  "value": Node {
-                                    "end": 97,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 61,
-                                        "line": 2,
-                                      },
-                                      "start": Position {
-                                        "column": 59,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "properties": Array [],
-                                    "start": 95,
-                                    "type": "ObjectExpression",
-                                  },
-                                },
-                                Node {
-                                  "computed": false,
-                                  "end": 110,
-                                  "key": Node {
-                                    "end": 106,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 70,
-                                        "line": 2,
-                                      },
-                                      "identifierName": "perTest",
-                                      "start": Position {
-                                        "column": 63,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "name": "perTest",
-                                    "start": 99,
-                                    "type": "Identifier",
-                                  },
-                                  "loc": SourceLocation {
-                                    "end": Position {
-                                      "column": 74,
-                                      "line": 2,
-                                    },
-                                    "start": Position {
-                                      "column": 63,
-                                      "line": 2,
-                                    },
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "start": 99,
-                                  "type": "ObjectProperty",
-                                  "value": Node {
-                                    "end": 110,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 74,
-                                        "line": 2,
-                                      },
-                                      "start": Position {
-                                        "column": 72,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "properties": Array [],
-                                    "start": 108,
-                                    "type": "ObjectExpression",
-                                  },
-                                },
-                              ],
-                              "start": 85,
-                              "type": "ObjectExpression",
-                            },
-                            "start": 61,
-                            "type": "LogicalExpression",
-                          },
-                          "start": 38,
-                          "type": "AssignmentExpression",
+                          "start": 149,
+                          "type": "BlockStatement",
                         },
+                        "end": 228,
                         "loc": SourceLocation {
                           "end": Position {
-                            "column": 77,
-                            "line": 2,
+                            "column": 3,
+                            "line": 4,
                           },
                           "start": Position {
                             "column": 2,
@@ -2499,133 +3143,779 @@ Object {
                           },
                         },
                         "start": 38,
-                        "type": "ExpressionStatement",
-                      },
-                      Node {
-                        "end": 475,
-                        "expression": Node {
-                          "end": 474,
+                        "test": Node {
+                          "end": 147,
                           "left": Node {
-                            "computed": false,
-                            "end": 133,
+                            "end": 104,
+                            "left": Node {
+                              "end": 87,
+                              "left": Node {
+                                "end": 74,
+                                "left": Node {
+                                  "computed": false,
+                                  "end": 60,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 24,
+                                      "line": 2,
+                                    },
+                                    "start": Position {
+                                      "column": 6,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "object": Node {
+                                    "end": 43,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 7,
+                                        "line": 2,
+                                      },
+                                      "identifierName": "g",
+                                      "start": Position {
+                                        "column": 6,
+                                        "line": 2,
+                                      },
+                                    },
+                                    "name": "g",
+                                    "start": 42,
+                                    "type": "Identifier",
+                                  },
+                                  "property": Node {
+                                    "end": 60,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 24,
+                                        "line": 2,
+                                      },
+                                      "identifierName": "__activeMutant__",
+                                      "start": Position {
+                                        "column": 8,
+                                        "line": 2,
+                                      },
+                                    },
+                                    "name": "__activeMutant__",
+                                    "start": 44,
+                                    "type": "Identifier",
+                                  },
+                                  "start": 42,
+                                  "type": "MemberExpression",
+                                },
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 38,
+                                    "line": 2,
+                                  },
+                                  "start": Position {
+                                    "column": 6,
+                                    "line": 2,
+                                  },
+                                },
+                                "operator": "===",
+                                "right": Node {
+                                  "end": 74,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 38,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "undefined",
+                                    "start": Position {
+                                      "column": 29,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "undefined",
+                                  "start": 65,
+                                  "type": "Identifier",
+                                },
+                                "start": 42,
+                                "type": "BinaryExpression",
+                              },
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 51,
+                                  "line": 2,
+                                },
+                                "start": Position {
+                                  "column": 6,
+                                  "line": 2,
+                                },
+                              },
+                              "operator": "&&",
+                              "right": Node {
+                                "computed": false,
+                                "end": 87,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 51,
+                                    "line": 2,
+                                  },
+                                  "start": Position {
+                                    "column": 42,
+                                    "line": 2,
+                                  },
+                                },
+                                "object": Node {
+                                  "end": 79,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 43,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "g",
+                                    "start": Position {
+                                      "column": 42,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "g",
+                                  "start": 78,
+                                  "type": "Identifier",
+                                },
+                                "property": Node {
+                                  "end": 87,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 51,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "process",
+                                    "start": Position {
+                                      "column": 44,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "process",
+                                  "start": 80,
+                                  "type": "Identifier",
+                                },
+                                "start": 78,
+                                "type": "MemberExpression",
+                              },
+                              "start": 42,
+                              "type": "LogicalExpression",
+                            },
                             "loc": SourceLocation {
                               "end": Position {
-                                "column": 19,
-                                "line": 3,
+                                "column": 68,
+                                "line": 2,
                               },
                               "start": Position {
-                                "column": 2,
-                                "line": 3,
+                                "column": 6,
+                                "line": 2,
+                              },
+                            },
+                            "operator": "&&",
+                            "right": Node {
+                              "computed": false,
+                              "end": 104,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 68,
+                                  "line": 2,
+                                },
+                                "start": Position {
+                                  "column": 55,
+                                  "line": 2,
+                                },
+                              },
+                              "object": Node {
+                                "computed": false,
+                                "end": 100,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 64,
+                                    "line": 2,
+                                  },
+                                  "start": Position {
+                                    "column": 55,
+                                    "line": 2,
+                                  },
+                                },
+                                "object": Node {
+                                  "end": 92,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 56,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "g",
+                                    "start": Position {
+                                      "column": 55,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "g",
+                                  "start": 91,
+                                  "type": "Identifier",
+                                },
+                                "property": Node {
+                                  "end": 100,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 64,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "process",
+                                    "start": Position {
+                                      "column": 57,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "process",
+                                  "start": 93,
+                                  "type": "Identifier",
+                                },
+                                "start": 91,
+                                "type": "MemberExpression",
+                              },
+                              "property": Node {
+                                "end": 104,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 68,
+                                    "line": 2,
+                                  },
+                                  "identifierName": "env",
+                                  "start": Position {
+                                    "column": 65,
+                                    "line": 2,
+                                  },
+                                },
+                                "name": "env",
+                                "start": 101,
+                                "type": "Identifier",
+                              },
+                              "start": 91,
+                              "type": "MemberExpression",
+                            },
+                            "start": 42,
+                            "type": "LogicalExpression",
+                          },
+                          "loc": SourceLocation {
+                            "end": Position {
+                              "column": 111,
+                              "line": 2,
+                            },
+                            "start": Position {
+                              "column": 6,
+                              "line": 2,
+                            },
+                          },
+                          "operator": "&&",
+                          "right": Node {
+                            "computed": false,
+                            "end": 147,
+                            "loc": SourceLocation {
+                              "end": Position {
+                                "column": 111,
+                                "line": 2,
+                              },
+                              "start": Position {
+                                "column": 72,
+                                "line": 2,
                               },
                             },
                             "object": Node {
-                              "end": 117,
+                              "computed": false,
+                              "end": 121,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 85,
+                                  "line": 2,
+                                },
+                                "start": Position {
+                                  "column": 72,
+                                  "line": 2,
+                                },
+                              },
+                              "object": Node {
+                                "computed": false,
+                                "end": 117,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 81,
+                                    "line": 2,
+                                  },
+                                  "start": Position {
+                                    "column": 72,
+                                    "line": 2,
+                                  },
+                                },
+                                "object": Node {
+                                  "end": 109,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 73,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "g",
+                                    "start": Position {
+                                      "column": 72,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "g",
+                                  "start": 108,
+                                  "type": "Identifier",
+                                },
+                                "property": Node {
+                                  "end": 117,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 81,
+                                      "line": 2,
+                                    },
+                                    "identifierName": "process",
+                                    "start": Position {
+                                      "column": 74,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "name": "process",
+                                  "start": 110,
+                                  "type": "Identifier",
+                                },
+                                "start": 108,
+                                "type": "MemberExpression",
+                              },
+                              "property": Node {
+                                "end": 121,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 85,
+                                    "line": 2,
+                                  },
+                                  "identifierName": "env",
+                                  "start": Position {
+                                    "column": 82,
+                                    "line": 2,
+                                  },
+                                },
+                                "name": "env",
+                                "start": 118,
+                                "type": "Identifier",
+                              },
+                              "start": 108,
+                              "type": "MemberExpression",
+                            },
+                            "property": Node {
+                              "end": 147,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 111,
+                                  "line": 2,
+                                },
+                                "identifierName": "__STRYKER_ACTIVE_MUTANT__",
+                                "start": Position {
+                                  "column": 86,
+                                  "line": 2,
+                                },
+                              },
+                              "name": "__STRYKER_ACTIVE_MUTANT__",
+                              "start": 122,
+                              "type": "Identifier",
+                            },
+                            "start": 108,
+                            "type": "MemberExpression",
+                          },
+                          "start": 42,
+                          "type": "LogicalExpression",
+                        },
+                        "type": "IfStatement",
+                      },
+                      Node {
+                        "end": 306,
+                        "expression": Node {
+                          "end": 305,
+                          "left": Node {
+                            "computed": false,
+                            "end": 251,
+                            "loc": SourceLocation {
+                              "end": Position {
+                                "column": 22,
+                                "line": 5,
+                              },
+                              "start": Position {
+                                "column": 2,
+                                "line": 5,
+                              },
+                            },
+                            "object": Node {
+                              "end": 232,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 3,
-                                  "line": 3,
+                                  "line": 5,
                                 },
                                 "identifierName": "g",
                                 "start": Position {
                                   "column": 2,
-                                  "line": 3,
+                                  "line": 5,
                                 },
                               },
                               "name": "g",
-                              "start": 116,
+                              "start": 231,
                               "type": "Identifier",
                             },
                             "property": Node {
-                              "end": 133,
+                              "end": 251,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 22,
+                                  "line": 5,
+                                },
+                                "identifierName": "__mutantCoverage__",
+                                "start": Position {
+                                  "column": 4,
+                                  "line": 5,
+                                },
+                              },
+                              "name": "__mutantCoverage__",
+                              "start": 233,
+                              "type": "Identifier",
+                            },
+                            "start": 231,
+                            "type": "MemberExpression",
+                          },
+                          "loc": SourceLocation {
+                            "end": Position {
+                              "column": 76,
+                              "line": 5,
+                            },
+                            "start": Position {
+                              "column": 2,
+                              "line": 5,
+                            },
+                          },
+                          "operator": "=",
+                          "right": Node {
+                            "end": 305,
+                            "left": Node {
+                              "computed": false,
+                              "end": 274,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 45,
+                                  "line": 5,
+                                },
+                                "start": Position {
+                                  "column": 25,
+                                  "line": 5,
+                                },
+                              },
+                              "object": Node {
+                                "end": 255,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 26,
+                                    "line": 5,
+                                  },
+                                  "identifierName": "g",
+                                  "start": Position {
+                                    "column": 25,
+                                    "line": 5,
+                                  },
+                                },
+                                "name": "g",
+                                "start": 254,
+                                "type": "Identifier",
+                              },
+                              "property": Node {
+                                "end": 274,
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 45,
+                                    "line": 5,
+                                  },
+                                  "identifierName": "__mutantCoverage__",
+                                  "start": Position {
+                                    "column": 27,
+                                    "line": 5,
+                                  },
+                                },
+                                "name": "__mutantCoverage__",
+                                "start": 256,
+                                "type": "Identifier",
+                              },
+                              "start": 254,
+                              "type": "MemberExpression",
+                            },
+                            "loc": SourceLocation {
+                              "end": Position {
+                                "column": 76,
+                                "line": 5,
+                              },
+                              "start": Position {
+                                "column": 25,
+                                "line": 5,
+                              },
+                            },
+                            "operator": "||",
+                            "right": Node {
+                              "end": 305,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 76,
+                                  "line": 5,
+                                },
+                                "start": Position {
+                                  "column": 49,
+                                  "line": 5,
+                                },
+                              },
+                              "properties": Array [
+                                Node {
+                                  "computed": false,
+                                  "end": 290,
+                                  "key": Node {
+                                    "end": 286,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 57,
+                                        "line": 5,
+                                      },
+                                      "identifierName": "static",
+                                      "start": Position {
+                                        "column": 51,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "name": "static",
+                                    "start": 280,
+                                    "type": "Identifier",
+                                  },
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 61,
+                                      "line": 5,
+                                    },
+                                    "start": Position {
+                                      "column": 51,
+                                      "line": 5,
+                                    },
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "start": 280,
+                                  "type": "ObjectProperty",
+                                  "value": Node {
+                                    "end": 290,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 61,
+                                        "line": 5,
+                                      },
+                                      "start": Position {
+                                        "column": 59,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "properties": Array [],
+                                    "start": 288,
+                                    "type": "ObjectExpression",
+                                  },
+                                },
+                                Node {
+                                  "computed": false,
+                                  "end": 303,
+                                  "key": Node {
+                                    "end": 299,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 70,
+                                        "line": 5,
+                                      },
+                                      "identifierName": "perTest",
+                                      "start": Position {
+                                        "column": 63,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "name": "perTest",
+                                    "start": 292,
+                                    "type": "Identifier",
+                                  },
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 74,
+                                      "line": 5,
+                                    },
+                                    "start": Position {
+                                      "column": 63,
+                                      "line": 5,
+                                    },
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "start": 292,
+                                  "type": "ObjectProperty",
+                                  "value": Node {
+                                    "end": 303,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 74,
+                                        "line": 5,
+                                      },
+                                      "start": Position {
+                                        "column": 72,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "properties": Array [],
+                                    "start": 301,
+                                    "type": "ObjectExpression",
+                                  },
+                                },
+                              ],
+                              "start": 278,
+                              "type": "ObjectExpression",
+                            },
+                            "start": 254,
+                            "type": "LogicalExpression",
+                          },
+                          "start": 231,
+                          "type": "AssignmentExpression",
+                        },
+                        "loc": SourceLocation {
+                          "end": Position {
+                            "column": 77,
+                            "line": 5,
+                          },
+                          "start": Position {
+                            "column": 2,
+                            "line": 5,
+                          },
+                        },
+                        "start": 231,
+                        "type": "ExpressionStatement",
+                      },
+                      Node {
+                        "end": 668,
+                        "expression": Node {
+                          "end": 667,
+                          "left": Node {
+                            "computed": false,
+                            "end": 326,
+                            "loc": SourceLocation {
+                              "end": Position {
+                                "column": 19,
+                                "line": 6,
+                              },
+                              "start": Position {
+                                "column": 2,
+                                "line": 6,
+                              },
+                            },
+                            "object": Node {
+                              "end": 310,
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 3,
+                                  "line": 6,
+                                },
+                                "identifierName": "g",
+                                "start": Position {
+                                  "column": 2,
+                                  "line": 6,
+                                },
+                              },
+                              "name": "g",
+                              "start": 309,
+                              "type": "Identifier",
+                            },
+                            "property": Node {
+                              "end": 326,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 19,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                                 "identifierName": "__coverMutant__",
                                 "start": Position {
                                   "column": 4,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                               },
                               "name": "__coverMutant__",
-                              "start": 118,
+                              "start": 311,
                               "type": "Identifier",
                             },
-                            "start": 116,
+                            "start": 309,
                             "type": "MemberExpression",
                           },
                           "loc": SourceLocation {
                             "end": Position {
                               "column": 3,
-                              "line": 12,
+                              "line": 15,
                             },
                             "start": Position {
                               "column": 2,
-                              "line": 3,
+                              "line": 6,
                             },
                           },
                           "operator": "=",
                           "right": Node {
-                            "end": 474,
+                            "end": 667,
                             "left": Node {
                               "computed": false,
-                              "end": 153,
+                              "end": 346,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 39,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                                 "start": Position {
                                   "column": 22,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                               },
                               "object": Node {
-                                "end": 137,
+                                "end": 330,
                                 "loc": SourceLocation {
                                   "end": Position {
                                     "column": 23,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                   "identifierName": "g",
                                   "start": Position {
                                     "column": 22,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                 },
                                 "name": "g",
-                                "start": 136,
+                                "start": 329,
                                 "type": "Identifier",
                               },
                               "property": Node {
-                                "end": 153,
+                                "end": 346,
                                 "loc": SourceLocation {
                                   "end": Position {
                                     "column": 39,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                   "identifierName": "__coverMutant__",
                                   "start": Position {
                                     "column": 24,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                 },
                                 "name": "__coverMutant__",
-                                "start": 138,
+                                "start": 331,
                                 "type": "Identifier",
                               },
-                              "start": 136,
+                              "start": 329,
                               "type": "MemberExpression",
                             },
                             "loc": SourceLocation {
                               "end": Position {
                                 "column": 3,
-                                "line": 12,
+                                "line": 15,
                               },
                               "start": Position {
                                 "column": 22,
-                                "line": 3,
+                                "line": 6,
                               },
                             },
                             "operator": "||",
@@ -2636,134 +3926,134 @@ Object {
                                   Node {
                                     "declarations": Array [
                                       Node {
-                                        "end": 210,
+                                        "end": 403,
                                         "id": Node {
-                                          "end": 180,
+                                          "end": 373,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 9,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                             "identifierName": "c",
                                             "start": Position {
                                               "column": 8,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                           },
                                           "name": "c",
-                                          "start": 179,
+                                          "start": 372,
                                           "type": "Identifier",
                                         },
                                         "init": Node {
                                           "computed": false,
-                                          "end": 210,
+                                          "end": 403,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 39,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                             "start": Position {
                                               "column": 12,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                           },
                                           "object": Node {
                                             "computed": false,
-                                            "end": 203,
+                                            "end": 396,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 32,
-                                                "line": 4,
+                                                "line": 7,
                                               },
                                               "start": Position {
                                                 "column": 12,
-                                                "line": 4,
+                                                "line": 7,
                                               },
                                             },
                                             "object": Node {
-                                              "end": 184,
+                                              "end": 377,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 13,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                                 "identifierName": "g",
                                                 "start": Position {
                                                   "column": 12,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                               },
                                               "name": "g",
-                                              "start": 183,
+                                              "start": 376,
                                               "type": "Identifier",
                                             },
                                             "property": Node {
-                                              "end": 203,
+                                              "end": 396,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 32,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                                 "identifierName": "__mutantCoverage__",
                                                 "start": Position {
                                                   "column": 14,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                               },
                                               "name": "__mutantCoverage__",
-                                              "start": 185,
+                                              "start": 378,
                                               "type": "Identifier",
                                             },
-                                            "start": 183,
+                                            "start": 376,
                                             "type": "MemberExpression",
                                           },
                                           "property": Node {
-                                            "end": 210,
+                                            "end": 403,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 39,
-                                                "line": 4,
+                                                "line": 7,
                                               },
                                               "identifierName": "static",
                                               "start": Position {
                                                 "column": 33,
-                                                "line": 4,
+                                                "line": 7,
                                               },
                                             },
                                             "name": "static",
-                                            "start": 204,
+                                            "start": 397,
                                             "type": "Identifier",
                                           },
-                                          "start": 183,
+                                          "start": 376,
                                           "type": "MemberExpression",
                                         },
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 39,
-                                            "line": 4,
+                                            "line": 7,
                                           },
                                           "start": Position {
                                             "column": 8,
-                                            "line": 4,
+                                            "line": 7,
                                           },
                                         },
-                                        "start": 179,
+                                        "start": 372,
                                         "type": "VariableDeclarator",
                                       },
                                     ],
-                                    "end": 211,
+                                    "end": 404,
                                     "kind": "var",
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 40,
-                                        "line": 4,
+                                        "line": 7,
                                       },
                                       "start": Position {
                                         "column": 4,
-                                        "line": 4,
+                                        "line": 7,
                                       },
                                     },
-                                    "start": 175,
+                                    "start": 368,
                                     "type": "VariableDeclaration",
                                   },
                                   Node {
@@ -2771,475 +4061,475 @@ Object {
                                     "consequent": Node {
                                       "body": Array [
                                         Node {
-                                          "end": 362,
+                                          "end": 555,
                                           "expression": Node {
-                                            "end": 361,
+                                            "end": 554,
                                             "left": Node {
-                                              "end": 250,
+                                              "end": 443,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 7,
-                                                  "line": 6,
+                                                  "line": 9,
                                                 },
                                                 "identifierName": "c",
                                                 "start": Position {
                                                   "column": 6,
-                                                  "line": 6,
+                                                  "line": 9,
                                                 },
                                               },
                                               "name": "c",
-                                              "start": 249,
+                                              "start": 442,
                                               "type": "Identifier",
                                             },
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 118,
-                                                "line": 6,
+                                                "line": 9,
                                               },
                                               "start": Position {
                                                 "column": 6,
-                                                "line": 6,
+                                                "line": 9,
                                               },
                                             },
                                             "operator": "=",
                                             "right": Node {
-                                              "end": 361,
+                                              "end": 554,
                                               "left": Node {
                                                 "computed": true,
-                                                "end": 302,
+                                                "end": 495,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 59,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                   "start": Position {
                                                     "column": 10,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                 },
                                                 "object": Node {
                                                   "computed": false,
-                                                  "end": 281,
+                                                  "end": 474,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 38,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                     "start": Position {
                                                       "column": 10,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                   },
                                                   "object": Node {
                                                     "computed": false,
-                                                    "end": 273,
+                                                    "end": 466,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 30,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "start": Position {
                                                         "column": 10,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "object": Node {
-                                                      "end": 254,
+                                                      "end": 447,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 11,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "g",
                                                         "start": Position {
                                                           "column": 10,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "g",
-                                                      "start": 253,
+                                                      "start": 446,
                                                       "type": "Identifier",
                                                     },
                                                     "property": Node {
-                                                      "end": 273,
+                                                      "end": 466,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 30,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "__mutantCoverage__",
                                                         "start": Position {
                                                           "column": 12,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "__mutantCoverage__",
-                                                      "start": 255,
+                                                      "start": 448,
                                                       "type": "Identifier",
                                                     },
-                                                    "start": 253,
+                                                    "start": 446,
                                                     "type": "MemberExpression",
                                                   },
                                                   "property": Node {
-                                                    "end": 281,
+                                                    "end": 474,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 38,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "identifierName": "perTest",
                                                       "start": Position {
                                                         "column": 31,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "name": "perTest",
-                                                    "start": 274,
+                                                    "start": 467,
                                                     "type": "Identifier",
                                                   },
-                                                  "start": 253,
+                                                  "start": 446,
                                                   "type": "MemberExpression",
                                                 },
                                                 "property": Node {
                                                   "computed": false,
-                                                  "end": 301,
+                                                  "end": 494,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 58,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                     "start": Position {
                                                       "column": 39,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                   },
                                                   "object": Node {
-                                                    "end": 283,
+                                                    "end": 476,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 40,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "identifierName": "g",
                                                       "start": Position {
                                                         "column": 39,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "name": "g",
-                                                    "start": 282,
+                                                    "start": 475,
                                                     "type": "Identifier",
                                                   },
                                                   "property": Node {
-                                                    "end": 301,
+                                                    "end": 494,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 58,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "identifierName": "__currentTestId__",
                                                       "start": Position {
                                                         "column": 41,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "name": "__currentTestId__",
-                                                    "start": 284,
+                                                    "start": 477,
                                                     "type": "Identifier",
                                                   },
-                                                  "start": 282,
+                                                  "start": 475,
                                                   "type": "MemberExpression",
                                                 },
-                                                "start": 253,
+                                                "start": 446,
                                                 "type": "MemberExpression",
                                               },
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 118,
-                                                  "line": 6,
+                                                  "line": 9,
                                                 },
                                                 "start": Position {
                                                   "column": 10,
-                                                  "line": 6,
+                                                  "line": 9,
                                                 },
                                               },
                                               "operator": "=",
                                               "right": Node {
-                                                "end": 361,
+                                                "end": 554,
                                                 "left": Node {
                                                   "computed": true,
-                                                  "end": 355,
+                                                  "end": 548,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 112,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                     "start": Position {
                                                       "column": 63,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                   },
                                                   "object": Node {
                                                     "computed": false,
-                                                    "end": 334,
+                                                    "end": 527,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 91,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "start": Position {
                                                         "column": 63,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "object": Node {
                                                       "computed": false,
-                                                      "end": 326,
+                                                      "end": 519,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 83,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "start": Position {
                                                           "column": 63,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "object": Node {
-                                                        "end": 307,
+                                                        "end": 500,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 64,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                           "identifierName": "g",
                                                           "start": Position {
                                                             "column": 63,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                         },
                                                         "name": "g",
-                                                        "start": 306,
+                                                        "start": 499,
                                                         "type": "Identifier",
                                                       },
                                                       "property": Node {
-                                                        "end": 326,
+                                                        "end": 519,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 83,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                           "identifierName": "__mutantCoverage__",
                                                           "start": Position {
                                                             "column": 65,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                         },
                                                         "name": "__mutantCoverage__",
-                                                        "start": 308,
+                                                        "start": 501,
                                                         "type": "Identifier",
                                                       },
-                                                      "start": 306,
+                                                      "start": 499,
                                                       "type": "MemberExpression",
                                                     },
                                                     "property": Node {
-                                                      "end": 334,
+                                                      "end": 527,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 91,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "perTest",
                                                         "start": Position {
                                                           "column": 84,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "perTest",
-                                                      "start": 327,
+                                                      "start": 520,
                                                       "type": "Identifier",
                                                     },
-                                                    "start": 306,
+                                                    "start": 499,
                                                     "type": "MemberExpression",
                                                   },
                                                   "property": Node {
                                                     "computed": false,
-                                                    "end": 354,
+                                                    "end": 547,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 111,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "start": Position {
                                                         "column": 92,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "object": Node {
-                                                      "end": 336,
+                                                      "end": 529,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 93,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "g",
                                                         "start": Position {
                                                           "column": 92,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "g",
-                                                      "start": 335,
+                                                      "start": 528,
                                                       "type": "Identifier",
                                                     },
                                                     "property": Node {
-                                                      "end": 354,
+                                                      "end": 547,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 111,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "identifierName": "__currentTestId__",
                                                         "start": Position {
                                                           "column": 94,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "name": "__currentTestId__",
-                                                      "start": 337,
+                                                      "start": 530,
                                                       "type": "Identifier",
                                                     },
-                                                    "start": 335,
+                                                    "start": 528,
                                                     "type": "MemberExpression",
                                                   },
-                                                  "start": 306,
+                                                  "start": 499,
                                                   "type": "MemberExpression",
                                                 },
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 118,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                   "start": Position {
                                                     "column": 63,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                 },
                                                 "operator": "||",
                                                 "right": Node {
-                                                  "end": 361,
+                                                  "end": 554,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 118,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                     "start": Position {
                                                       "column": 116,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                   },
                                                   "properties": Array [],
-                                                  "start": 359,
+                                                  "start": 552,
                                                   "type": "ObjectExpression",
                                                 },
-                                                "start": 306,
+                                                "start": 499,
                                                 "type": "LogicalExpression",
                                               },
-                                              "start": 253,
+                                              "start": 446,
                                               "type": "AssignmentExpression",
                                             },
-                                            "start": 249,
+                                            "start": 442,
                                             "type": "AssignmentExpression",
                                           },
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 119,
-                                              "line": 6,
+                                              "line": 9,
                                             },
                                             "start": Position {
                                               "column": 6,
-                                              "line": 6,
+                                              "line": 9,
                                             },
                                           },
-                                          "start": 249,
+                                          "start": 442,
                                           "type": "ExpressionStatement",
                                         },
                                       ],
                                       "directives": Array [],
-                                      "end": 368,
+                                      "end": 561,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 5,
-                                          "line": 7,
+                                          "line": 10,
                                         },
                                         "start": Position {
                                           "column": 29,
-                                          "line": 5,
+                                          "line": 8,
                                         },
                                       },
-                                      "start": 241,
+                                      "start": 434,
                                       "type": "BlockStatement",
                                     },
-                                    "end": 368,
+                                    "end": 561,
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 5,
-                                        "line": 7,
+                                        "line": 10,
                                       },
                                       "start": Position {
                                         "column": 4,
-                                        "line": 5,
+                                        "line": 8,
                                       },
                                     },
-                                    "start": 216,
+                                    "start": 409,
                                     "test": Node {
                                       "computed": false,
-                                      "end": 239,
+                                      "end": 432,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 27,
-                                          "line": 5,
+                                          "line": 8,
                                         },
                                         "start": Position {
                                           "column": 8,
-                                          "line": 5,
+                                          "line": 8,
                                         },
                                       },
                                       "object": Node {
-                                        "end": 221,
+                                        "end": 414,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 9,
-                                            "line": 5,
+                                            "line": 8,
                                           },
                                           "identifierName": "g",
                                           "start": Position {
                                             "column": 8,
-                                            "line": 5,
+                                            "line": 8,
                                           },
                                         },
                                         "name": "g",
-                                        "start": 220,
+                                        "start": 413,
                                         "type": "Identifier",
                                       },
                                       "property": Node {
-                                        "end": 239,
+                                        "end": 432,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 27,
-                                            "line": 5,
+                                            "line": 8,
                                           },
                                           "identifierName": "__currentTestId__",
                                           "start": Position {
                                             "column": 10,
-                                            "line": 5,
+                                            "line": 8,
                                           },
                                         },
                                         "name": "__currentTestId__",
-                                        "start": 222,
+                                        "start": 415,
                                         "type": "Identifier",
                                       },
-                                      "start": 220,
+                                      "start": 413,
                                       "type": "MemberExpression",
                                     },
                                     "type": "IfStatement",
@@ -3247,275 +4537,275 @@ Object {
                                   Node {
                                     "declarations": Array [
                                       Node {
-                                        "end": 390,
+                                        "end": 583,
                                         "id": Node {
-                                          "end": 378,
+                                          "end": 571,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 9,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                             "identifierName": "a",
                                             "start": Position {
                                               "column": 8,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                           },
                                           "name": "a",
-                                          "start": 377,
+                                          "start": 570,
                                           "type": "Identifier",
                                         },
                                         "init": Node {
-                                          "end": 390,
+                                          "end": 583,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 21,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                             "identifierName": "arguments",
                                             "start": Position {
                                               "column": 12,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                           },
                                           "name": "arguments",
-                                          "start": 381,
+                                          "start": 574,
                                           "type": "Identifier",
                                         },
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 21,
-                                            "line": 8,
+                                            "line": 11,
                                           },
                                           "start": Position {
                                             "column": 8,
-                                            "line": 8,
+                                            "line": 11,
                                           },
                                         },
-                                        "start": 377,
+                                        "start": 570,
                                         "type": "VariableDeclarator",
                                       },
                                     ],
-                                    "end": 391,
+                                    "end": 584,
                                     "kind": "var",
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 22,
-                                        "line": 8,
+                                        "line": 11,
                                       },
                                       "start": Position {
                                         "column": 4,
-                                        "line": 8,
+                                        "line": 11,
                                       },
                                     },
-                                    "start": 373,
+                                    "start": 566,
                                     "type": "VariableDeclaration",
                                   },
                                   Node {
                                     "body": Node {
                                       "body": Array [
                                         Node {
-                                          "end": 464,
+                                          "end": 657,
                                           "expression": Node {
-                                            "end": 463,
+                                            "end": 656,
                                             "left": Node {
                                               "computed": true,
-                                              "end": 442,
+                                              "end": 635,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 13,
-                                                  "line": 10,
+                                                  "line": 13,
                                                 },
                                                 "start": Position {
                                                   "column": 6,
-                                                  "line": 10,
+                                                  "line": 13,
                                                 },
                                               },
                                               "object": Node {
-                                                "end": 436,
+                                                "end": 629,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 7,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                   "identifierName": "c",
                                                   "start": Position {
                                                     "column": 6,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                 },
                                                 "name": "c",
-                                                "start": 435,
+                                                "start": 628,
                                                 "type": "Identifier",
                                               },
                                               "property": Node {
                                                 "computed": true,
-                                                "end": 441,
+                                                "end": 634,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 12,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                   "start": Position {
                                                     "column": 8,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                 },
                                                 "object": Node {
-                                                  "end": 438,
+                                                  "end": 631,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 9,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                     "identifierName": "a",
                                                     "start": Position {
                                                       "column": 8,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                   },
                                                   "name": "a",
-                                                  "start": 437,
+                                                  "start": 630,
                                                   "type": "Identifier",
                                                 },
                                                 "property": Node {
-                                                  "end": 440,
+                                                  "end": 633,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 11,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                     "identifierName": "i",
                                                     "start": Position {
                                                       "column": 10,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                   },
                                                   "name": "i",
-                                                  "start": 439,
+                                                  "start": 632,
                                                   "type": "Identifier",
                                                 },
-                                                "start": 437,
+                                                "start": 630,
                                                 "type": "MemberExpression",
                                               },
-                                              "start": 435,
+                                              "start": 628,
                                               "type": "MemberExpression",
                                             },
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 34,
-                                                "line": 10,
+                                                "line": 13,
                                               },
                                               "start": Position {
                                                 "column": 6,
-                                                "line": 10,
+                                                "line": 13,
                                               },
                                             },
                                             "operator": "=",
                                             "right": Node {
-                                              "end": 463,
+                                              "end": 656,
                                               "left": Node {
-                                                "end": 458,
+                                                "end": 651,
                                                 "extra": Object {
-                                                  "parenStart": 445,
+                                                  "parenStart": 638,
                                                   "parenthesized": true,
                                                 },
                                                 "left": Node {
                                                   "computed": true,
-                                                  "end": 453,
+                                                  "end": 646,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 24,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                     "start": Position {
                                                       "column": 17,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                   },
                                                   "object": Node {
-                                                    "end": 447,
+                                                    "end": 640,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 18,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                       "identifierName": "c",
                                                       "start": Position {
                                                         "column": 17,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                     },
                                                     "name": "c",
-                                                    "start": 446,
+                                                    "start": 639,
                                                     "type": "Identifier",
                                                   },
                                                   "property": Node {
                                                     "computed": true,
-                                                    "end": 452,
+                                                    "end": 645,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 23,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                       "start": Position {
                                                         "column": 19,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                     },
                                                     "object": Node {
-                                                      "end": 449,
+                                                      "end": 642,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 20,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                         "identifierName": "a",
                                                         "start": Position {
                                                           "column": 19,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                       },
                                                       "name": "a",
-                                                      "start": 448,
+                                                      "start": 641,
                                                       "type": "Identifier",
                                                     },
                                                     "property": Node {
-                                                      "end": 451,
+                                                      "end": 644,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 22,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                         "identifierName": "i",
                                                         "start": Position {
                                                           "column": 21,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                       },
                                                       "name": "i",
-                                                      "start": 450,
+                                                      "start": 643,
                                                       "type": "Identifier",
                                                     },
-                                                    "start": 448,
+                                                    "start": 641,
                                                     "type": "MemberExpression",
                                                   },
-                                                  "start": 446,
+                                                  "start": 639,
                                                   "type": "MemberExpression",
                                                 },
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 29,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                   "start": Position {
                                                     "column": 17,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                 },
                                                 "operator": "||",
                                                 "right": Node {
-                                                  "end": 458,
+                                                  "end": 651,
                                                   "extra": Object {
                                                     "raw": "0",
                                                     "rawValue": 0,
@@ -3523,33 +4813,33 @@ Object {
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 29,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                     "start": Position {
                                                       "column": 28,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                   },
-                                                  "start": 457,
+                                                  "start": 650,
                                                   "type": "NumericLiteral",
                                                   "value": 0,
                                                 },
-                                                "start": 446,
+                                                "start": 639,
                                                 "type": "LogicalExpression",
                                               },
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 34,
-                                                  "line": 10,
+                                                  "line": 13,
                                                 },
                                                 "start": Position {
                                                   "column": 16,
-                                                  "line": 10,
+                                                  "line": 13,
                                                 },
                                               },
                                               "operator": "+",
                                               "right": Node {
-                                                "end": 463,
+                                                "end": 656,
                                                 "extra": Object {
                                                   "raw": "1",
                                                   "rawValue": 1,
@@ -3557,76 +4847,76 @@ Object {
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 34,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                   "start": Position {
                                                     "column": 33,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                 },
-                                                "start": 462,
+                                                "start": 655,
                                                 "type": "NumericLiteral",
                                                 "value": 1,
                                               },
-                                              "start": 445,
+                                              "start": 638,
                                               "type": "BinaryExpression",
                                             },
-                                            "start": 435,
+                                            "start": 628,
                                             "type": "AssignmentExpression",
                                           },
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 35,
-                                              "line": 10,
+                                              "line": 13,
                                             },
                                             "start": Position {
                                               "column": 6,
-                                              "line": 10,
+                                              "line": 13,
                                             },
                                           },
-                                          "start": 435,
+                                          "start": 628,
                                           "type": "ExpressionStatement",
                                         },
                                       ],
                                       "directives": Array [],
-                                      "end": 470,
+                                      "end": 663,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 5,
-                                          "line": 11,
+                                          "line": 14,
                                         },
                                         "start": Position {
                                           "column": 35,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                       },
-                                      "start": 427,
+                                      "start": 620,
                                       "type": "BlockStatement",
                                     },
-                                    "end": 470,
+                                    "end": 663,
                                     "init": Node {
                                       "declarations": Array [
                                         Node {
-                                          "end": 407,
+                                          "end": 600,
                                           "id": Node {
-                                            "end": 405,
+                                            "end": 598,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 13,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                               "identifierName": "i",
                                               "start": Position {
                                                 "column": 12,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                             },
                                             "name": "i",
-                                            "start": 404,
+                                            "start": 597,
                                             "type": "Identifier",
                                           },
                                           "init": Node {
-                                            "end": 407,
+                                            "end": 600,
                                             "extra": Object {
                                               "raw": "0",
                                               "rawValue": 0,
@@ -3634,267 +4924,267 @@ Object {
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 15,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                               "start": Position {
                                                 "column": 14,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                             },
-                                            "start": 406,
+                                            "start": 599,
                                             "type": "NumericLiteral",
                                             "value": 0,
                                           },
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 15,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                             "start": Position {
                                               "column": 12,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                           },
-                                          "start": 404,
+                                          "start": 597,
                                           "type": "VariableDeclarator",
                                         },
                                       ],
-                                      "end": 407,
+                                      "end": 600,
                                       "kind": "var",
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 15,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                         "start": Position {
                                           "column": 8,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                       },
-                                      "start": 400,
+                                      "start": 593,
                                       "type": "VariableDeclaration",
                                     },
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 5,
-                                        "line": 11,
+                                        "line": 14,
                                       },
                                       "start": Position {
                                         "column": 4,
-                                        "line": 9,
+                                        "line": 12,
                                       },
                                     },
-                                    "start": 396,
+                                    "start": 589,
                                     "test": Node {
-                                      "end": 421,
+                                      "end": 614,
                                       "left": Node {
-                                        "end": 410,
+                                        "end": 603,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 18,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                           "identifierName": "i",
                                           "start": Position {
                                             "column": 17,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                         },
                                         "name": "i",
-                                        "start": 409,
+                                        "start": 602,
                                         "type": "Identifier",
                                       },
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 29,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                         "start": Position {
                                           "column": 17,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                       },
                                       "operator": "<",
                                       "right": Node {
                                         "computed": false,
-                                        "end": 421,
+                                        "end": 614,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 29,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                           "start": Position {
                                             "column": 21,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                         },
                                         "object": Node {
-                                          "end": 414,
+                                          "end": 607,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 22,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                             "identifierName": "a",
                                             "start": Position {
                                               "column": 21,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                           },
                                           "name": "a",
-                                          "start": 413,
+                                          "start": 606,
                                           "type": "Identifier",
                                         },
                                         "property": Node {
-                                          "end": 421,
+                                          "end": 614,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 29,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                             "identifierName": "length",
                                             "start": Position {
                                               "column": 23,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                           },
                                           "name": "length",
-                                          "start": 415,
+                                          "start": 608,
                                           "type": "Identifier",
                                         },
-                                        "start": 413,
+                                        "start": 606,
                                         "type": "MemberExpression",
                                       },
-                                      "start": 409,
+                                      "start": 602,
                                       "type": "BinaryExpression",
                                     },
                                     "type": "ForStatement",
                                     "update": Node {
                                       "argument": Node {
-                                        "end": 424,
+                                        "end": 617,
                                         "loc": SourceLocation {
                                           "end": Position {
                                             "column": 32,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                           "identifierName": "i",
                                           "start": Position {
                                             "column": 31,
-                                            "line": 9,
+                                            "line": 12,
                                           },
                                         },
                                         "name": "i",
-                                        "start": 423,
+                                        "start": 616,
                                         "type": "Identifier",
                                       },
-                                      "end": 426,
+                                      "end": 619,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 34,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                         "start": Position {
                                           "column": 31,
-                                          "line": 9,
+                                          "line": 12,
                                         },
                                       },
                                       "operator": "++",
                                       "prefix": false,
-                                      "start": 423,
+                                      "start": 616,
                                       "type": "UpdateExpression",
                                     },
                                   },
                                 ],
                                 "directives": Array [],
-                                "end": 474,
+                                "end": 667,
                                 "loc": SourceLocation {
                                   "end": Position {
                                     "column": 3,
-                                    "line": 12,
+                                    "line": 15,
                                   },
                                   "start": Position {
                                     "column": 55,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                 },
-                                "start": 169,
+                                "start": 362,
                                 "type": "BlockStatement",
                               },
-                              "end": 474,
+                              "end": 667,
                               "generator": false,
                               "id": null,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 3,
-                                  "line": 12,
+                                  "line": 15,
                                 },
                                 "start": Position {
                                   "column": 43,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                               },
                               "params": Array [],
-                              "start": 157,
+                              "start": 350,
                               "type": "FunctionExpression",
                             },
-                            "start": 136,
+                            "start": 329,
                             "type": "LogicalExpression",
                           },
-                          "start": 116,
+                          "start": 309,
                           "type": "AssignmentExpression",
                         },
                         "loc": SourceLocation {
                           "end": Position {
                             "column": 4,
-                            "line": 12,
+                            "line": 15,
                           },
                           "start": Position {
                             "column": 2,
-                            "line": 3,
+                            "line": 6,
                           },
                         },
-                        "start": 116,
+                        "start": 309,
                         "type": "ExpressionStatement",
                       },
                       Node {
                         "argument": Node {
-                          "end": 486,
+                          "end": 679,
                           "loc": SourceLocation {
                             "end": Position {
                               "column": 10,
-                              "line": 13,
+                              "line": 16,
                             },
                             "identifierName": "g",
                             "start": Position {
                               "column": 9,
-                              "line": 13,
+                              "line": 16,
                             },
                           },
                           "name": "g",
-                          "start": 485,
+                          "start": 678,
                           "type": "Identifier",
                         },
-                        "end": 487,
+                        "end": 680,
                         "loc": SourceLocation {
                           "end": Position {
                             "column": 11,
-                            "line": 13,
+                            "line": 16,
                           },
                           "start": Position {
                             "column": 2,
-                            "line": 13,
+                            "line": 16,
                           },
                         },
-                        "start": 478,
+                        "start": 671,
                         "type": "ReturnStatement",
                       },
                     ],
                     "directives": Array [],
-                    "end": 489,
+                    "end": 682,
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 1,
-                        "line": 14,
+                        "line": 17,
                       },
                       "start": Position {
                         "column": 34,
@@ -3904,7 +5194,7 @@ Object {
                     "start": 34,
                     "type": "BlockStatement",
                   },
-                  "end": 489,
+                  "end": 682,
                   "extra": Object {
                     "parenStart": 22,
                     "parenthesized": true,
@@ -3914,7 +5204,7 @@ Object {
                   "loc": SourceLocation {
                     "end": Position {
                       "column": 1,
-                      "line": 14,
+                      "line": 17,
                     },
                     "start": Position {
                       "column": 23,
@@ -3943,11 +5233,11 @@ Object {
                   "start": 23,
                   "type": "FunctionExpression",
                 },
-                "end": 521,
+                "end": 714,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 33,
-                    "line": 14,
+                    "line": 17,
                   },
                   "start": Position {
                     "column": 22,
@@ -3960,7 +5250,7 @@ Object {
               "loc": SourceLocation {
                 "end": Position {
                   "column": 33,
-                  "line": 14,
+                  "line": 17,
                 },
                 "start": Position {
                   "column": 4,
@@ -3971,12 +5261,12 @@ Object {
               "type": "VariableDeclarator",
             },
           ],
-          "end": 521,
+          "end": 714,
           "kind": "var",
           "loc": SourceLocation {
             "end": Position {
               "column": 33,
-              "line": 14,
+              "line": 17,
             },
             "start": Position {
               "column": 0,
@@ -4292,7 +5582,7 @@ Object {
               Node {
                 "declarations": Array [
                   Node {
-                    "end": 521,
+                    "end": 714,
                     "id": Node {
                       "end": 19,
                       "loc": SourceLocation {
@@ -4317,7 +5607,7 @@ Object {
                           "callee": Node {
                             "arguments": Array [
                               Node {
-                                "end": 517,
+                                "end": 710,
                                 "extra": Object {
                                   "raw": "\\"return this\\"",
                                   "rawValue": "return this",
@@ -4325,61 +5615,61 @@ Object {
                                 "loc": SourceLocation {
                                   "end": Position {
                                     "column": 29,
-                                    "line": 14,
+                                    "line": 17,
                                   },
                                   "start": Position {
                                     "column": 16,
-                                    "line": 14,
+                                    "line": 17,
                                   },
                                 },
-                                "start": 504,
+                                "start": 697,
                                 "type": "StringLiteral",
                                 "value": "return this",
                               },
                             ],
                             "callee": Node {
-                              "end": 503,
+                              "end": 696,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 15,
-                                  "line": 14,
+                                  "line": 17,
                                 },
                                 "identifierName": "Function",
                                 "start": Position {
                                   "column": 7,
-                                  "line": 14,
+                                  "line": 17,
                                 },
                               },
                               "name": "Function",
-                              "start": 495,
+                              "start": 688,
                               "type": "Identifier",
                             },
-                            "end": 518,
+                            "end": 711,
                             "loc": SourceLocation {
                               "end": Position {
                                 "column": 30,
-                                "line": 14,
+                                "line": 17,
                               },
                               "start": Position {
                                 "column": 3,
-                                "line": 14,
+                                "line": 17,
                               },
                             },
-                            "start": 491,
+                            "start": 684,
                             "type": "NewExpression",
                           },
-                          "end": 520,
+                          "end": 713,
                           "loc": SourceLocation {
                             "end": Position {
                               "column": 32,
-                              "line": 14,
+                              "line": 17,
                             },
                             "start": Position {
                               "column": 3,
-                              "line": 14,
+                              "line": 17,
                             },
                           },
-                          "start": 491,
+                          "start": 684,
                           "type": "CallExpression",
                         },
                       ],
@@ -4388,262 +5678,261 @@ Object {
                         "body": Node {
                           "body": Array [
                             Node {
-                              "end": 113,
-                              "expression": Node {
-                                "end": 112,
-                                "left": Node {
-                                  "computed": false,
-                                  "end": 58,
-                                  "loc": SourceLocation {
-                                    "end": Position {
-                                      "column": 22,
-                                      "line": 2,
+                              "alternate": null,
+                              "consequent": Node {
+                                "body": Array [
+                                  Node {
+                                    "end": 224,
+                                    "expression": Node {
+                                      "end": 223,
+                                      "left": Node {
+                                        "computed": false,
+                                        "end": 173,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 22,
+                                            "line": 3,
+                                          },
+                                          "start": Position {
+                                            "column": 4,
+                                            "line": 3,
+                                          },
+                                        },
+                                        "object": Node {
+                                          "end": 156,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 5,
+                                              "line": 3,
+                                            },
+                                            "identifierName": "g",
+                                            "start": Position {
+                                              "column": 4,
+                                              "line": 3,
+                                            },
+                                          },
+                                          "name": "g",
+                                          "start": 155,
+                                          "type": "Identifier",
+                                        },
+                                        "property": Node {
+                                          "end": 173,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 22,
+                                              "line": 3,
+                                            },
+                                            "identifierName": "__activeMutant__",
+                                            "start": Position {
+                                              "column": 6,
+                                              "line": 3,
+                                            },
+                                          },
+                                          "name": "__activeMutant__",
+                                          "start": 157,
+                                          "type": "Identifier",
+                                        },
+                                        "start": 155,
+                                        "type": "MemberExpression",
+                                      },
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 72,
+                                          "line": 3,
+                                        },
+                                        "start": Position {
+                                          "column": 4,
+                                          "line": 3,
+                                        },
+                                      },
+                                      "operator": "=",
+                                      "right": Node {
+                                        "arguments": Array [
+                                          Node {
+                                            "computed": false,
+                                            "end": 222,
+                                            "loc": SourceLocation {
+                                              "end": Position {
+                                                "column": 71,
+                                                "line": 3,
+                                              },
+                                              "start": Position {
+                                                "column": 32,
+                                                "line": 3,
+                                              },
+                                            },
+                                            "object": Node {
+                                              "computed": false,
+                                              "end": 196,
+                                              "loc": SourceLocation {
+                                                "end": Position {
+                                                  "column": 45,
+                                                  "line": 3,
+                                                },
+                                                "start": Position {
+                                                  "column": 32,
+                                                  "line": 3,
+                                                },
+                                              },
+                                              "object": Node {
+                                                "computed": false,
+                                                "end": 192,
+                                                "loc": SourceLocation {
+                                                  "end": Position {
+                                                    "column": 41,
+                                                    "line": 3,
+                                                  },
+                                                  "start": Position {
+                                                    "column": 32,
+                                                    "line": 3,
+                                                  },
+                                                },
+                                                "object": Node {
+                                                  "end": 184,
+                                                  "loc": SourceLocation {
+                                                    "end": Position {
+                                                      "column": 33,
+                                                      "line": 3,
+                                                    },
+                                                    "identifierName": "g",
+                                                    "start": Position {
+                                                      "column": 32,
+                                                      "line": 3,
+                                                    },
+                                                  },
+                                                  "name": "g",
+                                                  "start": 183,
+                                                  "type": "Identifier",
+                                                },
+                                                "property": Node {
+                                                  "end": 192,
+                                                  "loc": SourceLocation {
+                                                    "end": Position {
+                                                      "column": 41,
+                                                      "line": 3,
+                                                    },
+                                                    "identifierName": "process",
+                                                    "start": Position {
+                                                      "column": 34,
+                                                      "line": 3,
+                                                    },
+                                                  },
+                                                  "name": "process",
+                                                  "start": 185,
+                                                  "type": "Identifier",
+                                                },
+                                                "start": 183,
+                                                "type": "MemberExpression",
+                                              },
+                                              "property": Node {
+                                                "end": 196,
+                                                "loc": SourceLocation {
+                                                  "end": Position {
+                                                    "column": 45,
+                                                    "line": 3,
+                                                  },
+                                                  "identifierName": "env",
+                                                  "start": Position {
+                                                    "column": 42,
+                                                    "line": 3,
+                                                  },
+                                                },
+                                                "name": "env",
+                                                "start": 193,
+                                                "type": "Identifier",
+                                              },
+                                              "start": 183,
+                                              "type": "MemberExpression",
+                                            },
+                                            "property": Node {
+                                              "end": 222,
+                                              "loc": SourceLocation {
+                                                "end": Position {
+                                                  "column": 71,
+                                                  "line": 3,
+                                                },
+                                                "identifierName": "__STRYKER_ACTIVE_MUTANT__",
+                                                "start": Position {
+                                                  "column": 46,
+                                                  "line": 3,
+                                                },
+                                              },
+                                              "name": "__STRYKER_ACTIVE_MUTANT__",
+                                              "start": 197,
+                                              "type": "Identifier",
+                                            },
+                                            "start": 183,
+                                            "type": "MemberExpression",
+                                          },
+                                        ],
+                                        "callee": Node {
+                                          "end": 182,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 31,
+                                              "line": 3,
+                                            },
+                                            "identifierName": "Number",
+                                            "start": Position {
+                                              "column": 25,
+                                              "line": 3,
+                                            },
+                                          },
+                                          "name": "Number",
+                                          "start": 176,
+                                          "type": "Identifier",
+                                        },
+                                        "end": 223,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 72,
+                                            "line": 3,
+                                          },
+                                          "start": Position {
+                                            "column": 25,
+                                            "line": 3,
+                                          },
+                                        },
+                                        "start": 176,
+                                        "type": "CallExpression",
+                                      },
+                                      "start": 155,
+                                      "type": "AssignmentExpression",
                                     },
-                                    "start": Position {
-                                      "column": 2,
-                                      "line": 2,
-                                    },
-                                  },
-                                  "object": Node {
-                                    "end": 39,
                                     "loc": SourceLocation {
                                       "end": Position {
-                                        "column": 3,
-                                        "line": 2,
+                                        "column": 73,
+                                        "line": 3,
                                       },
-                                      "identifierName": "g",
-                                      "start": Position {
-                                        "column": 2,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "name": "g",
-                                    "start": 38,
-                                    "type": "Identifier",
-                                  },
-                                  "property": Node {
-                                    "end": 58,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 22,
-                                        "line": 2,
-                                      },
-                                      "identifierName": "__mutantCoverage__",
                                       "start": Position {
                                         "column": 4,
-                                        "line": 2,
+                                        "line": 3,
                                       },
                                     },
-                                    "name": "__mutantCoverage__",
-                                    "start": 40,
-                                    "type": "Identifier",
+                                    "start": 155,
+                                    "type": "ExpressionStatement",
                                   },
-                                  "start": 38,
-                                  "type": "MemberExpression",
-                                },
+                                ],
+                                "directives": Array [],
+                                "end": 228,
                                 "loc": SourceLocation {
                                   "end": Position {
-                                    "column": 76,
-                                    "line": 2,
+                                    "column": 3,
+                                    "line": 4,
                                   },
                                   "start": Position {
-                                    "column": 2,
+                                    "column": 113,
                                     "line": 2,
                                   },
                                 },
-                                "operator": "=",
-                                "right": Node {
-                                  "end": 112,
-                                  "left": Node {
-                                    "computed": false,
-                                    "end": 81,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 45,
-                                        "line": 2,
-                                      },
-                                      "start": Position {
-                                        "column": 25,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "object": Node {
-                                      "end": 62,
-                                      "loc": SourceLocation {
-                                        "end": Position {
-                                          "column": 26,
-                                          "line": 2,
-                                        },
-                                        "identifierName": "g",
-                                        "start": Position {
-                                          "column": 25,
-                                          "line": 2,
-                                        },
-                                      },
-                                      "name": "g",
-                                      "start": 61,
-                                      "type": "Identifier",
-                                    },
-                                    "property": Node {
-                                      "end": 81,
-                                      "loc": SourceLocation {
-                                        "end": Position {
-                                          "column": 45,
-                                          "line": 2,
-                                        },
-                                        "identifierName": "__mutantCoverage__",
-                                        "start": Position {
-                                          "column": 27,
-                                          "line": 2,
-                                        },
-                                      },
-                                      "name": "__mutantCoverage__",
-                                      "start": 63,
-                                      "type": "Identifier",
-                                    },
-                                    "start": 61,
-                                    "type": "MemberExpression",
-                                  },
-                                  "loc": SourceLocation {
-                                    "end": Position {
-                                      "column": 76,
-                                      "line": 2,
-                                    },
-                                    "start": Position {
-                                      "column": 25,
-                                      "line": 2,
-                                    },
-                                  },
-                                  "operator": "||",
-                                  "right": Node {
-                                    "end": 112,
-                                    "loc": SourceLocation {
-                                      "end": Position {
-                                        "column": 76,
-                                        "line": 2,
-                                      },
-                                      "start": Position {
-                                        "column": 49,
-                                        "line": 2,
-                                      },
-                                    },
-                                    "properties": Array [
-                                      Node {
-                                        "computed": false,
-                                        "end": 97,
-                                        "key": Node {
-                                          "end": 93,
-                                          "loc": SourceLocation {
-                                            "end": Position {
-                                              "column": 57,
-                                              "line": 2,
-                                            },
-                                            "identifierName": "static",
-                                            "start": Position {
-                                              "column": 51,
-                                              "line": 2,
-                                            },
-                                          },
-                                          "name": "static",
-                                          "start": 87,
-                                          "type": "Identifier",
-                                        },
-                                        "loc": SourceLocation {
-                                          "end": Position {
-                                            "column": 61,
-                                            "line": 2,
-                                          },
-                                          "start": Position {
-                                            "column": 51,
-                                            "line": 2,
-                                          },
-                                        },
-                                        "method": false,
-                                        "shorthand": false,
-                                        "start": 87,
-                                        "type": "ObjectProperty",
-                                        "value": Node {
-                                          "end": 97,
-                                          "loc": SourceLocation {
-                                            "end": Position {
-                                              "column": 61,
-                                              "line": 2,
-                                            },
-                                            "start": Position {
-                                              "column": 59,
-                                              "line": 2,
-                                            },
-                                          },
-                                          "properties": Array [],
-                                          "start": 95,
-                                          "type": "ObjectExpression",
-                                        },
-                                      },
-                                      Node {
-                                        "computed": false,
-                                        "end": 110,
-                                        "key": Node {
-                                          "end": 106,
-                                          "loc": SourceLocation {
-                                            "end": Position {
-                                              "column": 70,
-                                              "line": 2,
-                                            },
-                                            "identifierName": "perTest",
-                                            "start": Position {
-                                              "column": 63,
-                                              "line": 2,
-                                            },
-                                          },
-                                          "name": "perTest",
-                                          "start": 99,
-                                          "type": "Identifier",
-                                        },
-                                        "loc": SourceLocation {
-                                          "end": Position {
-                                            "column": 74,
-                                            "line": 2,
-                                          },
-                                          "start": Position {
-                                            "column": 63,
-                                            "line": 2,
-                                          },
-                                        },
-                                        "method": false,
-                                        "shorthand": false,
-                                        "start": 99,
-                                        "type": "ObjectProperty",
-                                        "value": Node {
-                                          "end": 110,
-                                          "loc": SourceLocation {
-                                            "end": Position {
-                                              "column": 74,
-                                              "line": 2,
-                                            },
-                                            "start": Position {
-                                              "column": 72,
-                                              "line": 2,
-                                            },
-                                          },
-                                          "properties": Array [],
-                                          "start": 108,
-                                          "type": "ObjectExpression",
-                                        },
-                                      },
-                                    ],
-                                    "start": 85,
-                                    "type": "ObjectExpression",
-                                  },
-                                  "start": 61,
-                                  "type": "LogicalExpression",
-                                },
-                                "start": 38,
-                                "type": "AssignmentExpression",
+                                "start": 149,
+                                "type": "BlockStatement",
                               },
+                              "end": 228,
                               "loc": SourceLocation {
                                 "end": Position {
-                                  "column": 77,
-                                  "line": 2,
+                                  "column": 3,
+                                  "line": 4,
                                 },
                                 "start": Position {
                                   "column": 2,
@@ -4651,133 +5940,779 @@ Object {
                                 },
                               },
                               "start": 38,
-                              "type": "ExpressionStatement",
-                            },
-                            Node {
-                              "end": 475,
-                              "expression": Node {
-                                "end": 474,
+                              "test": Node {
+                                "end": 147,
                                 "left": Node {
-                                  "computed": false,
-                                  "end": 133,
+                                  "end": 104,
+                                  "left": Node {
+                                    "end": 87,
+                                    "left": Node {
+                                      "end": 74,
+                                      "left": Node {
+                                        "computed": false,
+                                        "end": 60,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 24,
+                                            "line": 2,
+                                          },
+                                          "start": Position {
+                                            "column": 6,
+                                            "line": 2,
+                                          },
+                                        },
+                                        "object": Node {
+                                          "end": 43,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 7,
+                                              "line": 2,
+                                            },
+                                            "identifierName": "g",
+                                            "start": Position {
+                                              "column": 6,
+                                              "line": 2,
+                                            },
+                                          },
+                                          "name": "g",
+                                          "start": 42,
+                                          "type": "Identifier",
+                                        },
+                                        "property": Node {
+                                          "end": 60,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 24,
+                                              "line": 2,
+                                            },
+                                            "identifierName": "__activeMutant__",
+                                            "start": Position {
+                                              "column": 8,
+                                              "line": 2,
+                                            },
+                                          },
+                                          "name": "__activeMutant__",
+                                          "start": 44,
+                                          "type": "Identifier",
+                                        },
+                                        "start": 42,
+                                        "type": "MemberExpression",
+                                      },
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 38,
+                                          "line": 2,
+                                        },
+                                        "start": Position {
+                                          "column": 6,
+                                          "line": 2,
+                                        },
+                                      },
+                                      "operator": "===",
+                                      "right": Node {
+                                        "end": 74,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 38,
+                                            "line": 2,
+                                          },
+                                          "identifierName": "undefined",
+                                          "start": Position {
+                                            "column": 29,
+                                            "line": 2,
+                                          },
+                                        },
+                                        "name": "undefined",
+                                        "start": 65,
+                                        "type": "Identifier",
+                                      },
+                                      "start": 42,
+                                      "type": "BinaryExpression",
+                                    },
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 51,
+                                        "line": 2,
+                                      },
+                                      "start": Position {
+                                        "column": 6,
+                                        "line": 2,
+                                      },
+                                    },
+                                    "operator": "&&",
+                                    "right": Node {
+                                      "computed": false,
+                                      "end": 87,
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 51,
+                                          "line": 2,
+                                        },
+                                        "start": Position {
+                                          "column": 42,
+                                          "line": 2,
+                                        },
+                                      },
+                                      "object": Node {
+                                        "end": 79,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 43,
+                                            "line": 2,
+                                          },
+                                          "identifierName": "g",
+                                          "start": Position {
+                                            "column": 42,
+                                            "line": 2,
+                                          },
+                                        },
+                                        "name": "g",
+                                        "start": 78,
+                                        "type": "Identifier",
+                                      },
+                                      "property": Node {
+                                        "end": 87,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 51,
+                                            "line": 2,
+                                          },
+                                          "identifierName": "process",
+                                          "start": Position {
+                                            "column": 44,
+                                            "line": 2,
+                                          },
+                                        },
+                                        "name": "process",
+                                        "start": 80,
+                                        "type": "Identifier",
+                                      },
+                                      "start": 78,
+                                      "type": "MemberExpression",
+                                    },
+                                    "start": 42,
+                                    "type": "LogicalExpression",
+                                  },
                                   "loc": SourceLocation {
                                     "end": Position {
-                                      "column": 19,
-                                      "line": 3,
+                                      "column": 68,
+                                      "line": 2,
                                     },
                                     "start": Position {
-                                      "column": 2,
-                                      "line": 3,
+                                      "column": 6,
+                                      "line": 2,
+                                    },
+                                  },
+                                  "operator": "&&",
+                                  "right": Node {
+                                    "computed": false,
+                                    "end": 104,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 68,
+                                        "line": 2,
+                                      },
+                                      "start": Position {
+                                        "column": 55,
+                                        "line": 2,
+                                      },
+                                    },
+                                    "object": Node {
+                                      "computed": false,
+                                      "end": 100,
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 64,
+                                          "line": 2,
+                                        },
+                                        "start": Position {
+                                          "column": 55,
+                                          "line": 2,
+                                        },
+                                      },
+                                      "object": Node {
+                                        "end": 92,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 56,
+                                            "line": 2,
+                                          },
+                                          "identifierName": "g",
+                                          "start": Position {
+                                            "column": 55,
+                                            "line": 2,
+                                          },
+                                        },
+                                        "name": "g",
+                                        "start": 91,
+                                        "type": "Identifier",
+                                      },
+                                      "property": Node {
+                                        "end": 100,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 64,
+                                            "line": 2,
+                                          },
+                                          "identifierName": "process",
+                                          "start": Position {
+                                            "column": 57,
+                                            "line": 2,
+                                          },
+                                        },
+                                        "name": "process",
+                                        "start": 93,
+                                        "type": "Identifier",
+                                      },
+                                      "start": 91,
+                                      "type": "MemberExpression",
+                                    },
+                                    "property": Node {
+                                      "end": 104,
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 68,
+                                          "line": 2,
+                                        },
+                                        "identifierName": "env",
+                                        "start": Position {
+                                          "column": 65,
+                                          "line": 2,
+                                        },
+                                      },
+                                      "name": "env",
+                                      "start": 101,
+                                      "type": "Identifier",
+                                    },
+                                    "start": 91,
+                                    "type": "MemberExpression",
+                                  },
+                                  "start": 42,
+                                  "type": "LogicalExpression",
+                                },
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 111,
+                                    "line": 2,
+                                  },
+                                  "start": Position {
+                                    "column": 6,
+                                    "line": 2,
+                                  },
+                                },
+                                "operator": "&&",
+                                "right": Node {
+                                  "computed": false,
+                                  "end": 147,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 111,
+                                      "line": 2,
+                                    },
+                                    "start": Position {
+                                      "column": 72,
+                                      "line": 2,
                                     },
                                   },
                                   "object": Node {
-                                    "end": 117,
+                                    "computed": false,
+                                    "end": 121,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 85,
+                                        "line": 2,
+                                      },
+                                      "start": Position {
+                                        "column": 72,
+                                        "line": 2,
+                                      },
+                                    },
+                                    "object": Node {
+                                      "computed": false,
+                                      "end": 117,
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 81,
+                                          "line": 2,
+                                        },
+                                        "start": Position {
+                                          "column": 72,
+                                          "line": 2,
+                                        },
+                                      },
+                                      "object": Node {
+                                        "end": 109,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 73,
+                                            "line": 2,
+                                          },
+                                          "identifierName": "g",
+                                          "start": Position {
+                                            "column": 72,
+                                            "line": 2,
+                                          },
+                                        },
+                                        "name": "g",
+                                        "start": 108,
+                                        "type": "Identifier",
+                                      },
+                                      "property": Node {
+                                        "end": 117,
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 81,
+                                            "line": 2,
+                                          },
+                                          "identifierName": "process",
+                                          "start": Position {
+                                            "column": 74,
+                                            "line": 2,
+                                          },
+                                        },
+                                        "name": "process",
+                                        "start": 110,
+                                        "type": "Identifier",
+                                      },
+                                      "start": 108,
+                                      "type": "MemberExpression",
+                                    },
+                                    "property": Node {
+                                      "end": 121,
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 85,
+                                          "line": 2,
+                                        },
+                                        "identifierName": "env",
+                                        "start": Position {
+                                          "column": 82,
+                                          "line": 2,
+                                        },
+                                      },
+                                      "name": "env",
+                                      "start": 118,
+                                      "type": "Identifier",
+                                    },
+                                    "start": 108,
+                                    "type": "MemberExpression",
+                                  },
+                                  "property": Node {
+                                    "end": 147,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 111,
+                                        "line": 2,
+                                      },
+                                      "identifierName": "__STRYKER_ACTIVE_MUTANT__",
+                                      "start": Position {
+                                        "column": 86,
+                                        "line": 2,
+                                      },
+                                    },
+                                    "name": "__STRYKER_ACTIVE_MUTANT__",
+                                    "start": 122,
+                                    "type": "Identifier",
+                                  },
+                                  "start": 108,
+                                  "type": "MemberExpression",
+                                },
+                                "start": 42,
+                                "type": "LogicalExpression",
+                              },
+                              "type": "IfStatement",
+                            },
+                            Node {
+                              "end": 306,
+                              "expression": Node {
+                                "end": 305,
+                                "left": Node {
+                                  "computed": false,
+                                  "end": 251,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 22,
+                                      "line": 5,
+                                    },
+                                    "start": Position {
+                                      "column": 2,
+                                      "line": 5,
+                                    },
+                                  },
+                                  "object": Node {
+                                    "end": 232,
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 3,
-                                        "line": 3,
+                                        "line": 5,
                                       },
                                       "identifierName": "g",
                                       "start": Position {
                                         "column": 2,
-                                        "line": 3,
+                                        "line": 5,
                                       },
                                     },
                                     "name": "g",
-                                    "start": 116,
+                                    "start": 231,
                                     "type": "Identifier",
                                   },
                                   "property": Node {
-                                    "end": 133,
+                                    "end": 251,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 22,
+                                        "line": 5,
+                                      },
+                                      "identifierName": "__mutantCoverage__",
+                                      "start": Position {
+                                        "column": 4,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "name": "__mutantCoverage__",
+                                    "start": 233,
+                                    "type": "Identifier",
+                                  },
+                                  "start": 231,
+                                  "type": "MemberExpression",
+                                },
+                                "loc": SourceLocation {
+                                  "end": Position {
+                                    "column": 76,
+                                    "line": 5,
+                                  },
+                                  "start": Position {
+                                    "column": 2,
+                                    "line": 5,
+                                  },
+                                },
+                                "operator": "=",
+                                "right": Node {
+                                  "end": 305,
+                                  "left": Node {
+                                    "computed": false,
+                                    "end": 274,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 45,
+                                        "line": 5,
+                                      },
+                                      "start": Position {
+                                        "column": 25,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "object": Node {
+                                      "end": 255,
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 26,
+                                          "line": 5,
+                                        },
+                                        "identifierName": "g",
+                                        "start": Position {
+                                          "column": 25,
+                                          "line": 5,
+                                        },
+                                      },
+                                      "name": "g",
+                                      "start": 254,
+                                      "type": "Identifier",
+                                    },
+                                    "property": Node {
+                                      "end": 274,
+                                      "loc": SourceLocation {
+                                        "end": Position {
+                                          "column": 45,
+                                          "line": 5,
+                                        },
+                                        "identifierName": "__mutantCoverage__",
+                                        "start": Position {
+                                          "column": 27,
+                                          "line": 5,
+                                        },
+                                      },
+                                      "name": "__mutantCoverage__",
+                                      "start": 256,
+                                      "type": "Identifier",
+                                    },
+                                    "start": 254,
+                                    "type": "MemberExpression",
+                                  },
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 76,
+                                      "line": 5,
+                                    },
+                                    "start": Position {
+                                      "column": 25,
+                                      "line": 5,
+                                    },
+                                  },
+                                  "operator": "||",
+                                  "right": Node {
+                                    "end": 305,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 76,
+                                        "line": 5,
+                                      },
+                                      "start": Position {
+                                        "column": 49,
+                                        "line": 5,
+                                      },
+                                    },
+                                    "properties": Array [
+                                      Node {
+                                        "computed": false,
+                                        "end": 290,
+                                        "key": Node {
+                                          "end": 286,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 57,
+                                              "line": 5,
+                                            },
+                                            "identifierName": "static",
+                                            "start": Position {
+                                              "column": 51,
+                                              "line": 5,
+                                            },
+                                          },
+                                          "name": "static",
+                                          "start": 280,
+                                          "type": "Identifier",
+                                        },
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 61,
+                                            "line": 5,
+                                          },
+                                          "start": Position {
+                                            "column": 51,
+                                            "line": 5,
+                                          },
+                                        },
+                                        "method": false,
+                                        "shorthand": false,
+                                        "start": 280,
+                                        "type": "ObjectProperty",
+                                        "value": Node {
+                                          "end": 290,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 61,
+                                              "line": 5,
+                                            },
+                                            "start": Position {
+                                              "column": 59,
+                                              "line": 5,
+                                            },
+                                          },
+                                          "properties": Array [],
+                                          "start": 288,
+                                          "type": "ObjectExpression",
+                                        },
+                                      },
+                                      Node {
+                                        "computed": false,
+                                        "end": 303,
+                                        "key": Node {
+                                          "end": 299,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 70,
+                                              "line": 5,
+                                            },
+                                            "identifierName": "perTest",
+                                            "start": Position {
+                                              "column": 63,
+                                              "line": 5,
+                                            },
+                                          },
+                                          "name": "perTest",
+                                          "start": 292,
+                                          "type": "Identifier",
+                                        },
+                                        "loc": SourceLocation {
+                                          "end": Position {
+                                            "column": 74,
+                                            "line": 5,
+                                          },
+                                          "start": Position {
+                                            "column": 63,
+                                            "line": 5,
+                                          },
+                                        },
+                                        "method": false,
+                                        "shorthand": false,
+                                        "start": 292,
+                                        "type": "ObjectProperty",
+                                        "value": Node {
+                                          "end": 303,
+                                          "loc": SourceLocation {
+                                            "end": Position {
+                                              "column": 74,
+                                              "line": 5,
+                                            },
+                                            "start": Position {
+                                              "column": 72,
+                                              "line": 5,
+                                            },
+                                          },
+                                          "properties": Array [],
+                                          "start": 301,
+                                          "type": "ObjectExpression",
+                                        },
+                                      },
+                                    ],
+                                    "start": 278,
+                                    "type": "ObjectExpression",
+                                  },
+                                  "start": 254,
+                                  "type": "LogicalExpression",
+                                },
+                                "start": 231,
+                                "type": "AssignmentExpression",
+                              },
+                              "loc": SourceLocation {
+                                "end": Position {
+                                  "column": 77,
+                                  "line": 5,
+                                },
+                                "start": Position {
+                                  "column": 2,
+                                  "line": 5,
+                                },
+                              },
+                              "start": 231,
+                              "type": "ExpressionStatement",
+                            },
+                            Node {
+                              "end": 668,
+                              "expression": Node {
+                                "end": 667,
+                                "left": Node {
+                                  "computed": false,
+                                  "end": 326,
+                                  "loc": SourceLocation {
+                                    "end": Position {
+                                      "column": 19,
+                                      "line": 6,
+                                    },
+                                    "start": Position {
+                                      "column": 2,
+                                      "line": 6,
+                                    },
+                                  },
+                                  "object": Node {
+                                    "end": 310,
+                                    "loc": SourceLocation {
+                                      "end": Position {
+                                        "column": 3,
+                                        "line": 6,
+                                      },
+                                      "identifierName": "g",
+                                      "start": Position {
+                                        "column": 2,
+                                        "line": 6,
+                                      },
+                                    },
+                                    "name": "g",
+                                    "start": 309,
+                                    "type": "Identifier",
+                                  },
+                                  "property": Node {
+                                    "end": 326,
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 19,
-                                        "line": 3,
+                                        "line": 6,
                                       },
                                       "identifierName": "__coverMutant__",
                                       "start": Position {
                                         "column": 4,
-                                        "line": 3,
+                                        "line": 6,
                                       },
                                     },
                                     "name": "__coverMutant__",
-                                    "start": 118,
+                                    "start": 311,
                                     "type": "Identifier",
                                   },
-                                  "start": 116,
+                                  "start": 309,
                                   "type": "MemberExpression",
                                 },
                                 "loc": SourceLocation {
                                   "end": Position {
                                     "column": 3,
-                                    "line": 12,
+                                    "line": 15,
                                   },
                                   "start": Position {
                                     "column": 2,
-                                    "line": 3,
+                                    "line": 6,
                                   },
                                 },
                                 "operator": "=",
                                 "right": Node {
-                                  "end": 474,
+                                  "end": 667,
                                   "left": Node {
                                     "computed": false,
-                                    "end": 153,
+                                    "end": 346,
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 39,
-                                        "line": 3,
+                                        "line": 6,
                                       },
                                       "start": Position {
                                         "column": 22,
-                                        "line": 3,
+                                        "line": 6,
                                       },
                                     },
                                     "object": Node {
-                                      "end": 137,
+                                      "end": 330,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 23,
-                                          "line": 3,
+                                          "line": 6,
                                         },
                                         "identifierName": "g",
                                         "start": Position {
                                           "column": 22,
-                                          "line": 3,
+                                          "line": 6,
                                         },
                                       },
                                       "name": "g",
-                                      "start": 136,
+                                      "start": 329,
                                       "type": "Identifier",
                                     },
                                     "property": Node {
-                                      "end": 153,
+                                      "end": 346,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 39,
-                                          "line": 3,
+                                          "line": 6,
                                         },
                                         "identifierName": "__coverMutant__",
                                         "start": Position {
                                           "column": 24,
-                                          "line": 3,
+                                          "line": 6,
                                         },
                                       },
                                       "name": "__coverMutant__",
-                                      "start": 138,
+                                      "start": 331,
                                       "type": "Identifier",
                                     },
-                                    "start": 136,
+                                    "start": 329,
                                     "type": "MemberExpression",
                                   },
                                   "loc": SourceLocation {
                                     "end": Position {
                                       "column": 3,
-                                      "line": 12,
+                                      "line": 15,
                                     },
                                     "start": Position {
                                       "column": 22,
-                                      "line": 3,
+                                      "line": 6,
                                     },
                                   },
                                   "operator": "||",
@@ -4788,134 +6723,134 @@ Object {
                                         Node {
                                           "declarations": Array [
                                             Node {
-                                              "end": 210,
+                                              "end": 403,
                                               "id": Node {
-                                                "end": 180,
+                                                "end": 373,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 9,
-                                                    "line": 4,
+                                                    "line": 7,
                                                   },
                                                   "identifierName": "c",
                                                   "start": Position {
                                                     "column": 8,
-                                                    "line": 4,
+                                                    "line": 7,
                                                   },
                                                 },
                                                 "name": "c",
-                                                "start": 179,
+                                                "start": 372,
                                                 "type": "Identifier",
                                               },
                                               "init": Node {
                                                 "computed": false,
-                                                "end": 210,
+                                                "end": 403,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 39,
-                                                    "line": 4,
+                                                    "line": 7,
                                                   },
                                                   "start": Position {
                                                     "column": 12,
-                                                    "line": 4,
+                                                    "line": 7,
                                                   },
                                                 },
                                                 "object": Node {
                                                   "computed": false,
-                                                  "end": 203,
+                                                  "end": 396,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 32,
-                                                      "line": 4,
+                                                      "line": 7,
                                                     },
                                                     "start": Position {
                                                       "column": 12,
-                                                      "line": 4,
+                                                      "line": 7,
                                                     },
                                                   },
                                                   "object": Node {
-                                                    "end": 184,
+                                                    "end": 377,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 13,
-                                                        "line": 4,
+                                                        "line": 7,
                                                       },
                                                       "identifierName": "g",
                                                       "start": Position {
                                                         "column": 12,
-                                                        "line": 4,
+                                                        "line": 7,
                                                       },
                                                     },
                                                     "name": "g",
-                                                    "start": 183,
+                                                    "start": 376,
                                                     "type": "Identifier",
                                                   },
                                                   "property": Node {
-                                                    "end": 203,
+                                                    "end": 396,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 32,
-                                                        "line": 4,
+                                                        "line": 7,
                                                       },
                                                       "identifierName": "__mutantCoverage__",
                                                       "start": Position {
                                                         "column": 14,
-                                                        "line": 4,
+                                                        "line": 7,
                                                       },
                                                     },
                                                     "name": "__mutantCoverage__",
-                                                    "start": 185,
+                                                    "start": 378,
                                                     "type": "Identifier",
                                                   },
-                                                  "start": 183,
+                                                  "start": 376,
                                                   "type": "MemberExpression",
                                                 },
                                                 "property": Node {
-                                                  "end": 210,
+                                                  "end": 403,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 39,
-                                                      "line": 4,
+                                                      "line": 7,
                                                     },
                                                     "identifierName": "static",
                                                     "start": Position {
                                                       "column": 33,
-                                                      "line": 4,
+                                                      "line": 7,
                                                     },
                                                   },
                                                   "name": "static",
-                                                  "start": 204,
+                                                  "start": 397,
                                                   "type": "Identifier",
                                                 },
-                                                "start": 183,
+                                                "start": 376,
                                                 "type": "MemberExpression",
                                               },
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 39,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                                 "start": Position {
                                                   "column": 8,
-                                                  "line": 4,
+                                                  "line": 7,
                                                 },
                                               },
-                                              "start": 179,
+                                              "start": 372,
                                               "type": "VariableDeclarator",
                                             },
                                           ],
-                                          "end": 211,
+                                          "end": 404,
                                           "kind": "var",
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 40,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                             "start": Position {
                                               "column": 4,
-                                              "line": 4,
+                                              "line": 7,
                                             },
                                           },
-                                          "start": 175,
+                                          "start": 368,
                                           "type": "VariableDeclaration",
                                         },
                                         Node {
@@ -4923,475 +6858,475 @@ Object {
                                           "consequent": Node {
                                             "body": Array [
                                               Node {
-                                                "end": 362,
+                                                "end": 555,
                                                 "expression": Node {
-                                                  "end": 361,
+                                                  "end": 554,
                                                   "left": Node {
-                                                    "end": 250,
+                                                    "end": 443,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 7,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "identifierName": "c",
                                                       "start": Position {
                                                         "column": 6,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "name": "c",
-                                                    "start": 249,
+                                                    "start": 442,
                                                     "type": "Identifier",
                                                   },
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 118,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                     "start": Position {
                                                       "column": 6,
-                                                      "line": 6,
+                                                      "line": 9,
                                                     },
                                                   },
                                                   "operator": "=",
                                                   "right": Node {
-                                                    "end": 361,
+                                                    "end": 554,
                                                     "left": Node {
                                                       "computed": true,
-                                                      "end": 302,
+                                                      "end": 495,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 59,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "start": Position {
                                                           "column": 10,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "object": Node {
                                                         "computed": false,
-                                                        "end": 281,
+                                                        "end": 474,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 38,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                           "start": Position {
                                                             "column": 10,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                         },
                                                         "object": Node {
                                                           "computed": false,
-                                                          "end": 273,
+                                                          "end": 466,
                                                           "loc": SourceLocation {
                                                             "end": Position {
                                                               "column": 30,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                             "start": Position {
                                                               "column": 10,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                           },
                                                           "object": Node {
-                                                            "end": 254,
+                                                            "end": 447,
                                                             "loc": SourceLocation {
                                                               "end": Position {
                                                                 "column": 11,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                               "identifierName": "g",
                                                               "start": Position {
                                                                 "column": 10,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                             },
                                                             "name": "g",
-                                                            "start": 253,
+                                                            "start": 446,
                                                             "type": "Identifier",
                                                           },
                                                           "property": Node {
-                                                            "end": 273,
+                                                            "end": 466,
                                                             "loc": SourceLocation {
                                                               "end": Position {
                                                                 "column": 30,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                               "identifierName": "__mutantCoverage__",
                                                               "start": Position {
                                                                 "column": 12,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                             },
                                                             "name": "__mutantCoverage__",
-                                                            "start": 255,
+                                                            "start": 448,
                                                             "type": "Identifier",
                                                           },
-                                                          "start": 253,
+                                                          "start": 446,
                                                           "type": "MemberExpression",
                                                         },
                                                         "property": Node {
-                                                          "end": 281,
+                                                          "end": 474,
                                                           "loc": SourceLocation {
                                                             "end": Position {
                                                               "column": 38,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                             "identifierName": "perTest",
                                                             "start": Position {
                                                               "column": 31,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                           },
                                                           "name": "perTest",
-                                                          "start": 274,
+                                                          "start": 467,
                                                           "type": "Identifier",
                                                         },
-                                                        "start": 253,
+                                                        "start": 446,
                                                         "type": "MemberExpression",
                                                       },
                                                       "property": Node {
                                                         "computed": false,
-                                                        "end": 301,
+                                                        "end": 494,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 58,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                           "start": Position {
                                                             "column": 39,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                         },
                                                         "object": Node {
-                                                          "end": 283,
+                                                          "end": 476,
                                                           "loc": SourceLocation {
                                                             "end": Position {
                                                               "column": 40,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                             "identifierName": "g",
                                                             "start": Position {
                                                               "column": 39,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                           },
                                                           "name": "g",
-                                                          "start": 282,
+                                                          "start": 475,
                                                           "type": "Identifier",
                                                         },
                                                         "property": Node {
-                                                          "end": 301,
+                                                          "end": 494,
                                                           "loc": SourceLocation {
                                                             "end": Position {
                                                               "column": 58,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                             "identifierName": "__currentTestId__",
                                                             "start": Position {
                                                               "column": 41,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                           },
                                                           "name": "__currentTestId__",
-                                                          "start": 284,
+                                                          "start": 477,
                                                           "type": "Identifier",
                                                         },
-                                                        "start": 282,
+                                                        "start": 475,
                                                         "type": "MemberExpression",
                                                       },
-                                                      "start": 253,
+                                                      "start": 446,
                                                       "type": "MemberExpression",
                                                     },
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 118,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                       "start": Position {
                                                         "column": 10,
-                                                        "line": 6,
+                                                        "line": 9,
                                                       },
                                                     },
                                                     "operator": "=",
                                                     "right": Node {
-                                                      "end": 361,
+                                                      "end": 554,
                                                       "left": Node {
                                                         "computed": true,
-                                                        "end": 355,
+                                                        "end": 548,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 112,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                           "start": Position {
                                                             "column": 63,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                         },
                                                         "object": Node {
                                                           "computed": false,
-                                                          "end": 334,
+                                                          "end": 527,
                                                           "loc": SourceLocation {
                                                             "end": Position {
                                                               "column": 91,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                             "start": Position {
                                                               "column": 63,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                           },
                                                           "object": Node {
                                                             "computed": false,
-                                                            "end": 326,
+                                                            "end": 519,
                                                             "loc": SourceLocation {
                                                               "end": Position {
                                                                 "column": 83,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                               "start": Position {
                                                                 "column": 63,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                             },
                                                             "object": Node {
-                                                              "end": 307,
+                                                              "end": 500,
                                                               "loc": SourceLocation {
                                                                 "end": Position {
                                                                   "column": 64,
-                                                                  "line": 6,
+                                                                  "line": 9,
                                                                 },
                                                                 "identifierName": "g",
                                                                 "start": Position {
                                                                   "column": 63,
-                                                                  "line": 6,
+                                                                  "line": 9,
                                                                 },
                                                               },
                                                               "name": "g",
-                                                              "start": 306,
+                                                              "start": 499,
                                                               "type": "Identifier",
                                                             },
                                                             "property": Node {
-                                                              "end": 326,
+                                                              "end": 519,
                                                               "loc": SourceLocation {
                                                                 "end": Position {
                                                                   "column": 83,
-                                                                  "line": 6,
+                                                                  "line": 9,
                                                                 },
                                                                 "identifierName": "__mutantCoverage__",
                                                                 "start": Position {
                                                                   "column": 65,
-                                                                  "line": 6,
+                                                                  "line": 9,
                                                                 },
                                                               },
                                                               "name": "__mutantCoverage__",
-                                                              "start": 308,
+                                                              "start": 501,
                                                               "type": "Identifier",
                                                             },
-                                                            "start": 306,
+                                                            "start": 499,
                                                             "type": "MemberExpression",
                                                           },
                                                           "property": Node {
-                                                            "end": 334,
+                                                            "end": 527,
                                                             "loc": SourceLocation {
                                                               "end": Position {
                                                                 "column": 91,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                               "identifierName": "perTest",
                                                               "start": Position {
                                                                 "column": 84,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                             },
                                                             "name": "perTest",
-                                                            "start": 327,
+                                                            "start": 520,
                                                             "type": "Identifier",
                                                           },
-                                                          "start": 306,
+                                                          "start": 499,
                                                           "type": "MemberExpression",
                                                         },
                                                         "property": Node {
                                                           "computed": false,
-                                                          "end": 354,
+                                                          "end": 547,
                                                           "loc": SourceLocation {
                                                             "end": Position {
                                                               "column": 111,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                             "start": Position {
                                                               "column": 92,
-                                                              "line": 6,
+                                                              "line": 9,
                                                             },
                                                           },
                                                           "object": Node {
-                                                            "end": 336,
+                                                            "end": 529,
                                                             "loc": SourceLocation {
                                                               "end": Position {
                                                                 "column": 93,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                               "identifierName": "g",
                                                               "start": Position {
                                                                 "column": 92,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                             },
                                                             "name": "g",
-                                                            "start": 335,
+                                                            "start": 528,
                                                             "type": "Identifier",
                                                           },
                                                           "property": Node {
-                                                            "end": 354,
+                                                            "end": 547,
                                                             "loc": SourceLocation {
                                                               "end": Position {
                                                                 "column": 111,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                               "identifierName": "__currentTestId__",
                                                               "start": Position {
                                                                 "column": 94,
-                                                                "line": 6,
+                                                                "line": 9,
                                                               },
                                                             },
                                                             "name": "__currentTestId__",
-                                                            "start": 337,
+                                                            "start": 530,
                                                             "type": "Identifier",
                                                           },
-                                                          "start": 335,
+                                                          "start": 528,
                                                           "type": "MemberExpression",
                                                         },
-                                                        "start": 306,
+                                                        "start": 499,
                                                         "type": "MemberExpression",
                                                       },
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 118,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                         "start": Position {
                                                           "column": 63,
-                                                          "line": 6,
+                                                          "line": 9,
                                                         },
                                                       },
                                                       "operator": "||",
                                                       "right": Node {
-                                                        "end": 361,
+                                                        "end": 554,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 118,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                           "start": Position {
                                                             "column": 116,
-                                                            "line": 6,
+                                                            "line": 9,
                                                           },
                                                         },
                                                         "properties": Array [],
-                                                        "start": 359,
+                                                        "start": 552,
                                                         "type": "ObjectExpression",
                                                       },
-                                                      "start": 306,
+                                                      "start": 499,
                                                       "type": "LogicalExpression",
                                                     },
-                                                    "start": 253,
+                                                    "start": 446,
                                                     "type": "AssignmentExpression",
                                                   },
-                                                  "start": 249,
+                                                  "start": 442,
                                                   "type": "AssignmentExpression",
                                                 },
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 119,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                   "start": Position {
                                                     "column": 6,
-                                                    "line": 6,
+                                                    "line": 9,
                                                   },
                                                 },
-                                                "start": 249,
+                                                "start": 442,
                                                 "type": "ExpressionStatement",
                                               },
                                             ],
                                             "directives": Array [],
-                                            "end": 368,
+                                            "end": 561,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 5,
-                                                "line": 7,
+                                                "line": 10,
                                               },
                                               "start": Position {
                                                 "column": 29,
-                                                "line": 5,
+                                                "line": 8,
                                               },
                                             },
-                                            "start": 241,
+                                            "start": 434,
                                             "type": "BlockStatement",
                                           },
-                                          "end": 368,
+                                          "end": 561,
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 5,
-                                              "line": 7,
+                                              "line": 10,
                                             },
                                             "start": Position {
                                               "column": 4,
-                                              "line": 5,
+                                              "line": 8,
                                             },
                                           },
-                                          "start": 216,
+                                          "start": 409,
                                           "test": Node {
                                             "computed": false,
-                                            "end": 239,
+                                            "end": 432,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 27,
-                                                "line": 5,
+                                                "line": 8,
                                               },
                                               "start": Position {
                                                 "column": 8,
-                                                "line": 5,
+                                                "line": 8,
                                               },
                                             },
                                             "object": Node {
-                                              "end": 221,
+                                              "end": 414,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 9,
-                                                  "line": 5,
+                                                  "line": 8,
                                                 },
                                                 "identifierName": "g",
                                                 "start": Position {
                                                   "column": 8,
-                                                  "line": 5,
+                                                  "line": 8,
                                                 },
                                               },
                                               "name": "g",
-                                              "start": 220,
+                                              "start": 413,
                                               "type": "Identifier",
                                             },
                                             "property": Node {
-                                              "end": 239,
+                                              "end": 432,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 27,
-                                                  "line": 5,
+                                                  "line": 8,
                                                 },
                                                 "identifierName": "__currentTestId__",
                                                 "start": Position {
                                                   "column": 10,
-                                                  "line": 5,
+                                                  "line": 8,
                                                 },
                                               },
                                               "name": "__currentTestId__",
-                                              "start": 222,
+                                              "start": 415,
                                               "type": "Identifier",
                                             },
-                                            "start": 220,
+                                            "start": 413,
                                             "type": "MemberExpression",
                                           },
                                           "type": "IfStatement",
@@ -5399,275 +7334,275 @@ Object {
                                         Node {
                                           "declarations": Array [
                                             Node {
-                                              "end": 390,
+                                              "end": 583,
                                               "id": Node {
-                                                "end": 378,
+                                                "end": 571,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 9,
-                                                    "line": 8,
+                                                    "line": 11,
                                                   },
                                                   "identifierName": "a",
                                                   "start": Position {
                                                     "column": 8,
-                                                    "line": 8,
+                                                    "line": 11,
                                                   },
                                                 },
                                                 "name": "a",
-                                                "start": 377,
+                                                "start": 570,
                                                 "type": "Identifier",
                                               },
                                               "init": Node {
-                                                "end": 390,
+                                                "end": 583,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 21,
-                                                    "line": 8,
+                                                    "line": 11,
                                                   },
                                                   "identifierName": "arguments",
                                                   "start": Position {
                                                     "column": 12,
-                                                    "line": 8,
+                                                    "line": 11,
                                                   },
                                                 },
                                                 "name": "arguments",
-                                                "start": 381,
+                                                "start": 574,
                                                 "type": "Identifier",
                                               },
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 21,
-                                                  "line": 8,
+                                                  "line": 11,
                                                 },
                                                 "start": Position {
                                                   "column": 8,
-                                                  "line": 8,
+                                                  "line": 11,
                                                 },
                                               },
-                                              "start": 377,
+                                              "start": 570,
                                               "type": "VariableDeclarator",
                                             },
                                           ],
-                                          "end": 391,
+                                          "end": 584,
                                           "kind": "var",
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 22,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                             "start": Position {
                                               "column": 4,
-                                              "line": 8,
+                                              "line": 11,
                                             },
                                           },
-                                          "start": 373,
+                                          "start": 566,
                                           "type": "VariableDeclaration",
                                         },
                                         Node {
                                           "body": Node {
                                             "body": Array [
                                               Node {
-                                                "end": 464,
+                                                "end": 657,
                                                 "expression": Node {
-                                                  "end": 463,
+                                                  "end": 656,
                                                   "left": Node {
                                                     "computed": true,
-                                                    "end": 442,
+                                                    "end": 635,
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 13,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                       "start": Position {
                                                         "column": 6,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                     },
                                                     "object": Node {
-                                                      "end": 436,
+                                                      "end": 629,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 7,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                         "identifierName": "c",
                                                         "start": Position {
                                                           "column": 6,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                       },
                                                       "name": "c",
-                                                      "start": 435,
+                                                      "start": 628,
                                                       "type": "Identifier",
                                                     },
                                                     "property": Node {
                                                       "computed": true,
-                                                      "end": 441,
+                                                      "end": 634,
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 12,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                         "start": Position {
                                                           "column": 8,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                       },
                                                       "object": Node {
-                                                        "end": 438,
+                                                        "end": 631,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 9,
-                                                            "line": 10,
+                                                            "line": 13,
                                                           },
                                                           "identifierName": "a",
                                                           "start": Position {
                                                             "column": 8,
-                                                            "line": 10,
+                                                            "line": 13,
                                                           },
                                                         },
                                                         "name": "a",
-                                                        "start": 437,
+                                                        "start": 630,
                                                         "type": "Identifier",
                                                       },
                                                       "property": Node {
-                                                        "end": 440,
+                                                        "end": 633,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 11,
-                                                            "line": 10,
+                                                            "line": 13,
                                                           },
                                                           "identifierName": "i",
                                                           "start": Position {
                                                             "column": 10,
-                                                            "line": 10,
+                                                            "line": 13,
                                                           },
                                                         },
                                                         "name": "i",
-                                                        "start": 439,
+                                                        "start": 632,
                                                         "type": "Identifier",
                                                       },
-                                                      "start": 437,
+                                                      "start": 630,
                                                       "type": "MemberExpression",
                                                     },
-                                                    "start": 435,
+                                                    "start": 628,
                                                     "type": "MemberExpression",
                                                   },
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 34,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                     "start": Position {
                                                       "column": 6,
-                                                      "line": 10,
+                                                      "line": 13,
                                                     },
                                                   },
                                                   "operator": "=",
                                                   "right": Node {
-                                                    "end": 463,
+                                                    "end": 656,
                                                     "left": Node {
-                                                      "end": 458,
+                                                      "end": 651,
                                                       "extra": Object {
-                                                        "parenStart": 445,
+                                                        "parenStart": 638,
                                                         "parenthesized": true,
                                                       },
                                                       "left": Node {
                                                         "computed": true,
-                                                        "end": 453,
+                                                        "end": 646,
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 24,
-                                                            "line": 10,
+                                                            "line": 13,
                                                           },
                                                           "start": Position {
                                                             "column": 17,
-                                                            "line": 10,
+                                                            "line": 13,
                                                           },
                                                         },
                                                         "object": Node {
-                                                          "end": 447,
+                                                          "end": 640,
                                                           "loc": SourceLocation {
                                                             "end": Position {
                                                               "column": 18,
-                                                              "line": 10,
+                                                              "line": 13,
                                                             },
                                                             "identifierName": "c",
                                                             "start": Position {
                                                               "column": 17,
-                                                              "line": 10,
+                                                              "line": 13,
                                                             },
                                                           },
                                                           "name": "c",
-                                                          "start": 446,
+                                                          "start": 639,
                                                           "type": "Identifier",
                                                         },
                                                         "property": Node {
                                                           "computed": true,
-                                                          "end": 452,
+                                                          "end": 645,
                                                           "loc": SourceLocation {
                                                             "end": Position {
                                                               "column": 23,
-                                                              "line": 10,
+                                                              "line": 13,
                                                             },
                                                             "start": Position {
                                                               "column": 19,
-                                                              "line": 10,
+                                                              "line": 13,
                                                             },
                                                           },
                                                           "object": Node {
-                                                            "end": 449,
+                                                            "end": 642,
                                                             "loc": SourceLocation {
                                                               "end": Position {
                                                                 "column": 20,
-                                                                "line": 10,
+                                                                "line": 13,
                                                               },
                                                               "identifierName": "a",
                                                               "start": Position {
                                                                 "column": 19,
-                                                                "line": 10,
+                                                                "line": 13,
                                                               },
                                                             },
                                                             "name": "a",
-                                                            "start": 448,
+                                                            "start": 641,
                                                             "type": "Identifier",
                                                           },
                                                           "property": Node {
-                                                            "end": 451,
+                                                            "end": 644,
                                                             "loc": SourceLocation {
                                                               "end": Position {
                                                                 "column": 22,
-                                                                "line": 10,
+                                                                "line": 13,
                                                               },
                                                               "identifierName": "i",
                                                               "start": Position {
                                                                 "column": 21,
-                                                                "line": 10,
+                                                                "line": 13,
                                                               },
                                                             },
                                                             "name": "i",
-                                                            "start": 450,
+                                                            "start": 643,
                                                             "type": "Identifier",
                                                           },
-                                                          "start": 448,
+                                                          "start": 641,
                                                           "type": "MemberExpression",
                                                         },
-                                                        "start": 446,
+                                                        "start": 639,
                                                         "type": "MemberExpression",
                                                       },
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 29,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                         "start": Position {
                                                           "column": 17,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                       },
                                                       "operator": "||",
                                                       "right": Node {
-                                                        "end": 458,
+                                                        "end": 651,
                                                         "extra": Object {
                                                           "raw": "0",
                                                           "rawValue": 0,
@@ -5675,33 +7610,33 @@ Object {
                                                         "loc": SourceLocation {
                                                           "end": Position {
                                                             "column": 29,
-                                                            "line": 10,
+                                                            "line": 13,
                                                           },
                                                           "start": Position {
                                                             "column": 28,
-                                                            "line": 10,
+                                                            "line": 13,
                                                           },
                                                         },
-                                                        "start": 457,
+                                                        "start": 650,
                                                         "type": "NumericLiteral",
                                                         "value": 0,
                                                       },
-                                                      "start": 446,
+                                                      "start": 639,
                                                       "type": "LogicalExpression",
                                                     },
                                                     "loc": SourceLocation {
                                                       "end": Position {
                                                         "column": 34,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                       "start": Position {
                                                         "column": 16,
-                                                        "line": 10,
+                                                        "line": 13,
                                                       },
                                                     },
                                                     "operator": "+",
                                                     "right": Node {
-                                                      "end": 463,
+                                                      "end": 656,
                                                       "extra": Object {
                                                         "raw": "1",
                                                         "rawValue": 1,
@@ -5709,76 +7644,76 @@ Object {
                                                       "loc": SourceLocation {
                                                         "end": Position {
                                                           "column": 34,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                         "start": Position {
                                                           "column": 33,
-                                                          "line": 10,
+                                                          "line": 13,
                                                         },
                                                       },
-                                                      "start": 462,
+                                                      "start": 655,
                                                       "type": "NumericLiteral",
                                                       "value": 1,
                                                     },
-                                                    "start": 445,
+                                                    "start": 638,
                                                     "type": "BinaryExpression",
                                                   },
-                                                  "start": 435,
+                                                  "start": 628,
                                                   "type": "AssignmentExpression",
                                                 },
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 35,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                   "start": Position {
                                                     "column": 6,
-                                                    "line": 10,
+                                                    "line": 13,
                                                   },
                                                 },
-                                                "start": 435,
+                                                "start": 628,
                                                 "type": "ExpressionStatement",
                                               },
                                             ],
                                             "directives": Array [],
-                                            "end": 470,
+                                            "end": 663,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 5,
-                                                "line": 11,
+                                                "line": 14,
                                               },
                                               "start": Position {
                                                 "column": 35,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                             },
-                                            "start": 427,
+                                            "start": 620,
                                             "type": "BlockStatement",
                                           },
-                                          "end": 470,
+                                          "end": 663,
                                           "init": Node {
                                             "declarations": Array [
                                               Node {
-                                                "end": 407,
+                                                "end": 600,
                                                 "id": Node {
-                                                  "end": 405,
+                                                  "end": 598,
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 13,
-                                                      "line": 9,
+                                                      "line": 12,
                                                     },
                                                     "identifierName": "i",
                                                     "start": Position {
                                                       "column": 12,
-                                                      "line": 9,
+                                                      "line": 12,
                                                     },
                                                   },
                                                   "name": "i",
-                                                  "start": 404,
+                                                  "start": 597,
                                                   "type": "Identifier",
                                                 },
                                                 "init": Node {
-                                                  "end": 407,
+                                                  "end": 600,
                                                   "extra": Object {
                                                     "raw": "0",
                                                     "rawValue": 0,
@@ -5786,267 +7721,267 @@ Object {
                                                   "loc": SourceLocation {
                                                     "end": Position {
                                                       "column": 15,
-                                                      "line": 9,
+                                                      "line": 12,
                                                     },
                                                     "start": Position {
                                                       "column": 14,
-                                                      "line": 9,
+                                                      "line": 12,
                                                     },
                                                   },
-                                                  "start": 406,
+                                                  "start": 599,
                                                   "type": "NumericLiteral",
                                                   "value": 0,
                                                 },
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 15,
-                                                    "line": 9,
+                                                    "line": 12,
                                                   },
                                                   "start": Position {
                                                     "column": 12,
-                                                    "line": 9,
+                                                    "line": 12,
                                                   },
                                                 },
-                                                "start": 404,
+                                                "start": 597,
                                                 "type": "VariableDeclarator",
                                               },
                                             ],
-                                            "end": 407,
+                                            "end": 600,
                                             "kind": "var",
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 15,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                               "start": Position {
                                                 "column": 8,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                             },
-                                            "start": 400,
+                                            "start": 593,
                                             "type": "VariableDeclaration",
                                           },
                                           "loc": SourceLocation {
                                             "end": Position {
                                               "column": 5,
-                                              "line": 11,
+                                              "line": 14,
                                             },
                                             "start": Position {
                                               "column": 4,
-                                              "line": 9,
+                                              "line": 12,
                                             },
                                           },
-                                          "start": 396,
+                                          "start": 589,
                                           "test": Node {
-                                            "end": 421,
+                                            "end": 614,
                                             "left": Node {
-                                              "end": 410,
+                                              "end": 603,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 18,
-                                                  "line": 9,
+                                                  "line": 12,
                                                 },
                                                 "identifierName": "i",
                                                 "start": Position {
                                                   "column": 17,
-                                                  "line": 9,
+                                                  "line": 12,
                                                 },
                                               },
                                               "name": "i",
-                                              "start": 409,
+                                              "start": 602,
                                               "type": "Identifier",
                                             },
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 29,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                               "start": Position {
                                                 "column": 17,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                             },
                                             "operator": "<",
                                             "right": Node {
                                               "computed": false,
-                                              "end": 421,
+                                              "end": 614,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 29,
-                                                  "line": 9,
+                                                  "line": 12,
                                                 },
                                                 "start": Position {
                                                   "column": 21,
-                                                  "line": 9,
+                                                  "line": 12,
                                                 },
                                               },
                                               "object": Node {
-                                                "end": 414,
+                                                "end": 607,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 22,
-                                                    "line": 9,
+                                                    "line": 12,
                                                   },
                                                   "identifierName": "a",
                                                   "start": Position {
                                                     "column": 21,
-                                                    "line": 9,
+                                                    "line": 12,
                                                   },
                                                 },
                                                 "name": "a",
-                                                "start": 413,
+                                                "start": 606,
                                                 "type": "Identifier",
                                               },
                                               "property": Node {
-                                                "end": 421,
+                                                "end": 614,
                                                 "loc": SourceLocation {
                                                   "end": Position {
                                                     "column": 29,
-                                                    "line": 9,
+                                                    "line": 12,
                                                   },
                                                   "identifierName": "length",
                                                   "start": Position {
                                                     "column": 23,
-                                                    "line": 9,
+                                                    "line": 12,
                                                   },
                                                 },
                                                 "name": "length",
-                                                "start": 415,
+                                                "start": 608,
                                                 "type": "Identifier",
                                               },
-                                              "start": 413,
+                                              "start": 606,
                                               "type": "MemberExpression",
                                             },
-                                            "start": 409,
+                                            "start": 602,
                                             "type": "BinaryExpression",
                                           },
                                           "type": "ForStatement",
                                           "update": Node {
                                             "argument": Node {
-                                              "end": 424,
+                                              "end": 617,
                                               "loc": SourceLocation {
                                                 "end": Position {
                                                   "column": 32,
-                                                  "line": 9,
+                                                  "line": 12,
                                                 },
                                                 "identifierName": "i",
                                                 "start": Position {
                                                   "column": 31,
-                                                  "line": 9,
+                                                  "line": 12,
                                                 },
                                               },
                                               "name": "i",
-                                              "start": 423,
+                                              "start": 616,
                                               "type": "Identifier",
                                             },
-                                            "end": 426,
+                                            "end": 619,
                                             "loc": SourceLocation {
                                               "end": Position {
                                                 "column": 34,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                               "start": Position {
                                                 "column": 31,
-                                                "line": 9,
+                                                "line": 12,
                                               },
                                             },
                                             "operator": "++",
                                             "prefix": false,
-                                            "start": 423,
+                                            "start": 616,
                                             "type": "UpdateExpression",
                                           },
                                         },
                                       ],
                                       "directives": Array [],
-                                      "end": 474,
+                                      "end": 667,
                                       "loc": SourceLocation {
                                         "end": Position {
                                           "column": 3,
-                                          "line": 12,
+                                          "line": 15,
                                         },
                                         "start": Position {
                                           "column": 55,
-                                          "line": 3,
+                                          "line": 6,
                                         },
                                       },
-                                      "start": 169,
+                                      "start": 362,
                                       "type": "BlockStatement",
                                     },
-                                    "end": 474,
+                                    "end": 667,
                                     "generator": false,
                                     "id": null,
                                     "loc": SourceLocation {
                                       "end": Position {
                                         "column": 3,
-                                        "line": 12,
+                                        "line": 15,
                                       },
                                       "start": Position {
                                         "column": 43,
-                                        "line": 3,
+                                        "line": 6,
                                       },
                                     },
                                     "params": Array [],
-                                    "start": 157,
+                                    "start": 350,
                                     "type": "FunctionExpression",
                                   },
-                                  "start": 136,
+                                  "start": 329,
                                   "type": "LogicalExpression",
                                 },
-                                "start": 116,
+                                "start": 309,
                                 "type": "AssignmentExpression",
                               },
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 4,
-                                  "line": 12,
+                                  "line": 15,
                                 },
                                 "start": Position {
                                   "column": 2,
-                                  "line": 3,
+                                  "line": 6,
                                 },
                               },
-                              "start": 116,
+                              "start": 309,
                               "type": "ExpressionStatement",
                             },
                             Node {
                               "argument": Node {
-                                "end": 486,
+                                "end": 679,
                                 "loc": SourceLocation {
                                   "end": Position {
                                     "column": 10,
-                                    "line": 13,
+                                    "line": 16,
                                   },
                                   "identifierName": "g",
                                   "start": Position {
                                     "column": 9,
-                                    "line": 13,
+                                    "line": 16,
                                   },
                                 },
                                 "name": "g",
-                                "start": 485,
+                                "start": 678,
                                 "type": "Identifier",
                               },
-                              "end": 487,
+                              "end": 680,
                               "loc": SourceLocation {
                                 "end": Position {
                                   "column": 11,
-                                  "line": 13,
+                                  "line": 16,
                                 },
                                 "start": Position {
                                   "column": 2,
-                                  "line": 13,
+                                  "line": 16,
                                 },
                               },
-                              "start": 478,
+                              "start": 671,
                               "type": "ReturnStatement",
                             },
                           ],
                           "directives": Array [],
-                          "end": 489,
+                          "end": 682,
                           "loc": SourceLocation {
                             "end": Position {
                               "column": 1,
-                              "line": 14,
+                              "line": 17,
                             },
                             "start": Position {
                               "column": 34,
@@ -6056,7 +7991,7 @@ Object {
                           "start": 34,
                           "type": "BlockStatement",
                         },
-                        "end": 489,
+                        "end": 682,
                         "extra": Object {
                           "parenStart": 22,
                           "parenthesized": true,
@@ -6066,7 +8001,7 @@ Object {
                         "loc": SourceLocation {
                           "end": Position {
                             "column": 1,
-                            "line": 14,
+                            "line": 17,
                           },
                           "start": Position {
                             "column": 23,
@@ -6095,11 +8030,11 @@ Object {
                         "start": 23,
                         "type": "FunctionExpression",
                       },
-                      "end": 521,
+                      "end": 714,
                       "loc": SourceLocation {
                         "end": Position {
                           "column": 33,
-                          "line": 14,
+                          "line": 17,
                         },
                         "start": Position {
                           "column": 22,
@@ -6112,7 +8047,7 @@ Object {
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 33,
-                        "line": 14,
+                        "line": 17,
                       },
                       "start": Position {
                         "column": 4,
@@ -6123,12 +8058,12 @@ Object {
                     "type": "VariableDeclarator",
                   },
                 ],
-                "end": 521,
+                "end": 714,
                 "kind": "var",
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 33,
-                    "line": 14,
+                    "line": 17,
                   },
                   "start": Position {
                     "column": 0,

--- a/packages/instrumenter/testResources/instrumenter/app.component.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/app.component.ts.out.snap
@@ -2,6 +2,10 @@
 
 exports[`instrumenter integration should be able to instrument an angular component 1`] = `
 "var __global_69fa48 = function (g) {
+  if (g.__activeMutant__ === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    g.__activeMutant__ = Number(g.process.env.__STRYKER_ACTIVE_MUTANT__);
+  }
+
   g.__mutantCoverage__ = g.__mutantCoverage__ || {
     static: {},
     perTest: {}

--- a/packages/instrumenter/testResources/instrumenter/html-sample.html.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/html-sample.html.out.snap
@@ -14,6 +14,10 @@ exports[`instrumenter integration should be able to instrument html 1`] = `
     <script>
 // @ts-nocheck
 var __global_69fa48 = function (g) {
+  if (g.__activeMutant__ === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    g.__activeMutant__ = Number(g.process.env.__STRYKER_ACTIVE_MUTANT__);
+  }
+
   g.__mutantCoverage__ = g.__mutantCoverage__ || {
     static: {},
     perTest: {}

--- a/packages/instrumenter/testResources/instrumenter/js-sample.js.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/js-sample.js.out.snap
@@ -2,6 +2,10 @@
 
 exports[`instrumenter integration should be able to instrument a simple js file 1`] = `
 "var __global_69fa48 = function (g) {
+  if (g.__activeMutant__ === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    g.__activeMutant__ = Number(g.process.env.__STRYKER_ACTIVE_MUTANT__);
+  }
+
   g.__mutantCoverage__ = g.__mutantCoverage__ || {
     static: {},
     perTest: {}

--- a/packages/instrumenter/testResources/instrumenter/lit-html-sample.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/lit-html-sample.ts.out.snap
@@ -2,6 +2,10 @@
 
 exports[`instrumenter integration should be able to instrument a lit-html file 1`] = `
 "var __global_69fa48 = function (g) {
+  if (g.__activeMutant__ === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    g.__activeMutant__ = Number(g.process.env.__STRYKER_ACTIVE_MUTANT__);
+  }
+
   g.__mutantCoverage__ = g.__mutantCoverage__ || {
     static: {},
     perTest: {}

--- a/packages/instrumenter/testResources/instrumenter/super-call.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/super-call.ts.out.snap
@@ -2,6 +2,10 @@
 
 exports[`instrumenter integration should be able to instrument super calls 1`] = `
 "var __global_69fa48 = function (g) {
+  if (g.__activeMutant__ === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    g.__activeMutant__ = Number(g.process.env.__STRYKER_ACTIVE_MUTANT__);
+  }
+
   g.__mutantCoverage__ = g.__mutantCoverage__ || {
     static: {},
     perTest: {}

--- a/packages/instrumenter/testResources/instrumenter/ts-sample.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/ts-sample.ts.out.snap
@@ -2,6 +2,10 @@
 
 exports[`instrumenter integration should be able to instrument a simple ts file 1`] = `
 "var __global_69fa48 = function (g) {
+  if (g.__activeMutant__ === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    g.__activeMutant__ = Number(g.process.env.__STRYKER_ACTIVE_MUTANT__);
+  }
+
   g.__mutantCoverage__ = g.__mutantCoverage__ || {
     static: {},
     perTest: {}

--- a/packages/instrumenter/testResources/instrumenter/vue-sample.vue.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/vue-sample.vue.out.snap
@@ -89,6 +89,10 @@ exports[`instrumenter integration should be able to instrument a vue sample 1`] 
 <script>
 // @ts-nocheck
 var __global_69fa48 = function (g) {
+  if (g.__activeMutant__ === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    g.__activeMutant__ = Number(g.process.env.__STRYKER_ACTIVE_MUTANT__);
+  }
+
   g.__mutantCoverage__ = g.__mutantCoverage__ || {
     static: {},
     perTest: {}
@@ -160,6 +164,10 @@ export default __global_69fa48.__activeMutant__ === 1 ? {
 <script>
 // @ts-nocheck
 var __global_69fa48 = function (g) {
+  if (g.__activeMutant__ === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    g.__activeMutant__ = Number(g.process.env.__STRYKER_ACTIVE_MUTANT__);
+  }
+
   g.__mutantCoverage__ = g.__mutantCoverage__ || {
     static: {},
     perTest: {}

--- a/packages/test-helpers/src/assertions.ts
+++ b/packages/test-helpers/src/assertions.ts
@@ -10,10 +10,17 @@ import {
   CompleteDryRunResult,
   DryRunStatus,
   ErrorMutantRunResult,
+  TestResult,
+  FailedTestResult,
+  TestStatus,
 } from '@stryker-mutator/api/test_runner2';
 
 export function expectKilled(result: MutantRunResult): asserts result is KilledMutantRunResult {
   assert.equal(result.status, MutantRunStatus.Killed);
+}
+
+export function expectFailed(result: TestResult): asserts result is FailedTestResult {
+  assert.equal(result.status, TestStatus.Failed);
 }
 
 export function expectCompleted(runResult: DryRunResult): asserts runResult is CompleteDryRunResult {


### PR DESCRIPTION
Add support for the command test runner with mutation switching.

_NOTE: Support for the command test runner is "best effort"! It might not work for your test runner of choice_

The switching of mutants is done by providing the `__STRYKER_ACTIVE_MUTANT__` environment variable when executing the command. The `@stryker-mutator/instrumenter` now adds a check for this environment variable in each source file. This only works if the command you configure allows for this environment variable to flow through to the test environment.

In other words: this should work for node test runners like [node-tap](https://node-tap.org/) and mocha but not for test runners that spin up their own test environment, like jest or karma.

Note that for mocha, karma, and jest, you're better of using their respective test runner plugins.