### PR TITLE
bug(instrumentor): Adding instrumentor bug e2e's

### DIFF
--- a/e2e/test/jest-react-enyme-ts/src/OtherChild.spec.tsx
+++ b/e2e/test/jest-react-enyme-ts/src/OtherChild.spec.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { OtherChild } from './OtherChild';
+
+describe('OtherChild Component', () => {
+  it('should render correctly', () => {
+    expect(shallow(<OtherChild />)).toMatchSnapshot();
+  });
+});

--- a/e2e/test/jest-react-enyme-ts/src/OtherChild.tsx
+++ b/e2e/test/jest-react-enyme-ts/src/OtherChild.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const OtherChild = () => <div></div>;

--- a/e2e/test/jest-react-enyme-ts/src/ParentComponent.tsx
+++ b/e2e/test/jest-react-enyme-ts/src/ParentComponent.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ChildComponent from './ChildComponent';
+import { OtherChild } from './OtherChild';
 
-const ParentComponent = () => <div>
-  This is a parent component
-
-  <ChildComponent text="Some Text" />
-</div>
+const ParentComponent = () => (
+  <div>
+    This is a parent component
+    <ChildComponent text="Some Text" />
+    <OtherChild />
+  </div>
+);
 
 export default ParentComponent;

--- a/e2e/test/jest-react-enyme-ts/src/__snapshots__/OtherChild.spec.tsx.snap
+++ b/e2e/test/jest-react-enyme-ts/src/__snapshots__/OtherChild.spec.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OtherChild Component should render correctly 1`] = `<div />`;

--- a/e2e/test/jest-react-enyme-ts/src/__snapshots__/ParentComponent.spec.tsx.snap
+++ b/e2e/test/jest-react-enyme-ts/src/__snapshots__/ParentComponent.spec.tsx.snap
@@ -6,5 +6,6 @@ exports[`Parent Component should render correctly 1`] = `
   <ChildComponent
     text="Some Text"
   />
+  <Component />
 </div>
 `;

--- a/e2e/test/jest-react-enyme-ts/src/getUrl.spec.ts
+++ b/e2e/test/jest-react-enyme-ts/src/getUrl.spec.ts
@@ -1,0 +1,11 @@
+import getUrl from './getUrl';
+
+describe('getUrl', () => {
+  it('should return https://localhost/test for dev', () => {
+    expect(getUrl('dev')).toEqual('https://localhost/test');
+  });
+
+  it('should return https://stage.localhost/test for dev', () => {
+    expect(getUrl('stage')).toEqual('https://stage.localhost/test');
+  });
+});

--- a/e2e/test/jest-react-enyme-ts/src/getUrl.ts
+++ b/e2e/test/jest-react-enyme-ts/src/getUrl.ts
@@ -1,0 +1,10 @@
+const uri = 'test';
+
+export default (environment: 'dev' | 'stage') => {
+  switch (environment) {
+    case 'dev':
+      return `https://localhost/${uri}`;
+    case 'stage':
+      return `https://stage.localhost/${uri}`;
+  }
+};

--- a/e2e/test/jest-react-enyme-ts/stryker.conf.json
+++ b/e2e/test/jest-react-enyme-ts/stryker.conf.json
@@ -5,7 +5,9 @@
   "tempDirName": "stryker-tmp",
   "mutate": [
     "src/*.tsx",
-    "!src/*.spec.tsx"
+    "src/*.ts",
+    "!src/*.spec.tsx",
+    "!src/*.spec.ts"
   ],
   "concurrency": 2,
   "coverageAnalysis": "off",


### PR DESCRIPTION
 * Variables that are defined as `export const  a = () => <div></div>` should *not* have a node name #2362
 * For some reason `https://` as part of a string is instrumented into an unterminated string