### PR TITLE
fix(core): allow skipped tests when matching mutants

### DIFF
--- a/e2e/test/mocha-javascript/stryker.conf.json
+++ b/e2e/test/mocha-javascript/stryker.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "testRunner": "mocha",
   "concurrency": 2,
-  "coverageAnalysis": "off",
+  "coverageAnalysis": "perTest",
   "reporters": ["clear-text", "html", "event-recorder"],
   "plugins": [
     "@stryker-mutator/mocha-runner"

--- a/e2e/test/mocha-javascript/test/unit/Circle.spec.js
+++ b/e2e/test/mocha-javascript/test/unit/Circle.spec.js
@@ -10,4 +10,9 @@ describe('Circle', function() {
 
     expect(circumference).to.be.equal(expectedCircumference);
   });
+
+  it('should skip this test', function() {
+    getCircumference(2);
+    this.skip();
+  });
 });

--- a/e2e/test/mocha-javascript/verify/verify.ts
+++ b/e2e/test/mocha-javascript/verify/verify.ts
@@ -14,9 +14,10 @@ describe('Verify stryker has ran correctly', () => {
       metrics: produceMetrics({
         killed: 26,
         mutationScore: 74.29,
-        mutationScoreBasedOnCoveredCode: 74.29,
-        survived: 9,
-        totalCovered: 35,
+        mutationScoreBasedOnCoveredCode: 96.3,
+        noCoverage: 8,
+        survived: 1,
+        totalCovered: 27,
         totalDetected: 26,
         totalMutants: 35,
         totalUndetected: 9,


### PR DESCRIPTION
Allow for a coverage per test result for a non-existing test. This can happen when you add a `this.skip` inside a `it`. In that case, `beforeEach` still executes and can add test coverage.

We now ignore simply ignore this and log a debug message.

Fixes #2485 