### PR TITLE
Fix/cache clean mem leak

### DIFF
--- a/packages/jasmine-runner/.mocharc.jsonc
+++ b/packages/jasmine-runner/.mocharc.jsonc
@@ -3,5 +3,6 @@
     "test/unit/**/*.js",
     "test/integration/**/*.js"
   ],
-  "file": "test/helpers/setupTests.js"
+  "file": "test/helpers/setupTests.js",
+  "timeout": 10000
 }

--- a/packages/jasmine-runner/src/JasmineTestRunner.ts
+++ b/packages/jasmine-runner/src/JasmineTestRunner.ts
@@ -26,7 +26,7 @@ export function createJasmineTestRunner(injector: Injector<PluginContext>) {
   return injector.provideClass(pluginTokens.directoryRequireCache, DirectoryRequireCache).injectClass(JasmineTestRunner);
 }
 
-export default class JasmineTestRunner implements TestRunner2 {
+export class JasmineTestRunner implements TestRunner2 {
   private readonly jasmineConfigFile: string | undefined;
   private readonly Date: typeof Date = Date; // take Date prototype now we still can (user might choose to mock it away)
 
@@ -43,6 +43,10 @@ export default class JasmineTestRunner implements TestRunner2 {
     global.__activeMutant__ = options.activeMutant.id;
     const runResult = await this.run(options.testFilter);
     return toMutantRunResult(runResult);
+  }
+
+  public async init(): Promise<void> {
+    this.requireCache.init({ rootModuleId: require.resolve('jasmine'), initFiles: [] });
   }
 
   public async dispose(): Promise<void> {
@@ -97,7 +101,7 @@ export default class JasmineTestRunner implements TestRunner2 {
   private createJasmineRunner(testFilter: undefined | string[]) {
     let specFilter: undefined | ((spec: jasmine.Spec) => boolean) = undefined;
     if (testFilter) {
-      specFilter = (spec: jasmine.Spec) => testFilter.includes(spec.id.toString());
+      specFilter = (spec) => testFilter.includes(spec.id.toString());
     }
     const jasmine = new Jasmine({ projectBaseDir: process.cwd() });
     // The `loadConfigFile` will fallback on the default

--- a/packages/jasmine-runner/src/index.ts
+++ b/packages/jasmine-runner/src/index.ts
@@ -2,8 +2,8 @@ import { declareFactoryPlugin, PluginKind } from '@stryker-mutator/api/plugin';
 
 import * as strykerValidationSchema from '../schema/jasmine-runner-options.json';
 
-import { createJasmineTestRunner } from './JasmineTestRunner';
+import { JasmineTestRunner, createJasmineTestRunner } from './JasmineTestRunner';
 
 export const strykerPlugins = [declareFactoryPlugin(PluginKind.TestRunner2, 'jasmine', createJasmineTestRunner)];
 
-export { strykerValidationSchema };
+export { strykerValidationSchema, JasmineTestRunner, createJasmineTestRunner };

--- a/packages/jasmine-runner/test/integration/JasmineRunner.it.spec.ts
+++ b/packages/jasmine-runner/test/integration/JasmineRunner.it.spec.ts
@@ -4,7 +4,7 @@ import { factory, assertions, testInjector } from '@stryker-mutator/test-helpers
 import { expect } from 'chai';
 import { TestStatus } from '@stryker-mutator/api/test_runner';
 
-import JasmineTestRunner, { createJasmineTestRunner } from '../../src/JasmineTestRunner';
+import { JasmineTestRunner, createJasmineTestRunner } from '../../src/JasmineTestRunner';
 import { expectTestResultsToEqual } from '../helpers/assertions';
 
 import { jasmineInitSuccessResults } from './helpers';
@@ -18,10 +18,11 @@ describe('JasmineRunner integration', () => {
   });
 
   describe('using the jasmine-init project', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       process.chdir(path.resolve(__dirname, '../../testResources/jasmine-init'));
       testInjector.options.jasmineConfigFile = 'spec/support/jasmine.json';
       sut = testInjector.injector.injectFunction(createJasmineTestRunner);
+      await sut.init();
     });
 
     it('should run the specs', async () => {
@@ -84,9 +85,10 @@ describe('JasmineRunner integration', () => {
   });
 
   describe('using a jasmine-project with errors', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       process.chdir(path.resolve(__dirname, '../../testResources/errors'));
       sut = testInjector.injector.injectFunction(createJasmineTestRunner);
+      await sut.init();
     });
 
     it('should be able to tell the error', async () => {
@@ -99,9 +101,10 @@ describe('JasmineRunner integration', () => {
   });
 
   describe('when it includes failed tests', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       process.chdir(path.resolve(__dirname, '../../testResources/test-failures'));
       sut = testInjector.injector.injectFunction(createJasmineTestRunner);
+      await sut.init();
     });
 
     it('should complete with one test failure', async () => {

--- a/packages/jasmine-runner/test/integration/MemoryLeak.it.spec.ts
+++ b/packages/jasmine-runner/test/integration/MemoryLeak.it.spec.ts
@@ -1,0 +1,18 @@
+import path = require('path');
+
+import execa = require('execa');
+
+import { expect } from 'chai';
+
+import { JasmineTestRunner } from '../../src';
+
+describe(JasmineTestRunner.name, () => {
+  it('should not leak memory when running multiple times (#2461)', async () => {
+    const childProcess = await execa.node(path.resolve(__dirname, 'MemoryLeak.worker.js'), [], {
+      stdio: 'pipe',
+      nodeOptions: ['--max-old-space-size=32', '--max-semi-space-size=1'],
+    });
+    expect(childProcess.exitCode).eq(0);
+    expect(childProcess.stdout).contains('Iterator count 1');
+  });
+});

--- a/packages/jasmine-runner/test/integration/MemoryLeak.worker.ts
+++ b/packages/jasmine-runner/test/integration/MemoryLeak.worker.ts
@@ -1,0 +1,44 @@
+import path = require('path');
+
+import { testInjector } from '@stryker-mutator/test-helpers';
+
+import { expect } from 'chai';
+import { DryRunStatus, TestStatus } from '@stryker-mutator/api/test_runner';
+
+import { createJasmineTestRunner } from '../../src';
+
+/**
+ * This file will run the mocha runner a number of times in a test suite that is designed
+ * to result in an OutOfMemory error when the mocha test runner does not clean it's memory
+ * Start this process with `--max-old-space-size=32 --max-semi-space-size=1` to get a fast OutOfMemory error (if there is a memory leak)
+ *
+ * @see https://github.com/stryker-mutator/stryker/issues/2461
+ * @see https://nodejs.org/api/modules.html#modules_accessing_the_main_module
+ * @see https://stackoverflow.com/questions/30252905/nodejs-decrease-v8-garbage-collector-memory-usage
+ */
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}
+
+async function main() {
+  process.chdir(path.resolve(__dirname, '..', '..', 'testResources', 'big-project'));
+  const jasmineRunner = testInjector.injector.injectFunction(createJasmineTestRunner);
+  await jasmineRunner.init();
+  await doDryRun();
+
+  async function doDryRun(n = 20) {
+    if (n > 0) {
+      console.log(`Iterator count ${n}`);
+      const result = await jasmineRunner.dryRun({ coverageAnalysis: 'off', timeout: 3000 });
+      if (result.status === DryRunStatus.Complete) {
+        expect(result.tests).lengthOf(1);
+        expect(result.tests[0].status).eq(TestStatus.Success);
+      }
+      await doDryRun(n - 1);
+    }
+  }
+}

--- a/packages/jasmine-runner/test/integration/jasmine-init-instrumented.it.spec.ts
+++ b/packages/jasmine-runner/test/integration/jasmine-init-instrumented.it.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { MutantRunStatus } from '@stryker-mutator/api/test_runner';
 import { assertions } from '@stryker-mutator/test-helpers';
 
-import JasmineTestRunner, { createJasmineTestRunner } from '../../src/JasmineTestRunner';
+import { JasmineTestRunner, createJasmineTestRunner } from '../../src';
 
 describe('JasmineRunner integration with code instrumentation', () => {
   let sut: JasmineTestRunner;

--- a/packages/jasmine-runner/test/unit/JasmineTestRunner.spec.ts
+++ b/packages/jasmine-runner/test/unit/JasmineTestRunner.spec.ts
@@ -8,7 +8,7 @@ import { DirectoryRequireCache } from '@stryker-mutator/util';
 
 import * as helpers from '../../src/helpers';
 import * as pluginTokens from '../../src/pluginTokens';
-import JasmineTestRunner from '../../src/JasmineTestRunner';
+import { JasmineTestRunner } from '../../src';
 import { expectTestResultsToEqual } from '../helpers/assertions';
 import { createEnvStub, createRunDetails, createCustomReporterResult } from '../helpers/mockFactories';
 
@@ -30,6 +30,13 @@ describe(JasmineTestRunner.name, () => {
     jasmineEnvStub.addReporter.callsFake((rep: jasmine.CustomReporter) => (reporter = rep));
     testInjector.options.jasmineConfigFile = 'jasmineConfFile';
     sut = testInjector.injector.provideValue(pluginTokens.directoryRequireCache, directoryRequireCacheMock).injectClass(JasmineTestRunner);
+  });
+
+  describe('init', () => {
+    it('should initialize the require cache', async () => {
+      await sut.init();
+      expect(directoryRequireCacheMock.init).calledWithExactly({ initFiles: [], rootModuleId: require.resolve('jasmine') });
+    });
   });
 
   describe('mutantRun', () => {

--- a/packages/jasmine-runner/testResources/big-project/lib/big-text.js
+++ b/packages/jasmine-runner/testResources/big-project/lib/big-text.js
@@ -1,0 +1,6 @@
+
+// Change the text each iteration to prevent nodejs from optimizing it into one value on the heap
+if (!global.n) {
+  global.n = 500000;
+}
+module.exports.text = new Array(global.n++).fill('i').join(',');

--- a/packages/jasmine-runner/testResources/big-project/spec/support/jasmine.json
+++ b/packages/jasmine-runner/testResources/big-project/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/packages/jasmine-runner/testResources/big-project/spec/tests/big-text.spec.js
+++ b/packages/jasmine-runner/testResources/big-project/spec/tests/big-text.spec.js
@@ -1,0 +1,9 @@
+const { text } = require('../../lib/big-text');
+
+describe('Big text', () => {
+  it('should contain i', () => {
+    if (text.indexOf('i') === -1) {
+      throw new Error();
+    }
+  });
+});

--- a/packages/mocha-runner/src/MochaTestRunner.ts
+++ b/packages/mocha-runner/src/MochaTestRunner.ts
@@ -47,7 +47,7 @@ export class MochaTestRunner implements TestRunner2 {
   public async init(): Promise<void> {
     this.mochaOptions = this.loader.load(this.options as MochaRunnerWithStrykerOptions);
     this.testFileNames = this.mochaAdapter.collectFiles(this.mochaOptions);
-    this.requireCache.init(this.testFileNames);
+    this.requireCache.init({ initFiles: this.testFileNames, rootModuleId: require.resolve('mocha/lib/mocha') });
     if (this.mochaOptions.require) {
       this.rootHooks = await this.mochaAdapter.handleRequires(this.mochaOptions.require);
     }

--- a/packages/mocha-runner/test/integration/MemoryLeak.it.spec.ts
+++ b/packages/mocha-runner/test/integration/MemoryLeak.it.spec.ts
@@ -1,0 +1,18 @@
+import path = require('path');
+
+import execa = require('execa');
+
+import { expect } from 'chai';
+
+import { MochaTestRunner } from '../../src';
+
+describe(MochaTestRunner.name, () => {
+  it('should not leak memory when running multiple times (#2461)', async () => {
+    const childProcess = await execa.node(path.resolve(__dirname, 'MemoryLeak.worker.js'), [], {
+      stdio: 'pipe',
+      nodeOptions: ['--max-old-space-size=32', '--max-semi-space-size=1'],
+    });
+    expect(childProcess.exitCode).eq(0);
+    expect(childProcess.stdout).contains('Iterator count 1');
+  });
+});

--- a/packages/mocha-runner/test/integration/MemoryLeak.worker.ts
+++ b/packages/mocha-runner/test/integration/MemoryLeak.worker.ts
@@ -1,0 +1,45 @@
+import path = require('path');
+
+import { testInjector } from '@stryker-mutator/test-helpers';
+
+import { expect } from 'chai';
+import { DryRunStatus, TestStatus } from '@stryker-mutator/api/test_runner';
+
+import { createMochaTestRunner } from '../../src';
+
+/**
+ * This file will run the mocha runner a number of times in a test suite that is designed
+ * to result in an OutOfMemory error when the mocha test runner does not clean it's memory
+ * Start this process with `--max-old-space-size=32 --max-semi-space-size=1` to get a fast OutOfMemory error (if there is a memory leak)
+ *
+ * @see https://github.com/stryker-mutator/stryker/issues/2461
+ * @see https://nodejs.org/api/modules.html#modules_accessing_the_main_module
+ * @see https://stackoverflow.com/questions/30252905/nodejs-decrease-v8-garbage-collector-memory-usage
+ */
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}
+
+async function main() {
+  process.chdir(path.resolve(__dirname, '..', '..', 'testResources', 'big-project'));
+  const mochaRunner = testInjector.injector.injectFunction(createMochaTestRunner);
+
+  await mochaRunner.init();
+  await doDryRun();
+
+  async function doDryRun(n = 20) {
+    if (n > 0) {
+      console.log(`Iterator count ${n}`);
+      const result = await mochaRunner.dryRun({ coverageAnalysis: 'off', timeout: 3000 });
+      if (result.status === DryRunStatus.Complete) {
+        expect(result.tests).lengthOf(1);
+        expect(result.tests[0].status).eq(TestStatus.Success);
+      }
+      await doDryRun(n - 1);
+    }
+  }
+}

--- a/packages/mocha-runner/test/unit/MochaTestRunner.spec.ts
+++ b/packages/mocha-runner/test/unit/MochaTestRunner.spec.ts
@@ -83,7 +83,10 @@ describe(MochaTestRunner.name, () => {
 
       await sut.init();
 
-      expect(directoryRequireCacheMock.init).calledWithExactly(expectedTestFileNames);
+      expect(directoryRequireCacheMock.init).calledWithExactly({
+        initFiles: expectedTestFileNames,
+        rootModuleId: require.resolve('mocha/lib/mocha'),
+      });
     });
 
     it('should not handle requires when there are no `requires`', async () => {

--- a/packages/mocha-runner/testResources/big-project/src/big-text.js
+++ b/packages/mocha-runner/testResources/big-project/src/big-text.js
@@ -1,0 +1,6 @@
+
+// Change the text each iteration to prevent nodejs from optimizing it into one value on the heap
+if (!global.n) {
+  global.n = 500000;
+}
+module.exports.text = new Array(global.n++).fill('i').join(',');

--- a/packages/mocha-runner/testResources/big-project/test/big-text.spec.js
+++ b/packages/mocha-runner/testResources/big-project/test/big-text.spec.js
@@ -1,0 +1,9 @@
+const { text } = require('../src/big-text');
+
+describe('Big text', () => {
+  it('should contain i', () => {
+    if (text.indexOf('i') === -1) {
+      throw new Error();
+    }
+  });
+});

--- a/packages/util/src/DirectoryRequireCache.ts
+++ b/packages/util/src/DirectoryRequireCache.ts
@@ -4,13 +4,18 @@ import path = require('path');
  * A helper class that can be used by test runners.
  * The first time you call `record`, it will fill the internal registry with the files required in the current working directory (excluding node_modules)
  * Then each time you call `clear` it will clear those files from the require cache
+ *
+ * It will also delete the `module.children` property of the root module.
+ * @see https://github.com/stryker-mutator/stryker/issues/2461
  */
 export class DirectoryRequireCache {
   private cache: Set<string>;
   private initFiles?: readonly string[];
+  private rootModuleId: string;
 
-  public init(initFiles: readonly string[]) {
+  public init({ initFiles, rootModuleId }: { initFiles: readonly string[]; rootModuleId: string }) {
     this.initFiles = initFiles;
+    this.rootModuleId = rootModuleId;
   }
 
   /**
@@ -29,6 +34,14 @@ export class DirectoryRequireCache {
 
   public clear() {
     if (this.cache) {
+      if (this.rootModuleId) {
+        const rootModule = require.cache[this.rootModuleId];
+        if (rootModule) {
+          rootModule.children = rootModule.children.filter((childModule) => !this.cache.has(childModule.id));
+        } else {
+          throw new Error(`Could not find "${this.rootModuleId}" in require cache.`);
+        }
+      }
       this.cache.forEach((fileName) => delete require.cache[fileName]);
     }
   }


### PR DESCRIPTION
Fix a memory leak that keeps required files in-memory between test runs. Properly clear the require cache by also clearing [the mocha's/jasmine's module children](https://nodejs.org/api/modules.html#modules_module_children). This makes sure the required files by mocha can be garbage collected.

Fixes #2461 