### PR TITLE
test(helpers): fix a memory leak

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - test/**
+      # - test/**
 
 jobs:
   core:

--- a/packages/test-helpers/src/TestInjector.ts
+++ b/packages/test-helpers/src/TestInjector.ts
@@ -17,13 +17,10 @@ class TestInjector {
     this.logger = factory.logger();
     this.pluginResolver = factory.pluginResolver();
     this.injector = createInjector()
-      .provideValue(commonTokens.getLogger, provideLogger)
+      .provideValue(commonTokens.getLogger, () => this.logger)
       .provideValue(commonTokens.logger, this.logger)
       .provideValue(commonTokens.options, this.options)
       .provideValue(commonTokens.pluginResolver, this.pluginResolver);
-    function provideLogger(): Logger {
-      return this.logger;
-    }
   }
 }
 

--- a/packages/test-helpers/src/TestInjector.ts
+++ b/packages/test-helpers/src/TestInjector.ts
@@ -2,34 +2,28 @@ import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, PluginContext, PluginResolver } from '@stryker-mutator/api/plugin';
 import * as sinon from 'sinon';
-import { Injector, createInjector, Scope } from 'typed-inject';
+import { Injector, createInjector } from 'typed-inject';
 
 import * as factory from './factory';
 
 class TestInjector {
-  private readonly providePluginResolver = (): PluginResolver => {
-    return this.pluginResolver;
-  };
-  private readonly provideLogger = (): Logger => {
-    return this.logger;
-  };
-  private readonly provideOptions = () => {
-    return this.options;
-  };
-
   public pluginResolver: sinon.SinonStubbedInstance<PluginResolver>;
   public options: StrykerOptions;
   public logger: sinon.SinonStubbedInstance<Logger>;
-  public injector: Injector<PluginContext> = createInjector()
-    .provideValue(commonTokens.getLogger, this.provideLogger)
-    .provideFactory(commonTokens.logger, this.provideLogger, Scope.Transient)
-    .provideFactory(commonTokens.options, this.provideOptions, Scope.Transient)
-    .provideFactory(commonTokens.pluginResolver, this.providePluginResolver, Scope.Transient);
+  public injector: Injector<PluginContext>;
 
   public reset() {
     this.options = factory.strykerOptions();
     this.logger = factory.logger();
     this.pluginResolver = factory.pluginResolver();
+    this.injector = createInjector()
+      .provideValue(commonTokens.getLogger, provideLogger)
+      .provideValue(commonTokens.logger, this.logger)
+      .provideValue(commonTokens.options, this.options)
+      .provideValue(commonTokens.pluginResolver, this.pluginResolver);
+    function provideLogger(): Logger {
+      return this.logger;
+    }
   }
 }
 


### PR DESCRIPTION
Fix a memory leak in Strykers' own tests. Reuse of the `typed-inject@3` `Injector` caused essentially every object to ever be injected to be reachable and thus not garbage collectible.

We're now recreating a new Injector for each test.

Fixes #2456