### PR TITLE
cleanup & simplify default sandbox update options

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -176,7 +176,7 @@
             "type": "string"
           },
           "default": {
-            "**/*+(.js|.ts|.cjs|.mjs)?(x)": "/* eslint-disable */\n// @ts-nocheck\n"
+            "**/!(*.spec,*.test).{ts,tsx}": "// @ts-nocheck\n"
           }
         },
         "stripComments": {
@@ -191,7 +191,7 @@
               "type": "string"
             }
           ],
-          "default": "**/*+(.js|.ts|.cjs|.mjs)?(x)"
+          "default": "**/!(*.spec,*.test).{ts,tsx}"
         }
       }
     },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -297,7 +297,7 @@ The `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io,
 <a name="sandbox.fileHeaders"></a>
 ### `sandbox.fileHeaders` [`object`]
 
-Default: `{ "**/*+(.js|.ts|.cjs|.mjs)?(x)": "/* eslint-disable */\n// @ts-nocheck\n" }`
+Default: `"**/!(*.spec,*.test).{ts,tsx}": "// @ts-nocheck\n"`
 Command line: *none*
 Config file: `sandbox: { fileHeaders: {} }`
 
@@ -310,7 +310,7 @@ The key here is a [glob expression](https://globster.xyz/), where the value poin
 <a name="sandbox.stripComments"></a>
 ### `sandbox.stripComments` [`false` | `string`]
 
-Default: `"**/*+(.js|.ts|.cjs|.mjs)?(x)"`
+Default: `"default": "**/!(*.spec,*.test).{ts,tsx}"`
 Command line: *none*
 Config file: `sandbox: { stripComments: "" }`
 

--- a/packages/core/test/unit/sandbox/create-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/create-preprocessor.spec.ts
@@ -19,11 +19,11 @@ describe(createPreprocessor.name, () => {
 
   it('should add a header to .ts files', async () => {
     const output = await sut.preprocess([new File(path.resolve('app.ts'), 'foo.bar()')]);
-    assertions.expectTextFilesEqual(output, [new File(path.resolve('app.ts'), '/* eslint-disable */\n// @ts-nocheck\nfoo.bar()')]);
+    assertions.expectTextFilesEqual(output, [new File(path.resolve('app.ts'), '// @ts-nocheck\nfoo.bar()')]);
   });
 
   it('should strip // @ts-expect-error (see https://github.com/stryker-mutator/stryker/issues/2364)', async () => {
     const output = await sut.preprocess([new File(path.resolve('app.ts'), '// @ts-expect-error\nfoo.bar()')]);
-    assertions.expectTextFilesEqual(output, [new File(path.resolve('app.ts'), '/* eslint-disable */\n// @ts-nocheck\n\nfoo.bar()')]);
+    assertions.expectTextFilesEqual(output, [new File(path.resolve('app.ts'), '// @ts-nocheck\n\nfoo.bar()')]);
   });
 });

--- a/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
@@ -5,7 +5,7 @@ import { File } from '@stryker-mutator/api/core';
 
 import { FileHeaderPreprocessor } from '../../../src/sandbox/file-header-preprocessor';
 
-const EXPECTED_DEFAULT_HEADER = '/* eslint-disable */\n// @ts-nocheck\n';
+const EXPECTED_DEFAULT_HEADER = '// @ts-nocheck\n';
 
 describe(FileHeaderPreprocessor.name, () => {
   let sut: FileHeaderPreprocessor;
@@ -13,26 +13,20 @@ describe(FileHeaderPreprocessor.name, () => {
     sut = testInjector.injector.injectClass(FileHeaderPreprocessor);
   });
 
-  it('should add preprocess any js or friend file by default', async () => {
+  it('should update ts or tsx file by default', async () => {
     const inputContent = 'foo.bar()';
     const expectedOutputContent = `${EXPECTED_DEFAULT_HEADER}foo.bar()`;
     const input = [
-      new File('src/app.js', inputContent),
-      new File('test/app.spec.ts', inputContent),
-      new File('src/components/app.jsx', inputContent),
+      new File('src/app.ts', inputContent),
+      new File('test/app-test.ts', inputContent),
       new File('src/components/app.tsx', inputContent),
-      new File('src/components/app.cjs', inputContent),
-      new File('src/components/app.mjs', inputContent),
     ];
     const output = await sut.preprocess(input);
 
     assertions.expectTextFilesEqual(output, [
-      new File('src/app.js', expectedOutputContent),
-      new File('test/app.spec.ts', expectedOutputContent),
-      new File('src/components/app.jsx', expectedOutputContent),
+      new File('src/app.ts', expectedOutputContent),
+      new File('test/app-test.ts', expectedOutputContent),
       new File('src/components/app.tsx', expectedOutputContent),
-      new File('src/components/app.cjs', expectedOutputContent),
-      new File('src/components/app.mjs', expectedOutputContent),
     ]);
   });
 


### PR DESCRIPTION
__updated:__

## Proposed changes

- simplify & cleanup the extension matching pattern
- only update TypeScript sources
- skip update of `**/*.spec.ts*` & `**/*.test.ts*`
- remove the `eslint-disable ` line
- update test cases

## Motivation

- Coming from issue #2403, I started thinking that the sandbox updates are only needed to work around the issues between the mutator and TypeScript.
- I think it should be possible to skip test files, which should be straightforward for projects that use `*.spec.{js|ts}*` or `*.test.{js|ts}*`.
- I am also assuming that a smart Stryker configuration would *not* run a lint step during mutation testing.
- I tried something more elaborate in PR #2405, but it does not look practical without some more updates.

## Additional notes

This proposal does not skip test files in a `test`, `tests`, or `__tests__` directory if they do not use the standard `*.spec.{js|ts}*` or `*.test.{js|ts}*` naming conventions, in <https://github.com/facebook/react> for example. But this should not even be an issue with React, which is in JavaScript, if we would only update the TypeScript sources.

To skip the test files without these standard naming conventions would involve a bit more work. I am not so sure this would be worthwhile, maybe better to have TypeScript users switch to these standard naming conventions if needed for the test files.

---

I am proposing several improvements together, and would be happy to back some of the changes if needed.