### PR TITLE
feat(mocha): deprecate mocha < v6

### DIFF
--- a/e2e/test/mocha-old-version/package-lock.json
+++ b/e2e/test/mocha-old-version/package-lock.json
@@ -1,0 +1,196 @@
+{
+  "name": "mocha-old-version",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/e2e/test/mocha-old-version/package.json
+++ b/e2e/test/mocha-old-version/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mocha-old-version",
+  "version": "0.0.0",
+  "private": true,
+  "description": "A test package for mocha 5",
+  "main": "index.js",
+  "scripts": {
+    "pretest": "rimraf \"reports\"",
+    "test": "stryker run",
+    "posttest": "mocha --no-config --require ../../tasks/ts-node-register.js verify/*.ts"
+  },
+  "localDependencies": {
+    "@stryker-mutator/api": "../../../packages/api",
+    "@stryker-mutator/core": "../../../packages/core",
+    "@stryker-mutator/instrumenter": "../../../packages/instrumenter",
+    "@stryker-mutator/mocha-runner": "../../../packages/mocha-runner",
+    "@stryker-mutator/util": "../../../packages/util"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "mocha": "^5.2.0"
+  }
+}

--- a/e2e/test/mocha-old-version/src/add.js
+++ b/e2e/test/mocha-old-version/src/add.js
@@ -1,0 +1,6 @@
+module.exports.add = function(num1, num2) {
+  return num1 + num2;
+};
+
+
+

--- a/e2e/test/mocha-old-version/stryker.conf.json
+++ b/e2e/test/mocha-old-version/stryker.conf.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "testRunner": "mocha",
+  "concurrency": 1,
+  "coverageAnalysis": "off",
+  "reporters": ["clear-text", "html", "event-recorder"],
+  "mochaOptions": {
+    "spec": ["test/**/*.js"]
+  },
+  "fileLogLevel": "info",
+  "plugins": [
+    "@stryker-mutator/mocha-runner"
+  ]
+}

--- a/e2e/test/mocha-old-version/test/unit/add.spec.js
+++ b/e2e/test/mocha-old-version/test/unit/add.spec.js
@@ -1,0 +1,10 @@
+const { add } = require('../../src/add');
+const { expect } = require('chai');
+
+describe('add', () => {
+
+  it('2 + 3 = 5', () => {
+    expect(add(2, 3)).to.be.equal(5);
+  });
+
+});

--- a/e2e/test/mocha-old-version/verify/verify.ts
+++ b/e2e/test/mocha-old-version/verify/verify.ts
@@ -1,0 +1,17 @@
+import { promises as fs } from 'fs';
+import { expect } from 'chai';
+import { it } from 'mocha';
+
+describe('Verify stryker runs with mocha < 6', () => {
+
+  let strykerLog: string;
+
+  before(async () => {
+    strykerLog = await fs.readFile('./stryker.log', 'utf8');
+  });
+
+  it('should warn about old mocha version', async () => {
+    expect(strykerLog).contains('DEPRECATED: Mocha < 6 detected. Please upgrade to at least Mocha version 6. Stryker will drop support for Mocha < 6 in V5');
+  });
+
+});

--- a/packages/mocha-runner/src/LibWrapper.ts
+++ b/packages/mocha-runner/src/LibWrapper.ts
@@ -1,7 +1,11 @@
+import path = require('path');
+
 import * as Mocha from 'mocha';
 import glob = require('glob');
 
 import { MochaOptions } from '../src-generated/mocha-runner-options';
+
+const mochaRoot = path.dirname(require.resolve('mocha/package.json'));
 
 let loadOptions: undefined | ((argv?: string[] | string) => { [key: string]: any } | undefined);
 let collectFiles: undefined | ((options: MochaOptions) => string[]);
@@ -14,21 +18,21 @@ try {
    * @since 6.0.0'
    * @see https://mochajs.org/api/module-lib_cli_options.html#.loadOptions
    */
-  loadOptions = require('mocha/lib/cli/options').loadOptions;
+  loadOptions = require(`${mochaRoot}/lib/cli/options`).loadOptions;
 } catch {
   // Mocha < 6 doesn't support `loadOptions`
 }
 
 try {
   // https://github.com/mochajs/mocha/blob/master/lib/cli/run-helpers.js#L132
-  const runHelpers = require('mocha/lib/cli/run-helpers');
+  const runHelpers = require(`${mochaRoot}/lib/cli/run-helpers`);
   collectFiles = runHelpers.handleFiles;
   handleRequires = runHelpers.handleRequires; // handleRequires is available since mocha v7.2
   loadRootHooks = runHelpers.loadRootHooks; // loadRootHooks is available since mocha v7.2
 
   if (!collectFiles) {
     // Might be moved: https://github.com/mochajs/mocha/commit/15b96afccaf508312445770e3af1c145d90b28c6#diff-39b692a81eb0c9f3614247af744ab4a8
-    collectFiles = require('mocha/lib/cli/collect-files');
+    collectFiles = require(`${mochaRoot}/lib/cli/collect-files`);
   }
 } catch {
   // Mocha < 6 doesn't support `handleFiles`

--- a/packages/mocha-runner/src/MochaOptionsLoader.ts
+++ b/packages/mocha-runner/src/MochaOptionsLoader.ts
@@ -44,7 +44,7 @@ export default class MochaOptionsLoader {
       this.log.debug("Mocha >= 6 detected. Using mocha's `%s` to load mocha options", LibWrapper.loadOptions.name);
       return this.loadMocha6Options(overrides);
     } else {
-      this.log.warn('DEPRECATED: Mocha < 6 detected. Please upgrade to at least Mocha version 6.');
+      this.log.warn('DEPRECATED: Mocha < 6 detected. Please upgrade to at least Mocha version 6. Stryker will drop support for Mocha < 6 in V5.');
       this.log.debug('Mocha < 6 detected. Using custom logic to parse mocha options');
       return this.loadLegacyMochaOptsFile(overrides);
     }

--- a/packages/mocha-runner/test/unit/MochaOptionsLoader.spec.ts
+++ b/packages/mocha-runner/test/unit/MochaOptionsLoader.spec.ts
@@ -130,7 +130,9 @@ describe(MochaOptionsLoader.name, () => {
     it('should log deprecated mocha version warning', async () => {
       existsFileStub.returns(false);
       sut.load(options);
-      expect(testInjector.logger.warn).calledWith('DEPRECATED: Mocha < 6 detected. Please upgrade to at least Mocha version 6.');
+      expect(testInjector.logger.warn).calledWith(
+        'DEPRECATED: Mocha < 6 detected. Please upgrade to at least Mocha version 6. Stryker will drop support for Mocha < 6 in V5.'
+      );
     });
 
     it('should load a mocha.opts file if specified', () => {


### PR DESCRIPTION
BREAKING CHANGE: Mocha@<6 is deprecated and support for it will be removed in Stryker v5

Fixes #2370