### PR TITLE
fix(instrumenter): skip `as` expressions

### DIFF
--- a/packages/instrumenter/src/util/syntax-helpers.ts
+++ b/packages/instrumenter/src/util/syntax-helpers.ts
@@ -144,6 +144,7 @@ export function isTypeAnnotation(path: NodePath): boolean {
   return (
     path.isInterfaceDeclaration() ||
     path.isTypeAnnotation() ||
+    path.isTSAsExpression() ||
     types.isTSInterfaceDeclaration(path.node) ||
     types.isTSTypeAnnotation(path.node) ||
     types.isTSTypeAliasDeclaration(path.node) ||

--- a/packages/instrumenter/test/integration/instrumenter.it.spec.ts
+++ b/packages/instrumenter/test/integration/instrumenter.it.spec.ts
@@ -46,6 +46,9 @@ describe('instrumenter integration', () => {
   it('should be able to instrument super calls', async () => {
     await arrangeAndActAssert('super-call.ts');
   });
+  it('should be able to instrument TS type definitions (should not produce mutants)', async () => {
+    await arrangeAndActAssert('type-definitions.ts');
+  });
 
   async function arrangeAndActAssert(fileName: string, options = createInstrumenterOptions()) {
     const fullFileName = resolveTestResource(fileName);

--- a/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
+++ b/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
@@ -78,10 +78,19 @@ describe('babel-transformer', () => {
     expect(ast.root.program.body[0]).eq(declareGlobal);
   });
 
-  it('should skip type annotations', () => {
-    const ast = createTSAst({ rawContent: 'const foo: string;' });
-    transformBabel(ast, mutantCollectorMock, context);
-    expectMutateNotCalledWith((t) => t.isTSTypeAnnotation());
+  describe('types', () => {
+    it('should skip type annotations', () => {
+      const ast = createTSAst({ rawContent: 'const foo: string;' });
+      transformBabel(ast, mutantCollectorMock, context);
+      expectMutateNotCalledWith((t) => t.isTSTypeAnnotation());
+    });
+
+    it('should skip `as` expressions', () => {
+      const ast = createTSAst({ rawContent: 'let foo = "bar" as "bar"' });
+      transformBabel(ast, mutantCollectorMock, context);
+      expectMutateNotCalledWith((t) => t.isTSLiteralType());
+      expectMutateNotCalledWith((t) => t.isStringLiteral() && t.parentPath.isTSLiteralType());
+    });
   });
 
   it('should skip import declarations', () => {

--- a/packages/instrumenter/testResources/instrumenter/issues/urls-in-strings.js
+++ b/packages/instrumenter/testResources/instrumenter/issues/urls-in-strings.js
@@ -1,8 +1,0 @@
-// https://github.com/stryker-mutator/stryker/issues/2402
-
-const object = {
-  fizz: {
-      buzz: '',
-  },
-  bar: 'file://',
-};

--- a/packages/instrumenter/testResources/instrumenter/type-definitions.ts
+++ b/packages/instrumenter/testResources/instrumenter/type-definitions.ts
@@ -1,0 +1,4 @@
+/**
+ * @see https://github.com/stryker-mutator/stryker/issues/2465
+ */ 
+const flatten = require('lodash/flatten') as typeof import('lodash/flatten');

--- a/packages/instrumenter/testResources/instrumenter/type-definitions.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/type-definitions.ts.out.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`instrumenter integration issues should be able to instrument urls in strings 1`] = `
+exports[`instrumenter integration should be able to instrument TS type definitions (should not produce mutants) 1`] = `
 "var __global_69fa48 = function (g) {
   if (g.__activeMutant__ === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
     g.__activeMutant__ = Number(g.process.env.__STRYKER_ACTIVE_MUTANT__);
@@ -28,11 +28,8 @@ exports[`instrumenter integration issues should be able to instrument urls in st
   return g;
 }(new Function(\\"return this\\")());
 
-// https://github.com/stryker-mutator/stryker/issues/2402
-const object = __global_69fa48.__activeMutant__ === 0 ? {} : (__global_69fa48.__coverMutant__(0), {
-  fizz: __global_69fa48.__activeMutant__ === 1 ? {} : (__global_69fa48.__coverMutant__(1), {
-    buzz: __global_69fa48.__activeMutant__ === 2 ? \\"Stryker was here!\\" : (__global_69fa48.__coverMutant__(2), '')
-  }),
-  bar: __global_69fa48.__activeMutant__ === 3 ? \\"\\" : (__global_69fa48.__coverMutant__(3), 'file://')
-});"
+/**
+ * @see https://github.com/stryker-mutator/stryker/issues/2465
+ */
+const flatten = (require('lodash/flatten') as typeof import('lodash/flatten'));"
 `;


### PR DESCRIPTION
Don't instrument TS `as` expressions as this can result in invalid code.

Fixes #2465