### PR TITLE
fix(input files): support emojis in file names

### DIFF
--- a/e2e/test/mocha-javascript/package.json
+++ b/e2e/test/mocha-javascript/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "pretest": "rimraf \"reports\"",
     "test": "stryker run",
+    "test:unit": "mocha",
     "posttest": "mocha --no-config --require ../../tasks/ts-node-register.js verify/*.ts"
   },
   "author": "",

--- a/e2e/test/mocha-javascript/src/🐱‍👓ninja.cat.js
+++ b/e2e/test/mocha-javascript/src/🐱‍👓ninja.cat.js
@@ -1,0 +1,4 @@
+
+module.exports = function ninjaCatSays(toSay) {
+  return `🐱‍👓 ${toSay}`;
+}

--- a/e2e/test/mocha-javascript/test/unit/ninjaCat.spec.js
+++ b/e2e/test/mocha-javascript/test/unit/ninjaCat.spec.js
@@ -1,0 +1,10 @@
+const ninjaCatSays = require('../../src/🐱‍👓ninja.cat');
+const { expect } = require('chai');
+
+describe('🐱‍👓', () => {
+  describe('ninjaCatSays', () => {
+    it('should speak', () => {
+      expect(ninjaCatSays('ATTACK!')).eq('🐱‍👓 ATTACK!')
+    });
+  });
+});

--- a/e2e/test/mocha-javascript/verify/verify.ts
+++ b/e2e/test/mocha-javascript/verify/verify.ts
@@ -10,16 +10,17 @@ describe('Verify stryker has ran correctly', () => {
 
   it('should report correct score', async () => {
     await expectMetricsResult({
+      
       metrics: produceMetrics({
-        killed: 16,
-        mutationScore: 64,
-        mutationScoreBasedOnCoveredCode: 64,
+        killed: 18,
+        mutationScore: 66.67,
+        mutationScoreBasedOnCoveredCode: 66.67,
         survived: 9,
-        totalCovered: 25,
-        totalDetected: 16,
-        totalMutants: 25,
+        totalCovered: 27,
+        totalDetected: 18,
+        totalMutants: 27,
         totalUndetected: 9,
-        totalValid: 25
+        totalValid: 27
       })
     });
   });

--- a/packages/test-helpers/src/assertions.ts
+++ b/packages/test-helpers/src/assertions.ts
@@ -49,7 +49,7 @@ export function expectTextFileEqual(actual: File, expected: File) {
   expect(fileToJson(actual)).deep.eq(fileToJson(expected));
 }
 
-export function expectTextFilesEqual(actual: File[], expected: File[]) {
+export function expectTextFilesEqual(actual: readonly File[], expected: readonly File[]) {
   expect(actual.map(fileToJson)).deep.eq(expected.map(fileToJson));
 }
 


### PR DESCRIPTION
Support emojis and other encoded characters in file names when using `git ls-files`.

Fixes #2418 