### PR TITLE
test(e2e): add e2e test for coverage analysis

### DIFF
--- a/e2e/test/coverage-analysis/package.json
+++ b/e2e/test/coverage-analysis/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "coverage-analysis",
+  "description": "A e2e test for --coverageAnalysis",
+  "scripts": {
+    "test:unit": "jasmine",
+    "test": "mocha --no-package --require \"../../tasks/ts-node-register.js\" verify/verify.ts"
+  }
+}

--- a/e2e/test/coverage-analysis/spec/concat.spec.js
+++ b/e2e/test/coverage-analysis/spec/concat.spec.js
@@ -1,0 +1,7 @@
+const { concat } = require('../src/concat');
+
+describe(concat.name, () => {
+  it('should concat a and b', () => {
+    expect(concat('foo', 'bar')).toBe('foobar');
+  })
+});

--- a/e2e/test/coverage-analysis/spec/math.spec.js
+++ b/e2e/test/coverage-analysis/spec/math.spec.js
@@ -1,0 +1,17 @@
+const { add, multiply } = require('../src/math');
+
+describe(add.name, () => {
+
+  it('should add two numbers', () => {
+    expect(add(1, 2)).toBe(3);
+  });
+});
+
+describe(multiply.name, () => {
+  it('should multiply the numbers', () => {
+    // Bad test, surviving mutant when * => /
+    expect(multiply(2, 1)).toBe(2);
+  });
+});
+
+// Missing describe for `addOne` -> surviving / noCoverage mutant

--- a/e2e/test/coverage-analysis/spec/support/jasmine.json
+++ b/e2e/test/coverage-analysis/spec/support/jasmine.json
@@ -1,0 +1,5 @@
+{
+  "spec_files": [
+    "**/*[sS]pec.[jt]s"
+  ]
+}

--- a/e2e/test/coverage-analysis/src/concat.js
+++ b/e2e/test/coverage-analysis/src/concat.js
@@ -1,0 +1,3 @@
+module.exports.concat = function concat(a, b){
+  return `${a}${b}`;
+};

--- a/e2e/test/coverage-analysis/src/math.js
+++ b/e2e/test/coverage-analysis/src/math.js
@@ -1,0 +1,17 @@
+function add(a, b) {
+  return a + b;
+}
+
+function multiply(a, b) {
+  return a * b;
+}
+
+function addOne(a) {
+  return ++a;
+}
+
+module.exports = {
+  add,
+  multiply,
+  addOne
+};

--- a/e2e/test/coverage-analysis/verify/coverage-analysis-reporter.js
+++ b/e2e/test/coverage-analysis/verify/coverage-analysis-reporter.js
@@ -1,0 +1,31 @@
+const { PluginKind, declareClassPlugin } = require('@stryker-mutator/api/plugin');
+
+class CoverageAnalysisReporter {
+  /**
+   * @type {import('mutation-testing-report-schema').MutationTestResult}
+   */
+  report;
+  /**
+   * @type { CoverageAnalysisReporter }
+   */
+  static instance;
+  
+  constructor() {
+    CoverageAnalysisReporter.instance = this;
+  }
+  
+  /**
+   * @param {import('mutation-testing-report-schema').MutationTestResult} report 
+   * @returns {void}
+   */
+  onMutationTestReportReady(report) {
+    this.report = report;
+  }
+}
+const strykerPlugins = [declareClassPlugin(PluginKind.Reporter, 'coverageAnalysis', CoverageAnalysisReporter)];
+module.exports = {
+  CoverageAnalysisReporter,
+  strykerPlugins
+};
+
+

--- a/e2e/test/coverage-analysis/verify/verify.ts
+++ b/e2e/test/coverage-analysis/verify/verify.ts
@@ -1,0 +1,84 @@
+import { default as Stryker } from '@stryker-mutator/core';
+import { expect } from 'chai';
+import { CoverageAnalysisReporter } from './coverage-analysis-reporter';
+import { calculateMetrics, Metrics } from 'mutation-testing-metrics';
+
+const expectedTestCount = Object.freeze({
+  off: 18,
+  all: 12,
+  perTest: 6
+});
+
+describe('Coverage analysis', () => {
+  it('should provide the expected with --coverageAnalysis off', async () => {
+    // Arrange
+    const stryker = new Stryker({
+      coverageAnalysis: 'off',
+      testRunner: 'jasmine',
+      reporters: ['coverageAnalysis'],
+      plugins: ['@stryker-mutator/jasmine-runner', require.resolve('./coverage-analysis-reporter')]
+    });
+
+    // Act
+    const testsRan = (await stryker.runMutationTest()).reduce((a, b) => a + b.nrOfTestsRan, 0);
+
+    // Assert
+    const metricsResult = calculateMetrics(CoverageAnalysisReporter.instance?.report.files);
+    const expectedMetricsResult: Partial<Metrics> = {
+      noCoverage: 0,
+      survived: 3,
+      killed: 5,
+      mutationScore: 62.5
+    };
+    expect(metricsResult.metrics).deep.include(expectedMetricsResult);
+    expect(testsRan).eq(expectedTestCount.off);
+  });
+
+  it('should provide the expected with --coverageAnalysis all', async () => {
+    // Arrange
+    const stryker = new Stryker({
+      coverageAnalysis: 'all',
+      testRunner: 'jasmine',
+      reporters: ['coverageAnalysis'],
+      plugins: ['@stryker-mutator/jasmine-runner', require.resolve('./coverage-analysis-reporter')]
+    });
+
+    // Act
+    const testsRan = (await stryker.runMutationTest()).reduce((a, b) => a + b.nrOfTestsRan, 0);
+
+    // Assert
+    const metricsResult = calculateMetrics(CoverageAnalysisReporter.instance?.report.files);
+    const expectedMetricsResult: Partial<Metrics> = {
+      noCoverage: 2,
+      survived: 1,
+      killed: 5,
+      mutationScore: 62.5
+    };
+    expect(metricsResult.metrics).deep.include(expectedMetricsResult);
+    expect(testsRan).eq(expectedTestCount.all);
+  });
+
+  it('should provide the expected with --coverageAnalysis perTest', async () => {
+    // Arrange
+    const stryker = new Stryker({
+      coverageAnalysis: 'perTest',
+      testRunner: 'jasmine',
+      reporters: ['coverageAnalysis'],
+      plugins: ['@stryker-mutator/jasmine-runner', require.resolve('./coverage-analysis-reporter')]
+    });
+
+    // Act
+    const testsRan = (await stryker.runMutationTest()).reduce((a, b) => a + b.nrOfTestsRan, 0);
+
+    // Assert
+    const metricsResult = calculateMetrics(CoverageAnalysisReporter.instance?.report.files);
+    const expectedMetricsResult: Partial<Metrics> = {
+      noCoverage: 2,
+      survived: 1,
+      killed: 5,
+      mutationScore: 62.5
+    };
+    expect(metricsResult.metrics).deep.include(expectedMetricsResult);
+    expect(testsRan).eq(expectedTestCount.perTest);
+  });
+});


### PR DESCRIPTION
Add e2e test for coverage analysis `off`, `all` and `perTest`.

Fixes #2486 