### PR TITLE
feat(jest-runner): remove deprecated project types

### DIFF
--- a/packages/jest-runner/schema/jest-runner-options.json
+++ b/packages/jest-runner/schema/jest-runner-options.json
@@ -37,8 +37,6 @@
       "enum": [
         "create-react-app",
         "create-react-app-ts",
-        "react",
-        "react-ts",
         "custom"
       ]
     }

--- a/packages/jest-runner/src/configLoaders/index.ts
+++ b/packages/jest-runner/src/configLoaders/index.ts
@@ -32,18 +32,6 @@ export function configLoaderFactory(options: StrykerOptions, injector: Injector<
     case 'create-react-app-ts':
       warnAboutConfigFile(optionsWithJest.jest.projectType, optionsWithJest.jest.configFile);
       return configLoaderInjector.injectClass(ReactScriptsTSJestConfigLoader);
-    case 'react':
-      log.warn(
-        'DEPRECATED: The projectType "react" is deprecated. Use projectType "create-react-app" for react projects created by "create-react-app" or use "custom" for other react projects.'
-      );
-      warnAboutConfigFile(optionsWithJest.jest.projectType, optionsWithJest.jest.configFile);
-      return configLoaderInjector.injectClass(ReactScriptsJestConfigLoader);
-    case 'react-ts':
-      log.warn(
-        'DEPRECATED: The projectType "react-ts" is deprecated. Use projectType "create-react-app-ts" for react projects created by "create-react-app" or use "custom" for other react projects.'
-      );
-      warnAboutConfigFile(optionsWithJest.jest.projectType, optionsWithJest.jest.configFile);
-      return configLoaderInjector.injectClass(ReactScriptsTSJestConfigLoader);
     default:
       throw new Error(`No configLoader available for ${optionsWithJest.jest.projectType}`);
   }

--- a/packages/jest-runner/test/integration/JestTestRunner.it.spec.ts
+++ b/packages/jest-runner/test/integration/JestTestRunner.it.spec.ts
@@ -49,10 +49,10 @@ describe(`${JestTestRunner.name} integration test`, () => {
   };
 
   describe('dryRun', () => {
-    it.skip('should run tests on the example React + TypeScript project', async () => {
+    it('should run tests on the example React + TypeScript project', async () => {
       // TODO: Get a proper React TS project that works on Windows
       process.chdir(getProjectRoot('reactTsProject'));
-      const jestTestRunner = createSut({ projectType: 'react-ts' });
+      const jestTestRunner = createSut({ projectType: 'create-react-app-ts' });
 
       const runResult = await jestTestRunner.dryRun();
 
@@ -60,9 +60,9 @@ describe(`${JestTestRunner.name} integration test`, () => {
       expectToHaveSuccessfulTests(runResult, 1);
     });
 
-    it.skip('should set the test name and timeSpentMs', async () => {
+    it('should set the test name and timeSpentMs', async () => {
       process.chdir(getProjectRoot('reactTsProject'));
-      const jestTestRunner = createSut({ projectType: 'react-ts' });
+      const jestTestRunner = createSut({ projectType: 'create-react-app-ts' });
 
       const runResult = await jestTestRunner.dryRun();
 

--- a/packages/jest-runner/test/unit/configLoaders/configLoaderFactory.spec.ts
+++ b/packages/jest-runner/test/unit/configLoaders/configLoaderFactory.spec.ts
@@ -49,9 +49,9 @@ describe(configLoaderFactory.name, () => {
     expect(sut).eq(customConfigLoaderStub);
   });
 
-  describe('with "projectType": "react"', () => {
+  describe('with "projectType": "create-react-app"', () => {
     beforeEach(() => {
-      options.jest.projectType = 'react';
+      options.jest.projectType = 'create-react-app';
     });
 
     it('should create a ReactScriptsJestConfigLoader', () => {
@@ -75,7 +75,7 @@ describe(configLoaderFactory.name, () => {
 
   describe('with "projectType": "react-ts"', () => {
     beforeEach(() => {
-      options.jest.projectType = 'react-ts';
+      options.jest.projectType = 'create-react-app-ts';
     });
 
     it('should create a ReactScriptsTSJestConfigLoader', () => {

--- a/packages/jest-runner/test/unit/configLoaders/configLoaderFactory.spec.ts
+++ b/packages/jest-runner/test/unit/configLoaders/configLoaderFactory.spec.ts
@@ -63,17 +63,9 @@ describe(configLoaderFactory.name, () => {
     it('should warn when a configFile is set', () => {
       testConfigFileWarning(options);
     });
-
-    it('should log a deprecation warning', () => {
-      testInjector.injector.provideValue(commonTokens.options, options).injectFunction(configLoaderFactory);
-
-      expect(testInjector.logger.warn).calledWith(
-        'DEPRECATED: The projectType "react" is deprecated. Use projectType "create-react-app" for react projects created by "create-react-app" or use "custom" for other react projects.'
-      );
-    });
   });
 
-  describe('with "projectType": "react-ts"', () => {
+  describe('with "projectType": "create-react-app-ts"', () => {
     beforeEach(() => {
       options.jest.projectType = 'create-react-app-ts';
     });
@@ -86,14 +78,6 @@ describe(configLoaderFactory.name, () => {
 
     it('should warn when a configFile is set', () => {
       testConfigFileWarning(options);
-    });
-
-    it('should log a deprecation warning', () => {
-      testInjector.injector.provideValue(commonTokens.options, options).injectFunction(configLoaderFactory);
-
-      expect(testInjector.logger.warn).calledWith(
-        'DEPRECATED: The projectType "react-ts" is deprecated. Use projectType "create-react-app-ts" for react projects created by "create-react-app" or use "custom" for other react projects.'
-      );
     });
   });
 });


### PR DESCRIPTION
Remove deprecated project types.
* `react` --> `create-react-app`
* `react-ts` --> `create-react-app-ts`

Fixes #2021

BREAKING CHANGE: Project types `react` and `react-ts` have been removed. Please use `create-react-app` and `create-react-app-ts` respectively