### PR TITLE
feat(core): add ability to override file headers

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -315,7 +315,10 @@
       "errorMessage": "should be an \"object\" describing the mutator or a \"string\". See https://github.com/stryker-mutator/stryker/tree/master/packages/core#mutator."
     },
     "packageManager": {
-      "enum": ["npm", "yarn"],
+      "enum": [
+        "npm",
+        "yarn"
+      ],
       "description": "The package manager Stryker can use to install missing dependencies."
     },
     "plugins": {
@@ -343,6 +346,17 @@
     "htmlReporter": {
       "description": "The options for the html reporter",
       "$ref": "#/definitions/htmlReporterOptions"
+    },
+    "sandboxFileHeaders": {
+      "type": "object",
+      "title": "SandboxFileHeaders",
+      "description": "Configure additional headers to be added to files inside your sandbox. These headers will be added after Stryker has instrumented your code with mutants, but before a test runner or build command is executed. This can be used to ignore typescript compile errors and eslint warnings that might have been added in the process of instrumenting your code. The default setting should work for most use cases.",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {
+        "**/*+(.js|.ts|.cjs|.mjs)?(x)": "/* eslint-disable */\n// @ts-nocheck\n"
+      }
     },
     "symlinkNodeModules": {
       "description": "The 'symlinkNodeModules' value indicates whether Stryker should create a symbolic link to your current node_modules directory in the sandbox directories. This makes running your tests by Stryker behave more like your would run the tests yourself in your project directory. Only disable this setting if you really know what you are doing.",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,6 +113,7 @@ You can *ignore* files by adding an exclamation mark (`!`) at the start of an ex
 * [mutator](#mutator)
 * [plugins](#plugins)
 * [reporters](#reporters)
+* [sandboxFileHeaders](#sandboxFileHeaders)
 * [symlinkNodeModules](#symlinkNodeModules)
 * [tempDirName](#tempDirName)
 * [testFramework](#testFramework)
@@ -292,6 +293,19 @@ The `clear-text` reporter supports three additional config options:
 
 The `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a mutation score badge to your readme, as well as hosting your html report on the dashboard. It uses the [dashboard.*](#dashboard) configuration options. See [the Stryker handbook](https://github.com/stryker-mutator/stryker-handbook/blob/master/dashboard.md) for more info.
 
+<a name="sandboxFileHeaders"></a>
+### `sandboxFileHeaders` [`object`]
+
+Default: `{ "**/*+(.js|.ts|.cjs|.mjs)?(x)": "/* eslint-disable */\n// @ts-nocheck\n" }`
+Command line: *none*
+Config file: `sandboxFileHeaders: {}`
+
+Configure additional headers to be added to files inside your sandbox. These headers will be added after Stryker has instrumented your code with mutants, but before a test runner or build command is executed. This can be used to ignore typescript compile errors and eslint warnings that might have been added in the process of instrumenting your code. 
+
+The key here is a [glob expression](https://globster.xyz/), where the value points to the header to be used for matching files.
+
+*Note: The default setting should work for most use cases, only change this if you know what you are doing.*
+
 <a name="symlinkNodeModules"></a>
 ### `symlinkNodeModules` [`boolean`]
 
@@ -330,7 +344,7 @@ not check-in your chosen temp directory in your `.gitignore` file.
 
 Default: *none*
 Command line: `--testFramework jasmine`
-Config file: `testFramework: 'jasmine'`
+Config file: `testFramework: 'jasmine'` 
 
 Configure which test framework you are using.
 This option is not mandatory, as Stryker is test framework agnostic (it doesn't care what framework you use),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,7 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.groupby": "^4.6.0",
     "log4js": "6.2.1",
+    "minimatch": "^3.0.4",
     "mkdirp": "~1.0.3",
     "mutation-testing-elements": "~1.3.0",
     "mutation-testing-metrics": "~1.3.0",
@@ -87,6 +88,7 @@
     "@types/inquirer": "~6.0.2",
     "@types/lodash.flatmap": "^4.5.6",
     "@types/lodash.groupby": "^4.6.6",
+    "@types/minimatch": "^3.0.3",
     "@types/node": "^14.0.1",
     "@types/progress": "~2.0.1",
     "flatted": "^3.0.2"

--- a/packages/core/src/sandbox/create-preprocessor.ts
+++ b/packages/core/src/sandbox/create-preprocessor.ts
@@ -1,0 +1,11 @@
+import { tokens, Injector, commonTokens, OptionsContext } from '@stryker-mutator/api/plugin';
+
+import { SandboxTSConfigPreprocessor } from './sandbox-tsconfig-preprocessor';
+import { SandboxFileHeaderPreprocessor } from './sandbox-file-header-preprocessor';
+import { FilePreprocessor } from './file-preprocessor';
+import { MultiPreprocessor } from './multi-preprocessor';
+
+createPreprocessor.inject = tokens(commonTokens.injector);
+export function createPreprocessor(injector: Injector<OptionsContext>): FilePreprocessor {
+  return new MultiPreprocessor([injector.injectClass(SandboxTSConfigPreprocessor), injector.injectClass(SandboxFileHeaderPreprocessor)]);
+}

--- a/packages/core/src/sandbox/file-preprocessor.ts
+++ b/packages/core/src/sandbox/file-preprocessor.ts
@@ -1,0 +1,10 @@
+import { File } from '@stryker-mutator/api/core';
+
+/**
+ * A preprocessor changes files before writing them to the sandbox.
+ * Stuff like rewriting references tsconfig.json files or adding // @ts-nocheck
+ * This is a private api that we might want to open up in the future.
+ */
+export interface FilePreprocessor {
+  preprocess(file: File[]): Promise<File[]>;
+}

--- a/packages/core/src/sandbox/index.ts
+++ b/packages/core/src/sandbox/index.ts
@@ -1,2 +1,3 @@
+export type { FilePreprocessor } from './file-preprocessor';
 export * from './sandbox';
-export * from './sandbox-tsconfig-rewriter';
+export * from './create-preprocessor';

--- a/packages/core/src/sandbox/multi-preprocessor.ts
+++ b/packages/core/src/sandbox/multi-preprocessor.ts
@@ -1,0 +1,15 @@
+import { File } from '@stryker-mutator/api/core';
+
+import { FilePreprocessor } from './file-preprocessor';
+
+export class MultiPreprocessor implements FilePreprocessor {
+  constructor(private readonly preprocessors: FilePreprocessor[]) {}
+
+  public async preprocess(files: File[]): Promise<File[]> {
+    for await (const preprocessor of this.preprocessors) {
+      files = await preprocessor.preprocess(files);
+    }
+    return files;
+  }
+  
+}

--- a/packages/core/src/sandbox/multi-preprocessor.ts
+++ b/packages/core/src/sandbox/multi-preprocessor.ts
@@ -11,5 +11,4 @@ export class MultiPreprocessor implements FilePreprocessor {
     }
     return files;
   }
-  
 }

--- a/packages/core/src/sandbox/sandbox-file-header-preprocessor.ts
+++ b/packages/core/src/sandbox/sandbox-file-header-preprocessor.ts
@@ -1,0 +1,27 @@
+import path = require('path');
+
+import { File, StrykerOptions } from '@stryker-mutator/api/core';
+import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
+import minimatch = require('minimatch');
+
+import { FilePreprocessor } from './file-preprocessor';
+
+/**
+ * https://github.com/stryker-mutator/stryker/issues/2276
+ */
+export class SandboxFileHeaderPreprocessor implements FilePreprocessor {
+  public static readonly inject = tokens(commonTokens.options);
+
+  constructor(private readonly options: StrykerOptions) {}
+
+  public async preprocess(files: File[]): Promise<File[]> {
+    return files.map((file) => {
+      Object.entries(this.options.sandboxFileHeaders).forEach(([pattern, header]) => {
+        if (minimatch(path.resolve(file.name), path.resolve(pattern))) {
+          file = new File(file.name, `${header}${file.textContent}`);
+        }
+      });
+      return file;
+    });
+  }
+}

--- a/packages/core/src/sandbox/sandbox-tsconfig-preprocessor.ts
+++ b/packages/core/src/sandbox/sandbox-tsconfig-preprocessor.ts
@@ -4,6 +4,8 @@ import { StrykerOptions, File } from '@stryker-mutator/api/core';
 import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
 import { Logger } from '@stryker-mutator/api/logging';
 
+import { FilePreprocessor } from './file-preprocessor';
+
 /**
  * A helper class that rewrites `references` and `extends` file paths if they end up falling outside of the sandbox.
  * @example
@@ -21,13 +23,13 @@ import { Logger } from '@stryker-mutator/api/logging';
  *   }
  * }
  */
-export class SandboxTSConfigRewriter {
+export class SandboxTSConfigPreprocessor implements FilePreprocessor {
   private readonly touched: string[] = [];
   private readonly fs = new Map<string, File>();
   public static readonly inject = tokens(commonTokens.logger, commonTokens.options);
   constructor(private readonly log: Logger, private readonly options: StrykerOptions) {}
 
-  public async rewrite(input: File[]): Promise<readonly File[]> {
+  public async preprocess(input: File[]): Promise<File[]> {
     const tsconfigFile = path.resolve(this.options.tsconfigFile);
     if (input.find((file) => file.name === tsconfigFile)) {
       this.fs.clear();

--- a/packages/core/src/sandbox/sandbox.ts
+++ b/packages/core/src/sandbox/sandbox.ts
@@ -10,7 +10,7 @@ import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
 import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
 
 import { TemporaryDirectory } from '../utils/TemporaryDirectory';
-import { findNodeModules, symlinkJunction, writeFile, isJSOrFriend } from '../utils/fileUtils';
+import { findNodeModules, symlinkJunction, writeFile } from '../utils/fileUtils';
 import { coreTokens } from '../di';
 
 interface SandboxFactory {
@@ -25,10 +25,6 @@ interface SandboxFactory {
     typeof coreTokens.execa
   ];
 }
-
-const JS_HEADER = Buffer.from(`/* eslint-disable */
-// @ts-nocheck
-`);
 
 export class Sandbox {
   private readonly fileMap = new Map<string, string>();
@@ -121,11 +117,6 @@ export class Sandbox {
     mkdirp.sync(folderName);
     const targetFileName = path.join(folderName, path.basename(relativePath));
     this.fileMap.set(file.name, targetFileName);
-    if (isJSOrFriend(file.name)) {
-      // see https://github.com/stryker-mutator/stryker/issues/2276
-      return writeFile(targetFileName, Buffer.concat([JS_HEADER, file.content]));
-    } else {
-      return writeFile(targetFileName, file.content);
-    }
+    return writeFile(targetFileName, file.content);
   }
 }

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -38,16 +38,6 @@ export function importModule(moduleName: string): unknown {
   return require(moduleName);
 }
 
-const JS_OR_FRIEND_EXTENSION = Object.freeze(['.js', '.ts', '.jsx', '.tsx', '.cjs', '.mjs']);
-/**
- * Returns true if given file is a js or friend file (ts/js/jsx, etc)
- * @param fileName The file name
- */
-export function isJSOrFriend(fileName: string): boolean {
-  const ext = path.extname(fileName);
-  return JS_OR_FRIEND_EXTENSION.includes(ext.toLowerCase());
-}
-
 /**
  * Writes data to a specified file.
  * @param fileName The path to the file.

--- a/packages/core/test/integration/sandbox/create-preprocessor.it.spec.ts
+++ b/packages/core/test/integration/sandbox/create-preprocessor.it.spec.ts
@@ -1,0 +1,24 @@
+import path = require('path');
+
+import { testInjector, assertions } from '@stryker-mutator/test-helpers';
+import { File } from '@stryker-mutator/api/core';
+
+import { FilePreprocessor, createPreprocessor } from '../../../src/sandbox';
+
+describe('File preprocessor integration', () => {
+  let sut: FilePreprocessor;
+
+  beforeEach(() => {
+    sut = testInjector.injector.injectFunction(createPreprocessor);
+  });
+
+  it('should rewrite tsconfig files', async () => {
+    const output = await sut.preprocess([new File(path.resolve('tsconfig.json'), '{"extends": "../tsconfig.settings.json" }')]);
+    assertions.expectTextFilesEqual(output, [new File(path.resolve('tsconfig.json'), '{\n  "extends": "../../../tsconfig.settings.json"\n}')]);
+  });
+
+  it('should add a header to .ts files', async () => {
+    const output = await sut.preprocess([new File(path.resolve('app.ts'), 'foo.bar()')]);
+    assertions.expectTextFilesEqual(output, [new File(path.resolve('app.ts'), '/* eslint-disable */\n// @ts-nocheck\nfoo.bar()')]);
+  });
+});

--- a/packages/core/test/unit/sandbox/multi-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/multi-preprocessor.spec.ts
@@ -1,0 +1,36 @@
+import sinon = require('sinon');
+import { File } from '@stryker-mutator/api/core';
+import { expect } from 'chai';
+
+import { MultiPreprocessor } from '../../../src/sandbox/multi-preprocessor';
+import { FilePreprocessor } from '../../../src/sandbox';
+
+describe(MultiPreprocessor.name, () => {
+  describe(MultiPreprocessor.prototype.preprocess.name, () => {
+    it('should call preprocess on each preprocessor in order', async () => {
+      // Arrange
+      const input = [new File('foo.js', 'input')];
+      const firstResult = [new File('foo.js', 'first')];
+      const secondResult = [new File('foo.js', 'second')];
+      const first = createFilePreprocessorMock();
+      const second = createFilePreprocessorMock();
+      first.preprocess.resolves(firstResult);
+      second.preprocess.resolves(secondResult);
+      const sut = new MultiPreprocessor([first, second]);
+
+      // Act
+      const actual = await sut.preprocess(input);
+
+      // Assert
+      expect(actual).eq(secondResult);
+      expect(first.preprocess).calledWith(input);
+      expect(second.preprocess).calledWith(firstResult);
+    });
+  });
+
+  function createFilePreprocessorMock(): sinon.SinonStubbedInstance<FilePreprocessor> {
+    return {
+      preprocess: sinon.stub(),
+    };
+  }
+});

--- a/packages/core/test/unit/sandbox/sandbox-file-header-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/sandbox-file-header-preprocessor.spec.ts
@@ -1,0 +1,96 @@
+import path = require('path');
+
+import { testInjector, assertions } from '@stryker-mutator/test-helpers';
+import { File } from '@stryker-mutator/api/core';
+
+import { SandboxFileHeaderPreprocessor } from '../../../src/sandbox/sandbox-file-header-preprocessor';
+
+const EXPECTED_DEFAULT_HEADER = '/* eslint-disable */\n// @ts-nocheck\n';
+
+describe(SandboxFileHeaderPreprocessor.name, () => {
+  let sut: SandboxFileHeaderPreprocessor;
+  beforeEach(() => {
+    sut = testInjector.injector.injectClass(SandboxFileHeaderPreprocessor);
+  });
+
+  it('should add preprocess any js or friend file by default', async () => {
+    const inputContent = 'foo.bar()';
+    const expectedOutputContent = `${EXPECTED_DEFAULT_HEADER}foo.bar()`;
+    const input = [
+      new File('src/app.js', inputContent),
+      new File('test/app.spec.ts', inputContent),
+      new File('src/components/app.jsx', inputContent),
+      new File('src/components/app.tsx', inputContent),
+      new File('src/components/app.cjs', inputContent),
+      new File('src/components/app.mjs', inputContent),
+    ];
+    const output = await sut.preprocess(input);
+
+    assertions.expectTextFilesEqual(output, [
+      new File('src/app.js', expectedOutputContent),
+      new File('test/app.spec.ts', expectedOutputContent),
+      new File('src/components/app.jsx', expectedOutputContent),
+      new File('src/components/app.tsx', expectedOutputContent),
+      new File('src/components/app.cjs', expectedOutputContent),
+      new File('src/components/app.mjs', expectedOutputContent),
+    ]);
+  });
+
+  it('should also match a full file name', async () => {
+    // Arrange
+    const input = [new File(path.resolve('src', 'app.ts'), 'foo.bar()')];
+    testInjector.options.sandboxFileHeaders = {
+      ['+(src|test)/**/*+(.js|.ts)?(x)']: '// @ts-nocheck\n',
+    };
+
+    // Act
+    const output = await sut.preprocess(input);
+
+    // Assert
+    assertions.expectTextFilesEqual(output, [new File(path.resolve('src', 'app.ts'), '// @ts-nocheck\nfoo.bar()')]);
+  });
+
+  it('should not change unmatched files according to glob expression', async () => {
+    // Arrange
+    const input = [
+      new File(path.resolve('src', 'app.ts'), 'foo.bar()'),
+      new File(path.resolve('testResources', 'app.ts'), '// test file example that should be ignored'),
+    ];
+    testInjector.options.sandboxFileHeaders = {
+      ['+(src|test)/**/*+(.js|.ts)?(x)']: '// @ts-nocheck\n',
+    };
+
+    // Act
+    const output = await sut.preprocess(input);
+
+    // Assert
+    assertions.expectTextFilesEqual(output, [
+      new File(path.resolve('src', 'app.ts'), '// @ts-nocheck\nfoo.bar()'),
+      new File(path.resolve('testResources', 'app.ts'), '// test file example that should be ignored'),
+    ]);
+  });
+
+  it('should allow multiple headers', async () => {
+    // Arrange
+    const input = [new File('src/app.ts', 'foo.bar()'), new File('src/components/app.component.js', 'baz.qux()')];
+    testInjector.options.sandboxFileHeaders = {
+      ['**/*.ts']: '// @ts-nocheck\n',
+      ['**/*.js']: '/* eslint-disable */\n',
+    };
+
+    // Act
+    const output = await sut.preprocess(input);
+
+    // Assert
+    assertions.expectTextFilesEqual(output, [
+      new File('src/app.ts', '// @ts-nocheck\nfoo.bar()'),
+      new File('src/components/app.component.js', '/* eslint-disable */\nbaz.qux()'),
+    ]);
+  });
+
+  it('should pass-through any other files', async () => {
+    const input = [new File('README.md', '# Foo')];
+    const output = await sut.preprocess(input);
+    assertions.expectTextFilesEqual(output, [new File('README.md', '# Foo')]);
+  });
+});

--- a/packages/core/test/unit/sandbox/sandbox.spec.ts
+++ b/packages/core/test/unit/sandbox/sandbox.spec.ts
@@ -68,17 +68,6 @@ describe(Sandbox.name, () => {
       expect(writeFileStub).calledWith(path.join(SANDBOX_WORKING_DIR, 'c', 'd', 'e.log'), fileE.content);
     });
 
-    ['.js', '.ts', '.d.ts', '.jsx', '.cjs', '.mjs'].forEach((ext) => {
-      it(`should prefix a ${ext} with a ignore header`, async () => {
-        files.push(new File(`foo${ext}`, 'console.log("foo")'));
-        await createSut();
-        expect(writeFileStub).calledWith(
-          path.join(SANDBOX_WORKING_DIR, `foo${ext}`),
-          Buffer.from('/* eslint-disable */\n// @ts-nocheck\nconsole.log("foo")')
-        );
-      });
-    });
-
     it('should make the dir before copying the file', async () => {
       files.push(new File(path.resolve('a', 'b.js'), 'b content'));
       files.push(new File(path.resolve('c', 'd', 'e.js'), 'e content'));

--- a/packages/test-helpers/src/assertions.ts
+++ b/packages/test-helpers/src/assertions.ts
@@ -1,5 +1,7 @@
 import assert = require('assert');
 
+import { expect } from 'chai';
+
 import {
   MutantRunResult,
   SurvivedMutantRunResult,
@@ -14,6 +16,7 @@ import {
   FailedTestResult,
   TestStatus,
 } from '@stryker-mutator/api/test_runner2';
+import { File } from '@stryker-mutator/api/core';
 
 export function expectKilled(result: MutantRunResult): asserts result is KilledMutantRunResult {
   assert.equal(result.status, MutantRunStatus.Killed);
@@ -35,4 +38,19 @@ export function expectErrored(runResult: DryRunResult | MutantRunResult): void {
 }
 export function expectSurvived(runResult: MutantRunResult): asserts runResult is SurvivedMutantRunResult {
   assert.equal(runResult.status, MutantRunStatus.Survived);
+}
+
+export function expectTextFileEqual(actual: File, expected: File) {
+  expect(fileToJson(actual)).deep.eq(fileToJson(expected));
+}
+
+export function expectTextFilesEqual(actual: File[], expected: File[]) {
+  expect(actual.map(fileToJson)).deep.eq(expected.map(fileToJson));
+}
+
+function fileToJson(file: File) {
+  return {
+    name: file.name,
+    textContent: file.textContent,
+  };
 }

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -122,6 +122,7 @@
       "Surrializable",
       "execa",
       "memfs",
+      "preprocessors",
       "serializable",
       "surrialize"
     ]


### PR DESCRIPTION
Add the ability to override the file headers inside a sandbox. This allows users to opt-out of the default header, as well as add custom headers.

You can configure it like this:

```json
{
  "sandboxFileHeaders": {
  "**/*.ts": "// Hello world\n"
  }
}
```

The key here is a [glob expression](https://globster.xyz/), where the value points to the header to be used for matching files.

Fixes #2357