### PR TITLE
fix(instrumenter): don't mutate constructor blocks with initialized class properties

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -31,6 +31,6 @@ jobs:
           npm install
           npm run build
       - name: Run Stryker
-        run: npx lerna run --scope "@stryker-mutator/{api,instrumenter,util,typescript-checker,jest-runner}" --concurrency 1 --stream stryker -- -- --concurrency 3
+        run: npx lerna run --scope "@stryker-mutator/{api,instrumenter,util,typescript-checker,jest-runner,karma-runner}" --concurrency 1 --stream stryker -- -- --concurrency 3
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/packages/instrumenter/test/unit/mutators/block-statement-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/block-statement-mutator.spec.ts
@@ -68,5 +68,12 @@ describe(BlockStatementMutator.name, () => {
     it('should not mutate a constructor containing a super call and has (typescript) parameter properties', () => {
       expectJSMutation(sut, 'class Foo extends Bar { constructor(private baz: string) { super(); } }');
     });
+
+    /**
+     * @see https://github.com/stryker-mutator/stryker/issues/2474
+     */
+    it('should not mutate a constructor containing a super call and contains initialized properties', () => {
+      expectJSMutation(sut, 'class Foo extends Bar { private baz = "qux"; constructor() { super(); } }');
+    });
   });
 });


### PR DESCRIPTION
Don't mutate constructor block statements when the class contains initialized class properties. For example:

```ts
class Foo extends Baz {
  bar = 'bar';
  constructor() {  // Don't mutate this block!
     super();
  }
}
```

If you mutate the constructor block above, and TypeScript transpiles the code, it will call `this.bar` before the `super()` is initiated. Resulting in a runtime error.

Fixes #2474