### PR TITLE
improve & focus sandbox preprocessing options

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -188,7 +188,7 @@
             "type": "string"
           },
           "default": {
-            "**/*.{ts,tsx}": "/* eslint-disable */\n// @ts-nocheck\n"
+            "**/*.{ts,tsx}": "// @ts-nocheck\n"
           }
         },
         "removeComments": {

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -168,6 +168,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "ignorePatterns": {
+          "description": "Ignore these patterns when preprocessing the sandbox files",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/__tests__/**/*+(.js|.ts|.cjs|.mjs)?(x)",
+            "**/?(*.)+(spec|test)+(.js|.ts|.cjs|.mjs)?(x)",
+            "**/*+(Spec|Test)+(.js|.ts|.cjs|.mjs)?(x)"
+          ]
+        },
         "fileHeaders": {
           "type": "object",
           "title": "SandboxFileHeaders",

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -180,7 +180,7 @@
             "**/*+(Spec|Test)+(.js|.ts|.cjs|.mjs)?(x)"
           ]
         },
-        "fileHeaders": {
+        "addHeaders": {
           "type": "object",
           "title": "SandboxFileHeaders",
           "description": "Configure additional headers to be added to files inside your sandbox. These headers will be added after Stryker has instrumented your code with mutants, but before a test runner or build command is executed. This is used to ignore typescript compile errors and eslint warnings that might have been added in the process of instrumenting your code with mutants. The default setting should work for most use cases.",

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -191,7 +191,7 @@
             "**/*+(.js|.ts|.cjs|.mjs)?(x)": "/* eslint-disable */\n// @ts-nocheck\n"
           }
         },
-        "stripComments": {
+        "removeComments": {
           "description": "Configure files to be stripped of comments (either single line with `//` or multi line with `/**/`. These comments will be stripped after Stryker has instrumented your code with mutants, but before a test runner or build command is executed. This is used to remove any lingering `// @ts-check` or `// @ts-expect-error` comments that interfere with typescript compilation. The default setting allows comments to be stripped from all JavaScript and friend files in your sandbox, you can specify a different glob expression or set it to `false` to completely disable this behavior.",
           "anyOf": [
             {

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -175,9 +175,9 @@
             "type": "string"
           },
           "default": [
-            "**/__tests__/**/*+(.js|.ts|.cjs|.mjs)?(x)",
-            "**/?(*.)+(spec|test)+(.js|.ts|.cjs|.mjs)?(x)",
-            "**/*+(Spec|Test)+(.js|.ts|.cjs|.mjs)?(x)"
+            "**/__tests__/**/*.{js,ts,cjs,mjs}?(x)",
+            "**/*.{spec,test}.{js,ts,cjs,mjs}?(x)",
+            "**/*{Spec,Test}.{js,ts,cjs,mjs}?(x)"
           ]
         },
         "addHeaders": {
@@ -188,7 +188,7 @@
             "type": "string"
           },
           "default": {
-            "**/*+(.js|.ts|.cjs|.mjs)?(x)": "/* eslint-disable */\n// @ts-nocheck\n"
+            "**/*.{js,ts,cjs,mjs}?(x)": "/* eslint-disable */\n// @ts-nocheck\n"
           }
         },
         "removeComments": {
@@ -203,7 +203,7 @@
               "type": "string"
             }
           ],
-          "default": "**/*+(.js|.ts|.cjs|.mjs)?(x)"
+          "default": "**/*.{js,ts,cjs,mjs}?(x)"
         }
       }
     },

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -175,9 +175,9 @@
             "type": "string"
           },
           "default": [
-            "**/__tests__/**/*.{js,ts,cjs,mjs}?(x)",
-            "**/*.{spec,test}.{js,ts,cjs,mjs}?(x)",
-            "**/*{Spec,Test}.{js,ts,cjs,mjs}?(x)"
+            "**/__tests__/**/*.{ts,tsx}",
+            "**/*.{spec,test}.{ts,tsx}",
+            "**/*{Spec,Test}.{ts,tsx}"
           ]
         },
         "addHeaders": {
@@ -188,7 +188,7 @@
             "type": "string"
           },
           "default": {
-            "**/*.{js,ts,cjs,mjs}?(x)": "/* eslint-disable */\n// @ts-nocheck\n"
+            "**/*.{ts,tsx}": "/* eslint-disable */\n// @ts-nocheck\n"
           }
         },
         "removeComments": {
@@ -203,7 +203,7 @@
               "type": "string"
             }
           ],
-          "default": "**/*.{js,ts,cjs,mjs}?(x)"
+          "default": "**/*.{ts,tsx}"
         }
       }
     },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -298,7 +298,7 @@ The `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io,
 <a name="sandbox.ignorePatterns"></a>
 ### `sandbox.ignorePatterns` [`string[]`]
 
-Default: `['**/__tests__/**/*+(.js|.ts|.cjs|.mjs)?(x)', '**/?(*.)+(spec|test)+(.js|.ts|.cjs|.mjs)?(x)', '**/*+(Spec|Test)+(.js|.ts|.cjs|.mjs)?(x)']`
+Default: `['**/__tests__/**/*.{js,ts,cjs,mjs}?(x)', '**/*.{spec,test}.{js,ts,cjs,mjs}?(x)', '**/*{Spec,Test}.{js,ts,cjs,mjs}?(x)']`
 Command line: *none*
 Config file: `sandbox.ignorePatterns: ['src/**/*.js', 'a.js']`
 
@@ -307,7 +307,7 @@ Configure patterns to be ignored by the `sandbox` options below.
 <a name="sandbox.addHeaders"></a>
 ### `sandbox.addHeaders` [`object`]
 
-Default: `{ "**/*+(.js|.ts|.cjs|.mjs)?(x)": "/* eslint-disable */\n// @ts-nocheck\n" }`
+Default: `{ "**/*.{js,ts,cjs,mjs}?(x)": "/* eslint-disable */\n// @ts-nocheck\n" }`
 Command line: *none*
 Config file: `sandbox: { addHeaders: {} }`
 
@@ -320,7 +320,7 @@ The key here is a [glob expression](https://globster.xyz/), where the value poin
 <a name="sandbox.stripComments"></a>
 ### `sandbox.stripComments` [`false` | `string`]
 
-Default: `"**/*+(.js|.ts|.cjs|.mjs)?(x)"`
+Default: `"**/*.{js,ts,cjs,mjs}?(x)"`
 Command line: *none*
 Config file: `sandbox: { stripComments: "" }`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,6 +113,7 @@ You can *ignore* files by adding an exclamation mark (`!`) at the start of an ex
 * [mutator](#mutator)
 * [plugins](#plugins)
 * [reporters](#reporters)
+* [sandbox.ignore](#sandbox.ignore)
 * [sandbox.fileHeaders](#sandbox.fileHeaders)
 * [sandbox.stripComments](#sandbox.stripComments)
 * [symlinkNodeModules](#symlinkNodeModules)
@@ -293,6 +294,15 @@ The `clear-text` reporter supports three additional config options:
 * `maxTestsToLog` to show more tests that were executed to kill a mutant when `logTests` is true. The config for your config file is: `clearTextReporter: { logTests: true, maxTestsToLog: 7 },`
 
 The `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a mutation score badge to your readme, as well as hosting your html report on the dashboard. It uses the [dashboard.*](#dashboard) configuration options. See [the Stryker handbook](https://github.com/stryker-mutator/stryker-handbook/blob/master/dashboard.md) for more info.
+
+<a name="sandbox.ignorePatterns"></a>
+### `sandbox.ignorePatterns` [`string[]`]
+
+Default: `['**/__tests__/**/*+(.js|.ts|.cjs|.mjs)?(x)', '**/?(*.)+(spec|test)+(.js|.ts|.cjs|.mjs)?(x)', '**/*+(Spec|Test)+(.js|.ts|.cjs|.mjs)?(x)']`
+Command line: *none*
+Config file: `sandbox.ignorePatterns: ['src/**/*.js', 'a.js']`
+
+Configure patterns to be ignored by the `sandbox` options below.
 
 <a name="sandbox.fileHeaders"></a>
 ### `sandbox.fileHeaders` [`object`]

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -307,7 +307,7 @@ Configure patterns to be ignored by the `sandbox` options below.
 <a name="sandbox.addHeaders"></a>
 ### `sandbox.addHeaders` [`object`]
 
-Default: `{ "**/*.{ts,tsx}": "/* eslint-disable */\n// @ts-nocheck\n" }`
+Default: `{ "**/*.{ts,tsx}": "// @ts-nocheck\n" }`
 Command line: *none*
 Config file: `sandbox: { addHeaders: {} }`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -298,7 +298,7 @@ The `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io,
 <a name="sandbox.ignorePatterns"></a>
 ### `sandbox.ignorePatterns` [`string[]`]
 
-Default: `['**/__tests__/**/*.{js,ts,cjs,mjs}?(x)', '**/*.{spec,test}.{js,ts,cjs,mjs}?(x)', '**/*{Spec,Test}.{js,ts,cjs,mjs}?(x)']`
+Default: `['**/__tests__/**/*.{ts,tsx}', '**/*.{spec,test}.{ts,tsx}', '**/*{Spec,Test}.{ts,tsx}']`
 Command line: *none*
 Config file: `sandbox.ignorePatterns: ['src/**/*.js', 'a.js']`
 
@@ -307,7 +307,7 @@ Configure patterns to be ignored by the `sandbox` options below.
 <a name="sandbox.addHeaders"></a>
 ### `sandbox.addHeaders` [`object`]
 
-Default: `{ "**/*.{js,ts,cjs,mjs}?(x)": "/* eslint-disable */\n// @ts-nocheck\n" }`
+Default: `{ "**/*.{ts,tsx}": "/* eslint-disable */\n// @ts-nocheck\n" }`
 Command line: *none*
 Config file: `sandbox: { addHeaders: {} }`
 
@@ -320,7 +320,7 @@ The key here is a [glob expression](https://globster.xyz/), where the value poin
 <a name="sandbox.stripComments"></a>
 ### `sandbox.stripComments` [`false` | `string`]
 
-Default: `"**/*.{js,ts,cjs,mjs}?(x)"`
+Default: `"**/*.{ts,tsx}"`
 Command line: *none*
 Config file: `sandbox: { stripComments: "" }`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -114,7 +114,7 @@ You can *ignore* files by adding an exclamation mark (`!`) at the start of an ex
 * [plugins](#plugins)
 * [reporters](#reporters)
 * [sandbox.ignore](#sandbox.ignore)
-* [sandbox.fileHeaders](#sandbox.fileHeaders)
+* [sandbox.addHeaders](#sandbox.addHeaders)
 * [sandbox.stripComments](#sandbox.stripComments)
 * [symlinkNodeModules](#symlinkNodeModules)
 * [tempDirName](#tempDirName)
@@ -304,12 +304,12 @@ Config file: `sandbox.ignorePatterns: ['src/**/*.js', 'a.js']`
 
 Configure patterns to be ignored by the `sandbox` options below.
 
-<a name="sandbox.fileHeaders"></a>
-### `sandbox.fileHeaders` [`object`]
+<a name="sandbox.addHeaders"></a>
+### `sandbox.addHeaders` [`object`]
 
 Default: `{ "**/*+(.js|.ts|.cjs|.mjs)?(x)": "/* eslint-disable */\n// @ts-nocheck\n" }`
 Command line: *none*
-Config file: `sandbox: { fileHeaders: {} }`
+Config file: `sandbox: { addHeaders: {} }`
 
 Configure additional headers to be added to files inside your sandbox. These headers will be added after Stryker has instrumented your code with mutants, but before a test runner or build command is executed. This is be used to ignore typescript compile errors and eslint warnings that might have been added in the process of instrumenting your code. 
 

--- a/packages/core/src/sandbox/file-header-preprocessor.ts
+++ b/packages/core/src/sandbox/file-header-preprocessor.ts
@@ -16,6 +16,7 @@ export class FileHeaderPreprocessor implements FilePreprocessor {
 
   public async preprocess(files: File[]): Promise<File[]> {
     return files.map((file) => {
+      if (this.options.sandbox.ignorePatterns.some((pattern) => minimatch(path.resolve(file.name), path.resolve(pattern)))) return file;
       Object.entries(this.options.sandbox.fileHeaders).forEach(([pattern, header]) => {
         if (minimatch(path.resolve(file.name), path.resolve(pattern))) {
           file = new File(file.name, `${header}${file.textContent}`);

--- a/packages/core/src/sandbox/file-header-preprocessor.ts
+++ b/packages/core/src/sandbox/file-header-preprocessor.ts
@@ -17,7 +17,7 @@ export class FileHeaderPreprocessor implements FilePreprocessor {
   public async preprocess(files: File[]): Promise<File[]> {
     return files.map((file) => {
       if (this.options.sandbox.ignorePatterns.some((pattern) => minimatch(path.resolve(file.name), path.resolve(pattern)))) return file;
-      Object.entries(this.options.sandbox.fileHeaders).forEach(([pattern, header]) => {
+      Object.entries(this.options.sandbox.addHeaders).forEach(([pattern, header]) => {
         if (minimatch(path.resolve(file.name), path.resolve(pattern))) {
           file = new File(file.name, `${header}${file.textContent}`);
         }

--- a/packages/core/src/sandbox/strip-comments-preprocessor.ts
+++ b/packages/core/src/sandbox/strip-comments-preprocessor.ts
@@ -1,7 +1,7 @@
 import path = require('path');
 
 import { File, StrykerOptions } from '@stryker-mutator/api/core';
-import stripComments = require('strip-comments');
+import removeComments = require('strip-comments');
 import minimatch = require('minimatch');
 import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
 
@@ -17,13 +17,13 @@ export class StripCommentsPreprocessor implements FilePreprocessor {
   constructor(private readonly options: StrykerOptions) {}
 
   public async preprocess(files: File[]): Promise<File[]> {
-    if (this.options.sandbox.stripComments === false) {
+    if (this.options.sandbox.removeComments === false) {
       return files;
     } else {
-      const pattern = path.resolve(this.options.sandbox.stripComments);
+      const pattern = path.resolve(this.options.sandbox.removeComments);
       return files.map((file) => {
         if (minimatch(path.resolve(file.name), pattern)) {
-          return new File(file.name, stripComments(file.textContent));
+          return new File(file.name, removeComments(file.textContent));
         } else {
           return file;
         }

--- a/packages/core/test/unit/sandbox/create-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/create-preprocessor.spec.ts
@@ -5,6 +5,8 @@ import { File } from '@stryker-mutator/api/core';
 
 import { FilePreprocessor, createPreprocessor } from '../../../src/sandbox';
 
+const EXPECTED_DEFAULT_HEADER = '/* eslint-disable */\n// @ts-nocheck\n';
+
 describe(createPreprocessor.name, () => {
   let sut: FilePreprocessor;
 
@@ -19,11 +21,11 @@ describe(createPreprocessor.name, () => {
 
   it('should add a header to .ts files', async () => {
     const output = await sut.preprocess([new File(path.resolve('app.ts'), 'foo.bar()')]);
-    assertions.expectTextFilesEqual(output, [new File(path.resolve('app.ts'), '/* eslint-disable */\n// @ts-nocheck\nfoo.bar()')]);
+    assertions.expectTextFilesEqual(output, [new File(path.resolve('app.ts'), `${EXPECTED_DEFAULT_HEADER}foo.bar()`)]);
   });
 
   it('should strip // @ts-expect-error (see https://github.com/stryker-mutator/stryker/issues/2364)', async () => {
     const output = await sut.preprocess([new File(path.resolve('app.ts'), '// @ts-expect-error\nfoo.bar()')]);
-    assertions.expectTextFilesEqual(output, [new File(path.resolve('app.ts'), '/* eslint-disable */\n// @ts-nocheck\n\nfoo.bar()')]);
+    assertions.expectTextFilesEqual(output, [new File(path.resolve('app.ts'), `${EXPECTED_DEFAULT_HEADER}\nfoo.bar()`)]);
   });
 });

--- a/packages/core/test/unit/sandbox/create-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/create-preprocessor.spec.ts
@@ -5,7 +5,7 @@ import { File } from '@stryker-mutator/api/core';
 
 import { FilePreprocessor, createPreprocessor } from '../../../src/sandbox';
 
-const EXPECTED_DEFAULT_HEADER = '/* eslint-disable */\n// @ts-nocheck\n';
+const EXPECTED_DEFAULT_HEADER = '// @ts-nocheck\n';
 
 describe(createPreprocessor.name, () => {
   let sut: FilePreprocessor;

--- a/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
@@ -67,7 +67,7 @@ describe(FileHeaderPreprocessor.name, () => {
   it('should also match a full file name', async () => {
     // Arrange
     const input = [new File(path.resolve('src', 'app.ts'), 'foo.bar()')];
-    testInjector.options.sandbox.fileHeaders = {
+    testInjector.options.sandbox.addHeaders = {
       ['+(src|test)/**/*+(.js|.ts)?(x)']: '// @ts-nocheck\n',
     };
 
@@ -84,7 +84,7 @@ describe(FileHeaderPreprocessor.name, () => {
       new File(path.resolve('src', 'app.ts'), 'foo.bar()'),
       new File(path.resolve('testResources', 'app.ts'), '// test file example that should be ignored'),
     ];
-    testInjector.options.sandbox.fileHeaders = {
+    testInjector.options.sandbox.addHeaders = {
       ['+(src|test)/**/*+(.js|.ts)?(x)']: '// @ts-nocheck\n',
     };
 
@@ -101,7 +101,7 @@ describe(FileHeaderPreprocessor.name, () => {
   it('should allow multiple headers', async () => {
     // Arrange
     const input = [new File('src/app.ts', 'foo.bar()'), new File('src/components/app.component.js', 'baz.qux()')];
-    testInjector.options.sandbox.fileHeaders = {
+    testInjector.options.sandbox.addHeaders = {
       ['**/*.ts']: '// @ts-nocheck\n',
       ['**/*.js']: '/* eslint-disable */\n',
     };

--- a/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
@@ -13,54 +13,62 @@ describe(FileHeaderPreprocessor.name, () => {
     sut = testInjector.injector.injectClass(FileHeaderPreprocessor);
   });
 
-  it('should preprocess any non-ignored js or friend files by default', async () => {
+  it('should preprocess any non-ignored ts and tsx files by default', async () => {
     const inputContent = 'foo.bar()';
     const expectedOutputContent = `${EXPECTED_DEFAULT_HEADER}foo.bar()`;
     const input = [
-      new File('src/app.js', inputContent),
       new File('src/app.ts', inputContent),
-      new File('src/components/app.jsx', inputContent),
+      new File('src/app.tsx', inputContent),
+      new File('src/components/app.ts', inputContent),
       new File('src/components/app.tsx', inputContent),
-      new File('src/components/app.cjs', inputContent),
-      new File('src/components/app.mjs', inputContent),
     ];
     const output = await sut.preprocess(input);
 
     assertions.expectTextFilesEqual(output, [
-      new File('src/app.js', expectedOutputContent),
       new File('src/app.ts', expectedOutputContent),
-      new File('src/components/app.jsx', expectedOutputContent),
+      new File('src/app.tsx', expectedOutputContent),
+      new File('src/components/app.ts', expectedOutputContent),
       new File('src/components/app.tsx', expectedOutputContent),
-      new File('src/components/app.cjs', expectedOutputContent),
-      new File('src/components/app.mjs', expectedOutputContent),
     ]);
   });
 
-  it('should not change any ignored test js or friend files by default', async () => {
+  it('should not change any ignored test ts or tsx files by default', async () => {
     const inputContent = 'expect(true)';
 
     const input = [
-      new File('src/app.spec.js', inputContent),
       new File('src/app.spec.ts', inputContent),
-      new File('src/components/app.spec.jsx', inputContent),
       new File('src/components/app.spec.tsx', inputContent),
-      new File('src/components/app.spec.cjs', inputContent),
-      new File('src/components/app.spec.mjs', inputContent),
-      new File('src/components/appSpec.jsx', inputContent),
-      new File('src/__tests__/app.js', inputContent),
+      new File('src/components/appSpec.ts', inputContent),
+      new File('src/__tests__/app.ts', inputContent),
     ];
 
     const output = await sut.preprocess(input);
 
     assertions.expectTextFilesEqual(output, [
-      new File('src/app.spec.js', inputContent),
       new File('src/app.spec.ts', inputContent),
-      new File('src/components/app.spec.jsx', inputContent),
       new File('src/components/app.spec.tsx', inputContent),
-      new File('src/components/app.spec.cjs', inputContent),
-      new File('src/components/app.spec.mjs', inputContent),
-      new File('src/components/appSpec.jsx', inputContent),
-      new File('src/__tests__/app.js', inputContent),
+      new File('src/components/appSpec.ts', inputContent),
+      new File('src/__tests__/app.ts', inputContent),
+    ]);
+  });
+
+  it('should not preprocess any js or friend js files by default', async () => {
+    const inputContent = 'foo.bar()';
+
+    const input = [
+      new File('src/app.js', inputContent),
+      new File('src/components/app.jsx', inputContent),
+      new File('src/components/app.cjs', inputContent),
+      new File('src/components/app.mjs', inputContent),
+    ];
+
+    const output = await sut.preprocess(input);
+
+    assertions.expectTextFilesEqual(output, [
+      new File('src/app.js', inputContent),
+      new File('src/components/app.jsx', inputContent),
+      new File('src/components/app.cjs', inputContent),
+      new File('src/components/app.mjs', inputContent),
     ]);
   });
 

--- a/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
@@ -13,12 +13,12 @@ describe(FileHeaderPreprocessor.name, () => {
     sut = testInjector.injector.injectClass(FileHeaderPreprocessor);
   });
 
-  it('should add preprocess any js or friend file by default', async () => {
+  it('should preprocess any non-ignored js or friend files by default', async () => {
     const inputContent = 'foo.bar()';
     const expectedOutputContent = `${EXPECTED_DEFAULT_HEADER}foo.bar()`;
     const input = [
       new File('src/app.js', inputContent),
-      new File('test/app.spec.ts', inputContent),
+      new File('src/app.ts', inputContent),
       new File('src/components/app.jsx', inputContent),
       new File('src/components/app.tsx', inputContent),
       new File('src/components/app.cjs', inputContent),
@@ -28,11 +28,39 @@ describe(FileHeaderPreprocessor.name, () => {
 
     assertions.expectTextFilesEqual(output, [
       new File('src/app.js', expectedOutputContent),
-      new File('test/app.spec.ts', expectedOutputContent),
+      new File('src/app.ts', expectedOutputContent),
       new File('src/components/app.jsx', expectedOutputContent),
       new File('src/components/app.tsx', expectedOutputContent),
       new File('src/components/app.cjs', expectedOutputContent),
       new File('src/components/app.mjs', expectedOutputContent),
+    ]);
+  });
+
+  it('should not change any ignored test js or friend files by default', async () => {
+    const inputContent = 'expect(true)';
+
+    const input = [
+      new File('src/app.spec.js', inputContent),
+      new File('src/app.spec.ts', inputContent),
+      new File('src/components/app.spec.jsx', inputContent),
+      new File('src/components/app.spec.tsx', inputContent),
+      new File('src/components/app.spec.cjs', inputContent),
+      new File('src/components/app.spec.mjs', inputContent),
+      new File('src/components/appSpec.jsx', inputContent),
+      new File('src/__tests__/app.js', inputContent),
+    ];
+
+    const output = await sut.preprocess(input);
+
+    assertions.expectTextFilesEqual(output, [
+      new File('src/app.spec.js', inputContent),
+      new File('src/app.spec.ts', inputContent),
+      new File('src/components/app.spec.jsx', inputContent),
+      new File('src/components/app.spec.tsx', inputContent),
+      new File('src/components/app.spec.cjs', inputContent),
+      new File('src/components/app.spec.mjs', inputContent),
+      new File('src/components/appSpec.jsx', inputContent),
+      new File('src/__tests__/app.js', inputContent),
     ]);
   });
 

--- a/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/file-header-preprocessor.spec.ts
@@ -5,7 +5,7 @@ import { File } from '@stryker-mutator/api/core';
 
 import { FileHeaderPreprocessor } from '../../../src/sandbox/file-header-preprocessor';
 
-const EXPECTED_DEFAULT_HEADER = '/* eslint-disable */\n// @ts-nocheck\n';
+const EXPECTED_DEFAULT_HEADER = '// @ts-nocheck\n';
 
 describe(FileHeaderPreprocessor.name, () => {
   let sut: FileHeaderPreprocessor;

--- a/packages/core/test/unit/sandbox/strip-comments-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/strip-comments-preprocessor.spec.ts
@@ -26,13 +26,13 @@ describe(StripCommentsPreprocessor.name, () => {
     assertions.expectTextFilesEqual(output, [new File(path.resolve('src/app.ts'), 'foo.bar("// @ts-expect-error");')]);
   });
 
-  it('should only strip comments in that match the "sandbox.stripComments" glob expression', async () => {
+  it('should only strip comments in that match the "sandbox.removeComments" glob expression', async () => {
     const input = [
       new File(path.resolve('src/app.ts'), '// @ts-expect-error\nfoo.bar();'),
       new File(path.resolve('test/app.spec.ts'), '/* @ts-expect-error */\nfoo.bar();'),
       new File(path.resolve('testResources/project/app.ts'), '/* @ts-expect-error */\nfoo.bar();'),
     ];
-    testInjector.options.sandbox.stripComments = '+(src|test)/**/*.ts';
+    testInjector.options.sandbox.removeComments = '+(src|test)/**/*.ts';
     const output = await sut.preprocess(input);
     assertions.expectTextFilesEqual(output, [
       new File(path.resolve('src/app.ts'), '\nfoo.bar();'),
@@ -41,13 +41,13 @@ describe(StripCommentsPreprocessor.name, () => {
     ]);
   });
 
-  it('should not strip comments if "sandbox.stripComments" is set to `false`', async () => {
+  it('should not strip comments if "sandbox.removeComments" is set to `false`', async () => {
     const input = [
       new File(path.resolve('src/app.ts'), '// @ts-expect-error\nfoo.bar();'),
       new File(path.resolve('test/app.spec.ts'), '/* @ts-expect-error */\nfoo.bar();'),
       new File(path.resolve('testResources/project/app.ts'), '/* @ts-expect-error */\nfoo.bar();'),
     ];
-    testInjector.options.sandbox.stripComments = false;
+    testInjector.options.sandbox.removeComments = false;
     const output = await sut.preprocess(input);
     expect(output).eq(input);
   });


### PR DESCRIPTION
- add `sandbox.ignorePatterns` functionality to sandbox preprocessing, ignores test files & `__tests__` directory by default
- rename sandbox.fileHeaders -> sandbox.addHeaders, for consistency (all verbs)
- rename sandbox.stripComments -> sandbox.removeComments (bikeshedding)
- simplify default sandbox file patterns
- limit default sandbox preprocessing to ts & tsx files
- remove eslint-disable line from default sandbox.addHeaders - I think that smart Stryker configuration would not run eslint during mutation testing

This proposal was triggered by my investigation of __#2403__. I tried a couple other ideas but they are probably not worth considering.

It is very opinionated to the point of bikeshedding, but I broke the changes into individual commits. We should be able to revert or remove any changes not wanted in this proposal.

We may want to rename a few modules if we rename the options like I proposed, which should be pretty trivial.