### PR TITLE
feat(test runner api): remove `sandboxFileNames` injectable values

### DIFF
--- a/packages/api/src/plugin/Contexts.ts
+++ b/packages/api/src/plugin/Contexts.ts
@@ -1,7 +1,6 @@
 import { MutatorDescriptor, StrykerOptions } from '../../core';
 import { Logger, LoggerFactoryMethod } from '../../logging';
 
-import { PluginKind } from './PluginKind';
 import { PluginResolver } from './Plugins';
 import { commonTokens } from './tokens';
 
@@ -18,24 +17,7 @@ export interface BaseContext {
  * The dependency injection context for most of Stryker's plugins.
  * Can inject basic stuff as well as the Stryker options
  */
-export interface OptionsContext extends BaseContext {
+export interface PluginContext extends BaseContext {
   [commonTokens.options]: StrykerOptions;
   [commonTokens.mutatorDescriptor]: MutatorDescriptor;
-}
-
-/**
- * The dependency injection context for a `TestRunnerPlugin`
- */
-export interface TestRunnerPluginContext extends OptionsContext {
-  [commonTokens.sandboxFileNames]: readonly string[];
-}
-
-/**
- * Lookup type for plugin contexts by kind.
- */
-export interface PluginContexts {
-  [PluginKind.Reporter]: OptionsContext;
-  [PluginKind.TestRunner]: TestRunnerPluginContext;
-  [PluginKind.TestRunner2]: TestRunnerPluginContext;
-  [PluginKind.Checker]: OptionsContext;
 }

--- a/packages/api/src/plugin/Plugins.ts
+++ b/packages/api/src/plugin/Plugins.ts
@@ -5,39 +5,39 @@ import { TestRunner } from '../../test_runner';
 import { TestRunner2 } from '../../test_runner2';
 import { Checker } from '../../check';
 
-import { PluginContexts } from './Contexts';
+import { PluginContext } from './Contexts';
 import { PluginKind } from './PluginKind';
 
 /**
  * Represents a StrykerPlugin
  */
 export type Plugin<TPluginKind extends PluginKind> =
-  | FactoryPlugin<TPluginKind, Array<InjectionToken<PluginContexts[TPluginKind]>>>
-  | ClassPlugin<TPluginKind, Array<InjectionToken<PluginContexts[TPluginKind]>>>;
+  | FactoryPlugin<TPluginKind, Array<InjectionToken<PluginContext>>>
+  | ClassPlugin<TPluginKind, Array<InjectionToken<PluginContext>>>;
 
 /**
  * Represents a plugin that is created with a factory method
  */
-export interface FactoryPlugin<TPluginKind extends PluginKind, Tokens extends Array<InjectionToken<PluginContexts[TPluginKind]>>> {
+export interface FactoryPlugin<TPluginKind extends PluginKind, Tokens extends Array<InjectionToken<PluginContext>>> {
   readonly kind: TPluginKind;
   readonly name: string;
   /**
    * The factory method used to create the plugin
    */
-  readonly factory: InjectableFunction<PluginContexts[TPluginKind], PluginInterfaces[TPluginKind], Tokens>;
+  readonly factory: InjectableFunction<PluginContext, PluginInterfaces[TPluginKind], Tokens>;
 }
 
 /**
  * Represents a plugin that is created by instantiating a class.
  */
-export interface ClassPlugin<TPluginKind extends PluginKind, Tokens extends Array<InjectionToken<PluginContexts[TPluginKind]>>> {
+export interface ClassPlugin<TPluginKind extends PluginKind, Tokens extends Array<InjectionToken<PluginContext>>> {
   readonly kind: TPluginKind;
   readonly name: string;
   /**
    * The prototype function (class) used to create the plugin.
    * Not called `class` here, because that is a keyword
    */
-  readonly injectableClass: InjectableClass<PluginContexts[TPluginKind], PluginInterfaces[TPluginKind], Tokens>;
+  readonly injectableClass: InjectableClass<PluginContext, PluginInterfaces[TPluginKind], Tokens>;
 }
 
 /**
@@ -46,10 +46,10 @@ export interface ClassPlugin<TPluginKind extends PluginKind, Tokens extends Arra
  * @param name The name of the plugin
  * @param injectableClass The class to be instantiated for the plugin
  */
-export function declareClassPlugin<TPluginKind extends PluginKind, Tokens extends Array<InjectionToken<PluginContexts[TPluginKind]>>>(
+export function declareClassPlugin<TPluginKind extends PluginKind, Tokens extends Array<InjectionToken<PluginContext>>>(
   kind: TPluginKind,
   name: string,
-  injectableClass: InjectableClass<PluginContexts[TPluginKind], PluginInterfaces[TPluginKind], Tokens>
+  injectableClass: InjectableClass<PluginContext, PluginInterfaces[TPluginKind], Tokens>
 ): ClassPlugin<TPluginKind, Tokens> {
   return {
     injectableClass,
@@ -64,10 +64,10 @@ export function declareClassPlugin<TPluginKind extends PluginKind, Tokens extend
  * @param name The name of the plugin
  * @param factory The factory used to instantiate the plugin
  */
-export function declareFactoryPlugin<TPluginKind extends PluginKind, Tokens extends Array<InjectionToken<PluginContexts[TPluginKind]>>>(
+export function declareFactoryPlugin<TPluginKind extends PluginKind, Tokens extends Array<InjectionToken<PluginContext>>>(
   kind: TPluginKind,
   name: string,
-  factory: InjectableFunction<PluginContexts[TPluginKind], PluginInterfaces[TPluginKind], Tokens>
+  factory: InjectableFunction<PluginContext, PluginInterfaces[TPluginKind], Tokens>
 ): FactoryPlugin<TPluginKind, Tokens> {
   return {
     factory,

--- a/packages/api/src/plugin/tokens.ts
+++ b/packages/api/src/plugin/tokens.ts
@@ -20,7 +20,6 @@ export const commonTokens = Object.freeze({
   options: stringLiteral('options'),
   pluginResolver: stringLiteral('pluginResolver'),
   produceSourceMaps: stringLiteral('produceSourceMaps'),
-  sandboxFileNames: stringLiteral('sandboxFileNames'),
   target,
 });
 

--- a/packages/api/test/unit/plugin/tokens.spec.ts
+++ b/packages/api/test/unit/plugin/tokens.spec.ts
@@ -21,6 +21,5 @@ describe('commonTokens', () => {
   itShouldProvideToken('logger');
   itShouldProvideToken('pluginResolver');
   itShouldProvideToken('produceSourceMaps');
-  itShouldProvideToken('sandboxFileNames');
   itShouldProvideToken('getLogger');
 });

--- a/packages/core/src/checker/CheckerWorker.ts
+++ b/packages/core/src/checker/CheckerWorker.ts
@@ -1,7 +1,7 @@
 import { Checker, CheckResult, CheckStatus } from '@stryker-mutator/api/check';
 import { StrykerOptions, Mutant } from '@stryker-mutator/api/core';
 
-import { PluginKind, tokens, commonTokens, OptionsContext, Injector } from '@stryker-mutator/api/plugin';
+import { PluginKind, tokens, commonTokens, PluginContext, Injector } from '@stryker-mutator/api/plugin';
 
 import { StrykerError } from '@stryker-mutator/util';
 
@@ -11,7 +11,7 @@ export class CheckerWorker implements Checker {
   private readonly innerCheckers: Array<{ name: string; checker: Checker }> = [];
 
   public static inject = tokens(commonTokens.options, commonTokens.injector);
-  constructor(options: StrykerOptions, injector: Injector<OptionsContext>) {
+  constructor(options: StrykerOptions, injector: Injector<PluginContext>) {
     const pluginCreator = injector.injectFunction(PluginCreator.createFactory(PluginKind.Checker));
     this.innerCheckers = options.checkers.map((name) => ({ name, checker: pluginCreator.create(name) }));
   }

--- a/packages/core/src/child-proxy/ChildProcessProxy.ts
+++ b/packages/core/src/child-proxy/ChildProcessProxy.ts
@@ -2,7 +2,7 @@ import { ChildProcess, fork } from 'child_process';
 import * as os from 'os';
 
 import { File, StrykerOptions } from '@stryker-mutator/api/core';
-import { OptionsContext } from '@stryker-mutator/api/plugin';
+import { PluginContext } from '@stryker-mutator/api/plugin';
 import { isErrnoException, Task, ExpirableTask } from '@stryker-mutator/util';
 import { getLogger } from 'log4js';
 import { Disposable, InjectableClass, InjectionToken } from 'typed-inject';
@@ -71,13 +71,13 @@ export default class ChildProcessProxy<T> implements Disposable {
   /**
    * @description Creates a proxy where each function of the object created using the constructorFunction arg is ran inside of a child process
    */
-  public static create<TAdditionalContext, R, Tokens extends Array<InjectionToken<OptionsContext & TAdditionalContext>>>(
+  public static create<TAdditionalContext, R, Tokens extends Array<InjectionToken<PluginContext & TAdditionalContext>>>(
     requirePath: string,
     loggingContext: LoggingClientContext,
     options: StrykerOptions,
     additionalInjectableValues: TAdditionalContext,
     workingDirectory: string,
-    InjectableClass: InjectableClass<TAdditionalContext & OptionsContext, R, Tokens>
+    InjectableClass: InjectableClass<TAdditionalContext & PluginContext, R, Tokens>
   ): ChildProcessProxy<R> {
     return new ChildProcessProxy(requirePath, InjectableClass.name, loggingContext, options, additionalInjectableValues, workingDirectory);
   }

--- a/packages/core/src/di/PluginCreator.ts
+++ b/packages/core/src/di/PluginCreator.ts
@@ -3,7 +3,7 @@ import {
   commonTokens,
   FactoryPlugin,
   Plugin,
-  PluginContexts,
+  PluginContext,
   PluginInterfaces,
   PluginKind,
   PluginResolver,
@@ -15,7 +15,7 @@ export class PluginCreator<TPluginKind extends PluginKind> {
   private constructor(
     private readonly kind: TPluginKind,
     private readonly pluginResolver: PluginResolver,
-    private readonly injector: Injector<PluginContexts[TPluginKind]>
+    private readonly injector: Injector<PluginContext>
   ) {}
 
   public create(name: string): PluginInterfaces[TPluginKind] {
@@ -29,14 +29,14 @@ export class PluginCreator<TPluginKind extends PluginKind> {
     }
   }
 
-  private isFactoryPlugin(plugin: Plugin<PluginKind>): plugin is FactoryPlugin<TPluginKind, Array<InjectionToken<PluginContexts[TPluginKind]>>> {
-    return !!(plugin as FactoryPlugin<TPluginKind, Array<InjectionToken<PluginContexts[TPluginKind]>>>).factory;
+  private isFactoryPlugin(plugin: Plugin<PluginKind>): plugin is FactoryPlugin<TPluginKind, Array<InjectionToken<PluginContext>>> {
+    return !!(plugin as FactoryPlugin<TPluginKind, Array<InjectionToken<PluginContext>>>).factory;
   }
-  private isClassPlugin(plugin: Plugin<PluginKind>): plugin is ClassPlugin<TPluginKind, Array<InjectionToken<PluginContexts[TPluginKind]>>> {
-    return !!(plugin as ClassPlugin<TPluginKind, Array<InjectionToken<PluginContexts[TPluginKind]>>>).injectableClass;
+  private isClassPlugin(plugin: Plugin<PluginKind>): plugin is ClassPlugin<TPluginKind, Array<InjectionToken<PluginContext>>> {
+    return !!(plugin as ClassPlugin<TPluginKind, Array<InjectionToken<PluginContext>>>).injectableClass;
   }
 
-  public static createFactory<TPluginKind extends PluginKind, TContext extends PluginContexts[TPluginKind]>(
+  public static createFactory<TPluginKind extends PluginKind, TContext extends PluginContext>(
     kind: TPluginKind
   ): InjectableFunctionWithInject<TContext, PluginCreator<TPluginKind>, [typeof commonTokens.pluginResolver, typeof commonTokens.injector]> {
     function factory(pluginResolver: PluginResolver, injector: Injector<TContext>): PluginCreator<TPluginKind> {

--- a/packages/core/src/di/buildChildProcessInjector.ts
+++ b/packages/core/src/di/buildChildProcessInjector.ts
@@ -1,5 +1,5 @@
 import { StrykerOptions } from '@stryker-mutator/api/core';
-import { commonTokens, Injector, OptionsContext, Scope, tokens } from '@stryker-mutator/api/plugin';
+import { commonTokens, Injector, PluginContext, Scope, tokens } from '@stryker-mutator/api/plugin';
 import { getLogger } from 'log4js';
 import { rootInjector } from 'typed-inject';
 
@@ -7,7 +7,7 @@ import { loggerFactory, mutatorDescriptorFactory, pluginResolverFactory } from '
 
 import { coreTokens } from '.';
 
-export function buildChildProcessInjector(options: StrykerOptions): Injector<OptionsContext> {
+export function buildChildProcessInjector(options: StrykerOptions): Injector<PluginContext> {
   return rootInjector
     .provideValue(commonTokens.options, options)
     .provideValue(commonTokens.getLogger, getLogger)

--- a/packages/core/src/di/buildMainInjector.ts
+++ b/packages/core/src/di/buildMainInjector.ts
@@ -1,6 +1,6 @@
 import execa = require('execa');
 import { StrykerOptions, strykerCoreSchema, PartialStrykerOptions } from '@stryker-mutator/api/core';
-import { commonTokens, Injector, OptionsContext, PluginKind, Scope, tokens } from '@stryker-mutator/api/plugin';
+import { commonTokens, Injector, PluginContext, PluginKind, Scope, tokens } from '@stryker-mutator/api/plugin';
 import { Reporter } from '@stryker-mutator/api/report';
 import { getLogger } from 'log4js';
 
@@ -14,7 +14,7 @@ import { loggerFactory, mutatorDescriptorFactory, pluginResolverFactory } from '
 
 import { coreTokens, PluginCreator } from '.';
 
-export interface MainContext extends OptionsContext {
+export interface MainContext extends PluginContext {
   [coreTokens.reporter]: Required<Reporter>;
   [coreTokens.pluginCreatorReporter]: PluginCreator<PluginKind.Reporter>;
   [coreTokens.pluginCreatorChecker]: PluginCreator<PluginKind.Checker>;

--- a/packages/core/src/reporters/dashboard-reporter/index.ts
+++ b/packages/core/src/reporters/dashboard-reporter/index.ts
@@ -1,4 +1,4 @@
-import { commonTokens, Injector, OptionsContext, tokens } from '@stryker-mutator/api/plugin';
+import { commonTokens, Injector, PluginContext, tokens } from '@stryker-mutator/api/plugin';
 import { HttpClient } from 'typed-rest-client/HttpClient';
 
 import { determineCIProvider } from '../ci/Provider';
@@ -7,7 +7,7 @@ import DashboardReporter from './DashboardReporter';
 import DashboardReporterClient from './DashboardReporterClient';
 import { dashboardReporterTokens } from './tokens';
 
-export function dashboardReporterFactory(injector: Injector<OptionsContext>): DashboardReporter {
+export function dashboardReporterFactory(injector: Injector<PluginContext>): DashboardReporter {
   return injector
     .provideValue(dashboardReporterTokens.httpClient, new HttpClient('stryker-dashboard-reporter'))
     .provideClass(dashboardReporterTokens.dashboardReporterClient, DashboardReporterClient)

--- a/packages/core/src/sandbox/create-preprocessor.ts
+++ b/packages/core/src/sandbox/create-preprocessor.ts
@@ -1,4 +1,4 @@
-import { tokens, Injector, commonTokens, OptionsContext } from '@stryker-mutator/api/plugin';
+import { tokens, Injector, commonTokens, PluginContext } from '@stryker-mutator/api/plugin';
 
 import { TSConfigPreprocessor } from './ts-config-preprocessor';
 import { FileHeaderPreprocessor } from './file-header-preprocessor';
@@ -7,7 +7,7 @@ import { MultiPreprocessor } from './multi-preprocessor';
 import { StripCommentsPreprocessor } from './strip-comments-preprocessor';
 
 createPreprocessor.inject = tokens(commonTokens.injector);
-export function createPreprocessor(injector: Injector<OptionsContext>): FilePreprocessor {
+export function createPreprocessor(injector: Injector<PluginContext>): FilePreprocessor {
   return new MultiPreprocessor([
     injector.injectClass(StripCommentsPreprocessor),
     injector.injectClass(TSConfigPreprocessor),

--- a/packages/core/src/test-runner/ChildProcessTestRunnerDecorator.ts
+++ b/packages/core/src/test-runner/ChildProcessTestRunnerDecorator.ts
@@ -16,12 +16,12 @@ const MAX_WAIT_FOR_DISPOSE = 2000;
 export default class ChildProcessTestRunnerDecorator implements TestRunner2 {
   private readonly worker: ChildProcessProxy<ChildProcessTestRunnerWorker>;
 
-  constructor(options: StrykerOptions, sandboxFileNames: readonly string[], sandboxWorkingDirectory: string, loggingContext: LoggingClientContext) {
+  constructor(options: StrykerOptions, sandboxWorkingDirectory: string, loggingContext: LoggingClientContext) {
     this.worker = ChildProcessProxy.create(
       require.resolve(`./${ChildProcessTestRunnerWorker.name}`),
       loggingContext,
       options,
-      { sandboxFileNames },
+      {},
       sandboxWorkingDirectory,
       ChildProcessTestRunnerWorker
     );

--- a/packages/core/src/test-runner/ChildProcessTestRunnerWorker.ts
+++ b/packages/core/src/test-runner/ChildProcessTestRunnerWorker.ts
@@ -1,5 +1,5 @@
 import { StrykerOptions } from '@stryker-mutator/api/core';
-import { commonTokens, Injector, OptionsContext, PluginKind, tokens } from '@stryker-mutator/api/plugin';
+import { commonTokens, Injector, PluginContext, PluginKind, tokens } from '@stryker-mutator/api/plugin';
 import {
   TestRunner2,
   DryRunOptions,
@@ -17,12 +17,9 @@ import { PluginCreator } from '../di';
 export class ChildProcessTestRunnerWorker implements TestRunner2 {
   private readonly underlyingTestRunner: TestRunner2;
 
-  public static inject = tokens(commonTokens.sandboxFileNames, commonTokens.options, commonTokens.injector);
-  constructor(sandboxFileNames: readonly string[], { testRunner }: StrykerOptions, injector: Injector<OptionsContext>) {
-    this.underlyingTestRunner = injector
-      .provideValue(commonTokens.sandboxFileNames, sandboxFileNames)
-      .injectFunction(PluginCreator.createFactory(PluginKind.TestRunner2))
-      .create(testRunner);
+  public static inject = tokens(commonTokens.options, commonTokens.injector);
+  constructor({ testRunner }: StrykerOptions, injector: Injector<PluginContext>) {
+    this.underlyingTestRunner = injector.injectFunction(PluginCreator.createFactory(PluginKind.TestRunner2)).create(testRunner);
   }
 
   public async init(): Promise<void> {

--- a/packages/core/src/test-runner/index.ts
+++ b/packages/core/src/test-runner/index.ts
@@ -21,9 +21,6 @@ export function createTestRunnerFactory(
     return () => new RetryDecorator(() => new TimeoutDecorator(() => new CommandTestRunner(sandbox.workingDirectory, options)));
   } else {
     return () =>
-      new RetryDecorator(
-        () =>
-          new TimeoutDecorator(() => new ChildProcessTestRunnerDecorator(options, sandbox.sandboxFileNames, sandbox.workingDirectory, loggingContext))
-      );
+      new RetryDecorator(() => new TimeoutDecorator(() => new ChildProcessTestRunnerDecorator(options, sandbox.workingDirectory, loggingContext)));
   }
 }

--- a/packages/core/test/unit/test-runner/ChildProcessTestRunnerDecorator.spec.ts
+++ b/packages/core/test/unit/test-runner/ChildProcessTestRunnerDecorator.spec.ts
@@ -37,7 +37,7 @@ describe(ChildProcessTestRunnerDecorator.name, () => {
       plugins: ['foo-plugin', 'bar-plugin'],
     });
     loggingContext = { port: 4200, level: LogLevel.Fatal };
-    sut = new ChildProcessTestRunnerDecorator(options, [], 'a working directory', loggingContext);
+    sut = new ChildProcessTestRunnerDecorator(options, 'a working directory', loggingContext);
   });
 
   it('should create the child process proxy', () => {

--- a/packages/core/test/unit/test-runner/ChildProcessTestRunnerDecorator.spec.ts
+++ b/packages/core/test/unit/test-runner/ChildProcessTestRunnerDecorator.spec.ts
@@ -45,7 +45,7 @@ describe(ChildProcessTestRunnerDecorator.name, () => {
       require.resolve('../../../src/test-runner/ChildProcessTestRunnerWorker.js'),
       loggingContext,
       options,
-      { sandboxFileNames: [] },
+      {},
       'a working directory',
       ChildProcessTestRunnerWorker
     );

--- a/packages/jasmine-runner/src/index.ts
+++ b/packages/jasmine-runner/src/index.ts
@@ -1,9 +1,9 @@
-import { declareClassPlugin, PluginKind } from '@stryker-mutator/api/plugin';
+import { declareFactoryPlugin, PluginKind } from '@stryker-mutator/api/plugin';
 
 import * as strykerValidationSchema from '../schema/jasmine-runner-options.json';
 
-import JasmineTestRunner from './JasmineTestRunner';
+import { createJasmineTestRunner } from './JasmineTestRunner';
 
-export const strykerPlugins = [declareClassPlugin(PluginKind.TestRunner2, 'jasmine', JasmineTestRunner)];
+export const strykerPlugins = [declareFactoryPlugin(PluginKind.TestRunner2, 'jasmine', createJasmineTestRunner)];
 
 export { strykerValidationSchema };

--- a/packages/jasmine-runner/src/pluginTokens.ts
+++ b/packages/jasmine-runner/src/pluginTokens.ts
@@ -1,0 +1,1 @@
+export const directoryRequireCache = 'directoryRequireCache';

--- a/packages/jasmine-runner/test/integration/helpers.ts
+++ b/packages/jasmine-runner/test/integration/helpers.ts
@@ -1,15 +1,4 @@
-import path = require('path');
-
 import { TestStatus, SuccessTestResult } from '@stryker-mutator/api/test_runner2';
-
-export function resolveJasmineInitFiles(): readonly string[] {
-  return [
-    path.resolve('lib', 'jasmine_examples', 'Player.js'),
-    path.resolve('lib', 'jasmine_examples', 'Song.js'),
-    path.resolve('spec', 'helpers', 'jasmine_examples', 'SpecHelper.js'),
-    path.resolve('spec', 'jasmine_examples', 'PlayerSpec.js'),
-  ];
-}
 
 export const jasmineInitResultTestNames = Object.freeze([
   'Player should be able to play a Song',

--- a/packages/jasmine-runner/test/integration/jasmine-init-instrumented.it.spec.ts
+++ b/packages/jasmine-runner/test/integration/jasmine-init-instrumented.it.spec.ts
@@ -1,20 +1,22 @@
 import path = require('path');
 
-import { factory } from '@stryker-mutator/test-helpers';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import { KilledMutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test_runner2';
 import { assertions } from '@stryker-mutator/test-helpers';
 
-import JasmineTestRunner from '../../src/JasmineTestRunner';
-
-import { resolveJasmineInitFiles } from './helpers';
+import JasmineTestRunner, { createJasmineTestRunner } from '../../src/JasmineTestRunner';
 
 describe('JasmineRunner integration with code instrumentation', () => {
   let sut: JasmineTestRunner;
 
   beforeEach(() => {
     process.chdir(path.resolve(__dirname, '../../testResources/jasmine-init-instrumented'));
-    sut = new JasmineTestRunner(resolveJasmineInitFiles(), factory.strykerOptions());
+    sut = testInjector.injector.injectFunction(createJasmineTestRunner);
+  });
+
+  afterEach(async () => {
+    await sut.dispose();
   });
 
   describe('dryRun', () => {

--- a/packages/jest-runner/src/JestTestRunner.ts
+++ b/packages/jest-runner/src/JestTestRunner.ts
@@ -1,6 +1,6 @@
 import { StrykerOptions, INSTRUMENTER_CONSTANTS, Mutant } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
-import { commonTokens, Injector, OptionsContext, tokens } from '@stryker-mutator/api/plugin';
+import { commonTokens, Injector, PluginContext, tokens } from '@stryker-mutator/api/plugin';
 import {
   TestRunner2,
   MutantRunOptions,
@@ -25,7 +25,7 @@ import { configLoaderFactory } from './configLoaders';
 import { JestRunnerOptionsWithStrykerOptions } from './JestRunnerOptionsWithStrykerOptions';
 import JEST_OVERRIDE_OPTIONS from './jestOverrideOptions';
 
-export function jestTestRunnerFactory(injector: Injector<OptionsContext>) {
+export function jestTestRunnerFactory(injector: Injector<PluginContext>) {
   return injector
     .provideValue(processEnvToken, process.env)
     .provideValue(jestVersionToken, require('jest/package.json').version as string)

--- a/packages/jest-runner/src/configLoaders/index.ts
+++ b/packages/jest-runner/src/configLoaders/index.ts
@@ -1,4 +1,4 @@
-import { tokens, commonTokens, Injector, OptionsContext } from '@stryker-mutator/api/plugin';
+import { tokens, commonTokens, Injector, PluginContext } from '@stryker-mutator/api/plugin';
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 
@@ -10,7 +10,7 @@ import ReactScriptsJestConfigLoader from './ReactScriptsJestConfigLoader';
 import ReactScriptsTSJestConfigLoader from './ReactScriptsTSJestConfigLoader';
 
 configLoaderFactory.inject = tokens(commonTokens.options, commonTokens.injector, commonTokens.logger);
-export function configLoaderFactory(options: StrykerOptions, injector: Injector<OptionsContext>, log: Logger) {
+export function configLoaderFactory(options: StrykerOptions, injector: Injector<PluginContext>, log: Logger) {
   const warnAboutConfigFile = (projectType: string, configFile: string | undefined) => {
     if (configFile) {
       log.warn(`Config setting "configFile" is not supported for projectType "${projectType}"`);

--- a/packages/jest-runner/test/helpers/producers.ts
+++ b/packages/jest-runner/test/helpers/producers.ts
@@ -19,6 +19,7 @@ export function createAssertionResult(overrides?: Partial<AssertionResult>): Ass
     status: 'passed',
     title: 'should be bar',
     duration: 25,
+    failureDetails: [],
     ...overrides,
   };
 }
@@ -122,7 +123,7 @@ export const createFailResult = (): AggregatedResult =>
       }),
       createJestTestResult({
         testResults: [
-          {
+          createAssertionResult({
             ancestorTitles: ['App'],
             duration: 23,
             failureMessages: [],
@@ -130,7 +131,7 @@ export const createFailResult = (): AggregatedResult =>
             numPassingAsserts: 0,
             status: 'passed',
             title: 'renders without crashing',
-          },
+          }),
         ],
       }),
     ],

--- a/packages/mocha-runner/package.json
+++ b/packages/mocha-runner/package.json
@@ -38,14 +38,14 @@
   "dependencies": {
     "@stryker-mutator/api": "4.0.0-beta.2",
     "@stryker-mutator/util": "4.0.0-beta.2",
-    "multimatch": "~4.0.0",
+    "glob": "^7.1.6",
     "tslib": "~2.0.0"
   },
   "devDependencies": {
     "@stryker-mutator/core": "4.0.0-beta.2",
     "@stryker-mutator/mocha-framework": "4.0.0-beta.2",
     "@stryker-mutator/test-helpers": "4.0.0-beta.2",
-    "@types/multimatch": "~4.0.0",
+    "@types/glob": "^7.1.3",
     "@types/node": "^14.0.1"
   },
   "peerDependencies": {

--- a/packages/mocha-runner/src/LibWrapper.ts
+++ b/packages/mocha-runner/src/LibWrapper.ts
@@ -40,7 +40,7 @@ try {
 export default class LibWrapper {
   public static Mocha = Mocha;
   public static require = require;
-  public static glob = glob;
+  public static glob = glob.sync;
   public static loadOptions = loadOptions;
   public static collectFiles = collectFiles;
   public static handleRequires = handleRequires;

--- a/packages/mocha-runner/src/LibWrapper.ts
+++ b/packages/mocha-runner/src/LibWrapper.ts
@@ -1,5 +1,5 @@
 import * as Mocha from 'mocha';
-import * as multimatch from 'multimatch';
+import glob = require('glob');
 
 import { MochaOptions } from '../src-generated/mocha-runner-options';
 
@@ -40,7 +40,7 @@ try {
 export default class LibWrapper {
   public static Mocha = Mocha;
   public static require = require;
-  public static multimatch = multimatch;
+  public static glob = glob;
   public static loadOptions = loadOptions;
   public static collectFiles = collectFiles;
   public static handleRequires = handleRequires;

--- a/packages/mocha-runner/src/MochaAdapter.ts
+++ b/packages/mocha-runner/src/MochaAdapter.ts
@@ -71,7 +71,7 @@ export class MochaAdapter {
   private legacyDiscoverFiles(options: MochaOptions): string[] {
     const globPatterns = this.mochaFileGlobPatterns(options);
     const fileNames = new Set<string>();
-    globPatterns.forEach((patten) => LibWrapper.glob.sync(patten).forEach((fileName) => fileNames.add(fileName)));
+    globPatterns.forEach((patten) => LibWrapper.glob(patten).forEach((fileName) => fileNames.add(fileName)));
     if (fileNames.size) {
       this.log.debug(`Using files: ${JSON.stringify(fileNames, null, 2)}`);
     } else {

--- a/packages/mocha-runner/src/MochaAdapter.ts
+++ b/packages/mocha-runner/src/MochaAdapter.ts
@@ -19,9 +19,9 @@ const DEFAULT_TEST_PATTERN = 'test/**/*.js';
  * Currently supports mocha < 6
  */
 export class MochaAdapter {
-  public static readonly inject = tokens(commonTokens.logger, commonTokens.sandboxFileNames);
+  public static readonly inject = tokens(commonTokens.logger);
 
-  constructor(private readonly log: Logger, private readonly allFileNames: readonly string[]) {}
+  constructor(private readonly log: Logger) {}
 
   public create(options: Mocha.MochaOptions) {
     return new LibWrapper.Mocha(options);
@@ -70,12 +70,12 @@ export class MochaAdapter {
 
   private legacyDiscoverFiles(options: MochaOptions): string[] {
     const globPatterns = this.mochaFileGlobPatterns(options);
-    const globPatternsAbsolute = globPatterns.map((glob) => path.resolve(glob));
-    const fileNames = LibWrapper.multimatch(this.allFileNames.slice(), globPatternsAbsolute);
-    if (fileNames.length) {
+    const fileNames = new Set<string>();
+    globPatterns.forEach((patten) => LibWrapper.glob.sync(patten).forEach((fileName) => fileNames.add(fileName)));
+    if (fileNames.size) {
       this.log.debug(`Using files: ${JSON.stringify(fileNames, null, 2)}`);
     } else {
-      this.log.debug(`Tried ${JSON.stringify(globPatternsAbsolute, null, 2)} on files: ${JSON.stringify(this.allFileNames, null, 2)}.`);
+      this.log.debug(`Tried ${JSON.stringify(globPatterns, null, 2)} but did not result in any files.`);
       throw new Error(
         `[${MochaTestRunner.name}] No files discovered (tried pattern(s) ${JSON.stringify(
           globPatterns,
@@ -87,7 +87,7 @@ export class MochaAdapter {
         )} in your config file.`
       );
     }
-    return fileNames;
+    return [...fileNames];
   }
 
   private mochaFileGlobPatterns(mochaOptions: MochaOptions): string[] {

--- a/packages/mocha-runner/src/index.ts
+++ b/packages/mocha-runner/src/index.ts
@@ -1,4 +1,5 @@
-import { commonTokens, declareFactoryPlugin, Injector, PluginKind, tokens, TestRunnerPluginContext } from '@stryker-mutator/api/plugin';
+import { commonTokens, declareFactoryPlugin, Injector, PluginKind, tokens, PluginContext } from '@stryker-mutator/api/plugin';
+import { DirectoryRequireCache } from '@stryker-mutator/util';
 
 import * as strykerValidationSchema from '../schema/mocha-runner-options.json';
 
@@ -8,10 +9,11 @@ import { MochaTestRunner } from './MochaTestRunner';
 import { MochaAdapter } from './MochaAdapter';
 
 createMochaTestRunner.inject = tokens(commonTokens.injector);
-export function createMochaTestRunner(injector: Injector<TestRunnerPluginContext>): MochaTestRunner {
+export function createMochaTestRunner(injector: Injector<PluginContext>): MochaTestRunner {
   return injector
     .provideClass(pluginTokens.loader, MochaOptionsLoader)
     .provideClass(pluginTokens.mochaAdapter, MochaAdapter)
+    .provideClass(pluginTokens.directoryRequireCache, DirectoryRequireCache)
     .injectClass(MochaTestRunner);
 }
 

--- a/packages/mocha-runner/src/plugin-tokens.ts
+++ b/packages/mocha-runner/src/plugin-tokens.ts
@@ -1,2 +1,3 @@
 export const loader = 'loader';
 export const mochaAdapter = 'mochaAdapter';
+export const directoryRequireCache = 'directoryRequireCache';

--- a/packages/mocha-runner/test/integration/MochaFileResolving.spec.ts
+++ b/packages/mocha-runner/test/integration/MochaFileResolving.spec.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 
-import { commonTokens } from '@stryker-mutator/api/plugin';
 import { expect } from 'chai';
 import { testInjector } from '@stryker-mutator/test-helpers';
 
@@ -40,7 +39,7 @@ describe('Mocha 6 file resolving integration', () => {
   }
 
   function createTestRunner() {
-    return testInjector.injector.provideValue(commonTokens.sandboxFileNames, []).injectFunction(createMochaTestRunner);
+    return testInjector.injector.injectFunction(createMochaTestRunner);
   }
 
   function resolveTestDir(fileName = '.') {

--- a/packages/mocha-runner/test/integration/ProjectWithRootHooks.it.spec.ts
+++ b/packages/mocha-runner/test/integration/ProjectWithRootHooks.it.spec.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 
-import { commonTokens } from '@stryker-mutator/api/plugin';
 import { testInjector, factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
@@ -15,7 +14,7 @@ describe('Running a project with root hooks', () => {
 
   beforeEach(async () => {
     process.chdir(path.resolve(__dirname, '..', '..', 'testResources', 'parallel-with-root-hooks-sample'));
-    sut = testInjector.injector.provideValue(commonTokens.sandboxFileNames, []).injectFunction(createMochaTestRunner);
+    sut = testInjector.injector.injectFunction(createMochaTestRunner);
     await sut.init();
   });
 

--- a/packages/mocha-runner/test/integration/QUnitSample.it.spec.ts
+++ b/packages/mocha-runner/test/integration/QUnitSample.it.spec.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 
-import { commonTokens } from '@stryker-mutator/api/plugin';
 import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
@@ -8,14 +7,8 @@ import { createMochaOptions } from '../helpers/factories';
 import { createMochaTestRunner } from '../../src';
 
 describe('QUnit sample', () => {
-  let files: string[];
-
-  beforeEach(() => {
-    files = [];
-  });
-
   function createSut() {
-    return testInjector.injector.provideValue(commonTokens.sandboxFileNames, files).injectFunction(createMochaTestRunner);
+    return testInjector.injector.injectFunction(createMochaTestRunner);
   }
 
   it('should work when configured with "qunit" ui', async () => {
@@ -25,7 +18,6 @@ describe('QUnit sample', () => {
       ui: 'qunit',
     });
     testInjector.options.mochaOptions = mochaOptions;
-    files = mochaOptions.spec!;
     const sut = createSut();
     await sut.init();
     const actualResult = await sut.dryRun(factory.dryRunOptions());
@@ -40,7 +32,6 @@ describe('QUnit sample', () => {
   });
 
   it('should not run tests when not configured with "qunit" ui', async () => {
-    files = [resolve('./testResources/qunit-sample/MyMathSpec.js'), resolve('./testResources/qunit-sample/MyMath.js')];
     testInjector.options.mochaOptions = createMochaOptions({
       files: [resolve('./testResources/qunit-sample/MyMathSpec.js')],
     });

--- a/packages/mocha-runner/test/integration/SampleProject.it.spec.ts
+++ b/packages/mocha-runner/test/integration/SampleProject.it.spec.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 
-import { commonTokens } from '@stryker-mutator/api/plugin';
 import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
 import { TestResult, CompleteDryRunResult, TestStatus } from '@stryker-mutator/api/test_runner2';
 import { expect } from 'chai';
@@ -22,7 +21,7 @@ describe('Running a sample project', () => {
   let spec: string[];
 
   function createSut() {
-    return testInjector.injector.provideValue(commonTokens.sandboxFileNames, spec).injectFunction(createMochaTestRunner);
+    return testInjector.injector.injectFunction(createMochaTestRunner);
   }
 
   describe('when tests pass', () => {

--- a/packages/mocha-runner/test/integration/SampleProjectInstrumented.it.spec.ts
+++ b/packages/mocha-runner/test/integration/SampleProjectInstrumented.it.spec.ts
@@ -1,7 +1,6 @@
 import path = require('path');
 
 import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
-import { commonTokens } from '@stryker-mutator/api/plugin';
 import { expect } from 'chai';
 import { MutantCoverage } from '@stryker-mutator/api/test_runner2';
 
@@ -21,7 +20,7 @@ describe('Running an instrumented project', () => {
       resolve('./testResources/sample-project-instrumented/MyMathSpec.js'),
     ];
     testInjector.options.mochaOptions = createMochaOptions({ spec });
-    sut = testInjector.injector.provideValue(commonTokens.sandboxFileNames, spec).injectFunction(createMochaTestRunner);
+    sut = testInjector.injector.injectFunction(createMochaTestRunner);
     await sut.init();
   });
 

--- a/packages/mocha-runner/test/unit/MochaAdapter.spec.ts
+++ b/packages/mocha-runner/test/unit/MochaAdapter.spec.ts
@@ -14,12 +14,10 @@ describe(MochaAdapter.name, () => {
   let handleRequiresStub: sinon.SinonStub;
   let loadRootHooks: sinon.SinonStub;
   let sut: MochaAdapter;
-  let sandboxFileNames: string[];
   let mochaConstructorStub: sinon.SinonStub;
   let existsSyncStub: sinon.SinonStub;
 
   beforeEach(() => {
-    sandboxFileNames = [];
     requireStub = sinon.stub(LibWrapper, 'require');
     mochaConstructorStub = sinon.stub(LibWrapper, 'Mocha');
     collectFilesStub = sinon.stub(LibWrapper, 'collectFiles');
@@ -42,69 +40,61 @@ describe(MochaAdapter.name, () => {
   });
 
   describe(MochaAdapter.prototype.collectFiles.name, () => {
-    let multimatchStub: sinon.SinonStub;
+    let globStub: sinon.SinonStub;
 
     describe('when mocha version < 6', () => {
       beforeEach(() => {
         collectFilesStub.value(undefined);
-        multimatchStub = sinon.stub(LibWrapper, 'glob');
+        globStub = sinon.stub(LibWrapper, 'glob');
       });
 
       it('should log about mocha < 6 detection', async () => {
-        multimatchStub.returns(['foo.js']);
+        globStub.returns(['foo.js']);
         sut.collectFiles({});
         expect(testInjector.logger.debug).calledWith('Mocha < 6 detected. Using custom logic to discover files');
       });
 
       it('should support both `files` as `spec`', async () => {
-        multimatchStub.returns(['foo.js']);
-        sandboxFileNames.push('foo');
+        globStub.returns(['foo.js']);
         sut.collectFiles({
           files: ['bar'],
           spec: ['foo'],
         });
-        expect(multimatchStub).calledWith(['foo'], [path.resolve('foo'), path.resolve('bar')]);
-      });
-
-      it('should match given file names with configured mocha files as `array`', () => {
-        const relativeGlobPatterns = ['*.js', 'baz.js'];
-        const expectedGlobPatterns = relativeGlobPatterns.map((glob) => path.resolve(glob));
-        actAssertMatchedPatterns(relativeGlobPatterns, expectedGlobPatterns);
+        expect(globStub).calledWith('foo');
+        expect(globStub).calledWith('bar');
       });
 
       it('should match given file names with configured mocha files as `string`', () => {
+        // Arrange
         const relativeGlobPattern = '*.js';
-        const expectedGlobPatterns = [path.resolve(relativeGlobPattern)];
-        actAssertMatchedPatterns(relativeGlobPattern, expectedGlobPatterns);
+        const expectedFiles = ['foo.js', 'bar.js'];
+        globStub.returns(expectedFiles);
+
+        // Act
+        const actualFiles = sut.collectFiles({ files: relativeGlobPattern });
+
+        // Assert
+        expect(globStub).calledWith(relativeGlobPattern);
+        expect(actualFiles).deep.eq(expectedFiles);
       });
 
       it('should match given file names with default mocha pattern "test/**/*.js"', () => {
-        const expectedGlobPatterns = [path.resolve('test/**/*.js')];
-        actAssertMatchedPatterns(undefined, expectedGlobPatterns);
+        globStub.returns(['foo.js']);
+        sut.collectFiles({});
+        expect(globStub).calledWith('test/**/*.js');
       });
 
       it('should reject if no files could be discovered', async () => {
         // Arrange
-        multimatchStub.returns([]);
-        sandboxFileNames.push('foo.js', 'bar.js');
+        globStub.returns([]);
         const relativeGlobbing = JSON.stringify(['test/**/*.js'], null, 2);
-        const absoluteGlobbing = JSON.stringify([path.resolve('test/**/*.js')], null, 2);
-        const filesStringified = JSON.stringify(sandboxFileNames, null, 2);
 
         // Act & assert
         expect(() => sut.collectFiles({})).throws(
           `[MochaTestRunner] No files discovered (tried pattern(s) ${relativeGlobbing}). Please specify the files (glob patterns) containing your tests in mochaOptions.spec in your config file.`
         );
-        expect(testInjector.logger.debug).calledWith(`Tried ${absoluteGlobbing} on files: ${filesStringified}.`);
+        expect(testInjector.logger.debug).calledWith(`Tried ${relativeGlobbing} but did not result in any files.`);
       });
-
-      function actAssertMatchedPatterns(relativeGlobPatterns: string | string[] | undefined, expectedGlobPatterns: string[]) {
-        const expectedFiles = ['foo.js', 'bar.js'];
-        sandboxFileNames.push(...expectedFiles);
-        multimatchStub.returns(['foo.js']);
-        sut.collectFiles({ files: relativeGlobPatterns });
-        expect(multimatchStub).calledWith(expectedFiles, expectedGlobPatterns);
-      }
     });
 
     describe('when mocha version >= 6', () => {

--- a/packages/mocha-runner/test/unit/MochaAdapter.spec.ts
+++ b/packages/mocha-runner/test/unit/MochaAdapter.spec.ts
@@ -4,7 +4,6 @@ import fs = require('fs');
 import sinon = require('sinon');
 import { expect } from 'chai';
 import { testInjector } from '@stryker-mutator/test-helpers';
-import { commonTokens } from '@stryker-mutator/api/plugin';
 
 import { MochaAdapter } from '../../src/MochaAdapter';
 import LibWrapper from '../../src/LibWrapper';
@@ -27,7 +26,7 @@ describe(MochaAdapter.name, () => {
     handleRequiresStub = sinon.stub(LibWrapper, 'handleRequires');
     loadRootHooks = sinon.stub(LibWrapper, 'loadRootHooks');
     existsSyncStub = sinon.stub(fs, 'existsSync');
-    sut = testInjector.injector.provideValue(commonTokens.sandboxFileNames, sandboxFileNames).injectClass(MochaAdapter);
+    sut = testInjector.injector.injectClass(MochaAdapter);
   });
 
   describe(MochaAdapter.prototype.create.name, () => {
@@ -48,7 +47,7 @@ describe(MochaAdapter.name, () => {
     describe('when mocha version < 6', () => {
       beforeEach(() => {
         collectFilesStub.value(undefined);
-        multimatchStub = sinon.stub(LibWrapper, 'multimatch');
+        multimatchStub = sinon.stub(LibWrapper, 'glob');
       });
 
       it('should log about mocha < 6 detection', async () => {

--- a/packages/test-helpers/src/TestInjector.ts
+++ b/packages/test-helpers/src/TestInjector.ts
@@ -1,6 +1,6 @@
 import { MutatorDescriptor, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
-import { commonTokens, OptionsContext, PluginResolver } from '@stryker-mutator/api/plugin';
+import { commonTokens, PluginContext, PluginResolver } from '@stryker-mutator/api/plugin';
 import * as sinon from 'sinon';
 import { Injector, rootInjector, Scope } from 'typed-inject';
 
@@ -24,7 +24,7 @@ class TestInjector {
   public options: StrykerOptions;
   public mutatorDescriptor: MutatorDescriptor;
   public logger: sinon.SinonStubbedInstance<Logger>;
-  public injector: Injector<OptionsContext> = rootInjector
+  public injector: Injector<PluginContext> = rootInjector
     .provideValue(commonTokens.getLogger, this.provideLogger)
     .provideFactory(commonTokens.logger, this.provideLogger, Scope.Transient)
     .provideFactory(commonTokens.options, this.provideOptions, Scope.Transient)

--- a/packages/typescript-checker/src/typescript-checker.ts
+++ b/packages/typescript-checker/src/typescript-checker.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import ts from 'typescript';
 import { Checker, CheckResult, CheckStatus } from '@stryker-mutator/api/check';
-import { tokens, commonTokens, OptionsContext, Injector, Scope } from '@stryker-mutator/api/plugin';
+import { tokens, commonTokens, PluginContext, Injector, Scope } from '@stryker-mutator/api/plugin';
 import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
 import { Task, propertyPath } from '@stryker-mutator/util';
 import { Mutant, StrykerOptions } from '@stryker-mutator/api/core';
@@ -29,7 +29,7 @@ function typescriptCheckerLoggerFactory(loggerFactory: LoggerFactoryMethod, targ
 }
 
 create.inject = tokens(commonTokens.injector);
-export function create(injector: Injector<OptionsContext>): TypescriptChecker {
+export function create(injector: Injector<PluginContext>): TypescriptChecker {
   return injector
     .provideFactory(commonTokens.logger, typescriptCheckerLoggerFactory, Scope.Transient)
     .provideClass(pluginTokens.fs, HybridFileSystem)

--- a/packages/util/src/DirectoryRequireCache.ts
+++ b/packages/util/src/DirectoryRequireCache.ts
@@ -1,0 +1,35 @@
+import path = require('path');
+
+/**
+ * A helper class that can be used by test runners.
+ * The first time you call `record`, it will fill the internal registry with the files required in the current working directory (excluding node_modules)
+ * Then each time you call `clear` it will clear those files from the require cache
+ */
+export class DirectoryRequireCache {
+  private cache: Set<string>;
+  private initFiles?: readonly string[];
+
+  public init(initFiles: readonly string[]) {
+    this.initFiles = initFiles;
+  }
+
+  /**
+   * Records the files required in the current working directory (excluding node_modules)
+   * Only does so the first time, any subsequent calls will be ignored
+   */
+  public record() {
+    if (!this.cache) {
+      const cwd = process.cwd();
+      this.cache = new Set(this.initFiles);
+      Object.keys(require.cache)
+        .filter((fileName) => fileName.startsWith(`${cwd}${path.sep}`) && !fileName.startsWith(path.join(cwd, 'node_modules')))
+        .forEach((file) => this.cache.add(file));
+    }
+  }
+
+  public clear() {
+    if (this.cache) {
+      this.cache.forEach((fileName) => delete require.cache[fileName]);
+    }
+  }
+}

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -9,3 +9,4 @@ export * from './notEmpty';
 export * from './flatMap';
 export * from './I';
 export * from './Task';
+export * from './DirectoryRequireCache';

--- a/packages/util/test/unit/DirectoryRequireCache.spec.ts
+++ b/packages/util/test/unit/DirectoryRequireCache.spec.ts
@@ -99,5 +99,6 @@ function createModule(content: string, fileName: string): NodeModule {
     parent: null,
     paths: [],
     require,
+    path: '',
   };
 }

--- a/packages/util/test/unit/DirectoryRequireCache.spec.ts
+++ b/packages/util/test/unit/DirectoryRequireCache.spec.ts
@@ -1,0 +1,103 @@
+import path = require('path');
+
+import sinon = require('sinon');
+
+import { expect } from 'chai';
+
+import { DirectoryRequireCache } from '../../src';
+
+describe(DirectoryRequireCache.name, () => {
+  let workingDirectory: string;
+  let sut: DirectoryRequireCache;
+  let loadedFiles: Map<string, string>;
+
+  beforeEach(() => {
+    loadedFiles = new Map();
+    workingDirectory = path.join('stub', 'working', 'dir');
+    const cwdStub = sinon.stub(process, 'cwd').returns(workingDirectory);
+    cwdStub.returns(workingDirectory);
+    sut = new DirectoryRequireCache();
+  });
+
+  afterEach(() => {
+    for (const fileName of loadedFiles.keys()) {
+      delete require.cache[fileName];
+    }
+  });
+
+  function fakeRequireFile(fileName: string, content = fileName) {
+    loadedFiles.set(fileName, content);
+    require.cache[fileName] = createModule(content, fileName);
+  }
+
+  describe(DirectoryRequireCache.prototype.clear.name, () => {
+    it('should clear the init files', () => {
+      // Arrange
+      const dir2 = path.join('stub', 'working', 'dir2');
+      const fooFileName = path.join(dir2, 'foo.js');
+      const barFileName = path.join(dir2, 'bar.js');
+      const bazFileName = path.join(dir2, 'baz.js');
+      fakeRequireFile(fooFileName, 'foo');
+      fakeRequireFile(barFileName, 'foo');
+      fakeRequireFile(bazFileName, 'baz');
+      sut.init([fooFileName, barFileName]);
+      sut.record();
+
+      // Act
+      sut.clear();
+
+      // Assert
+      expect(require.cache[fooFileName]).undefined;
+      expect(require.cache[barFileName]).undefined;
+      expect(require.cache[bazFileName]?.exports).eq('baz');
+    });
+
+    it('should clear recorded files', () => {
+      // Arrange
+      const dir2 = path.join('stub', 'working', 'dir2');
+      const fooFileName = path.join(workingDirectory, 'foo.js');
+      const barFileName = path.join(workingDirectory, 'bar.js');
+      const bazFileName = path.join(dir2, 'baz.js');
+      fakeRequireFile(fooFileName, 'foo');
+      fakeRequireFile(barFileName, 'foo');
+      fakeRequireFile(bazFileName, 'baz');
+      sut.record();
+
+      // Act
+      sut.clear();
+
+      // Assert
+      expect(require.cache[fooFileName]).undefined;
+      expect(require.cache[barFileName]).undefined;
+      expect(require.cache[bazFileName]?.exports).eq('baz');
+    });
+
+    it('should not clear files from node_modules', () => {
+      // Arrange
+      const fooFileName = path.join(workingDirectory, 'foo.js');
+      const bazFileName = path.join(workingDirectory, 'node_modules', 'baz.js');
+      fakeRequireFile(fooFileName, 'foo');
+      fakeRequireFile(bazFileName, 'baz');
+      sut.record();
+
+      // Act
+      sut.clear();
+
+      // Assert
+      expect(require.cache[fooFileName]).undefined;
+      expect(require.cache[bazFileName]?.exports).eq('baz');
+    });
+  });
+});
+function createModule(content: string, fileName: string): NodeModule {
+  return {
+    exports: content,
+    children: [],
+    filename: fileName,
+    id: fileName,
+    loaded: true,
+    parent: null,
+    paths: [],
+    require,
+  };
+}

--- a/packages/util/test/unit/stringUtils.spec.ts
+++ b/packages/util/test/unit/stringUtils.spec.ts
@@ -46,7 +46,9 @@ describe('stringUtils', () => {
       expect(escapeRegExp('something normal')).eq('something normal');
     });
 
-    it("should not escape `/` (that's only needed for regex literals)");
+    it("should not escape `/` (that's only needed for regex literals)", () => {
+      expect(escapeRegExp('n/a')).eq('n/a');
+    });
 
     for (const letter of '.*+-?^${}()|[]\\') {
       it(`should escape "${letter}"`, () => {


### PR DESCRIPTION
Remove `sandboxFileNames` as injectable value for test runner plugins. Test runner plugins are expected to do their own file discovery in the current working directory. The list of sandbox files that Stryker internally copied over might differ from the list of files in the sandbox, because the user might have configured a `buildCommand` that compiled the files to their final representation.

* Remove `sandboxFileNames` from dependency injection context
* Rename `OptionsContext` to `PluginContext` and remove the `PluginContexts` mapped type (no longer needed)
* Move generic require cache clean functionality to `@stryker-mutator/util` 
    * Use this in the mocha-runner 
    * Use this in the jasmine-runner.

Fixed #2351 