### PR TITLE
fix(config): deprecate function based config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,11 +15,8 @@ assignees: ''
 
 <!--- Please place your stryker config below. Feel free to change paths in the files and mutate arrays if you cannot share them. -->
 
-```js
-module.exports = function(config){
-  config.set({
-    ....
-  });
+```json
+{
 }
 ```
 

--- a/packages/core/src/config/ConfigReader.ts
+++ b/packages/core/src/config/ConfigReader.ts
@@ -30,6 +30,7 @@ export default class ConfigReader {
     const configModule = this.loadConfigModule();
     let options: StrykerOptions;
     if (typeof configModule === 'function') {
+      this.log.warn('Usage of `module.export = function(config) {}` is deprecated. Please use `module.export = {} or JSON file respectively');
       options = defaultOptions();
       configModule(createConfig(options));
     } else {

--- a/packages/core/src/config/ConfigReader.ts
+++ b/packages/core/src/config/ConfigReader.ts
@@ -30,7 +30,9 @@ export default class ConfigReader {
     const configModule = this.loadConfigModule();
     let options: StrykerOptions;
     if (typeof configModule === 'function') {
-      this.log.warn('Usage of `module.export = function(config) {}` is deprecated. Please use `module.export = {} or JSON file respectively');
+      this.log.warn(
+        'Usage of `module.export = function(config) {}` is deprecated. Please use `module.export = {}` or a "stryker.conf.json" file. For more details, see https://stryker-mutator.io/blog/2020-03-11/stryker-version-3#new-config-format'
+      );
       options = defaultOptions();
       configModule(createConfig(options));
     } else {

--- a/packages/core/test/integration/config-reader/ConfigReader.it.spec.ts
+++ b/packages/core/test/integration/config-reader/ConfigReader.it.spec.ts
@@ -151,11 +151,10 @@ describe(ConfigReader.name, () => {
     });
 
     describe('deprecation informations', () => {
-      beforeEach(() => {
-        sut = createSut({ configFile: 'testResources/config-reader/deprecatedFunction.conf.js' });
-      });
-
       it('should report deprecation on module.export = function(config) {}', () => {
+        sut = createSut({ configFile: 'testResources/config-reader/deprecatedFunction.conf.js' });
+        sut.readConfig();
+
         expect(testInjector.logger.warn).called.with(
           'Usage of `module.export = function(config) {}` is deprecated. Please use `module.export = {}` or a "stryker.conf.json" file. For more details, see https://stryker-mutator.io/blog/2020-03-11/stryker-version-3#new-config-format'
         );

--- a/packages/core/test/integration/config-reader/ConfigReader.it.spec.ts
+++ b/packages/core/test/integration/config-reader/ConfigReader.it.spec.ts
@@ -155,7 +155,7 @@ describe(ConfigReader.name, () => {
         sut = createSut({ configFile: 'testResources/config-reader/deprecatedFunction.conf.js' });
         sut.readConfig();
 
-        expect(testInjector.logger.warn).called.with(
+        expect(testInjector.logger.warn).calledWithMatch(
           'Usage of `module.export = function(config) {}` is deprecated. Please use `module.export = {}` or a "stryker.conf.json" file. For more details, see https://stryker-mutator.io/blog/2020-03-11/stryker-version-3#new-config-format'
         );
       });

--- a/packages/core/test/integration/config-reader/ConfigReader.it.spec.ts
+++ b/packages/core/test/integration/config-reader/ConfigReader.it.spec.ts
@@ -149,5 +149,17 @@ describe(ConfigReader.name, () => {
         expect(() => sut.readConfig()).throws('Invalid config file. Inner error: SyntaxError: Unexpected identifier');
       });
     });
+
+    describe('deprecation informations', () => {
+      beforeEach(() => {
+        sut = createSut({ configFile: 'testResources/config-reader/json-and-js/stryker.conf.js' });
+      });
+
+      it('should report deprecation on module.export = function(config) {}', () => {
+        expect(testInjector.logger.warn).called.with(
+          'Usage of `module.export = function(config) {}` is deprecated. Please use `module.export = {} or JSON file respectively'
+        );
+      });
+    });
   });
 });

--- a/packages/core/test/integration/config-reader/ConfigReader.it.spec.ts
+++ b/packages/core/test/integration/config-reader/ConfigReader.it.spec.ts
@@ -152,12 +152,12 @@ describe(ConfigReader.name, () => {
 
     describe('deprecation informations', () => {
       beforeEach(() => {
-        sut = createSut({ configFile: 'testResources/config-reader/json-and-js/stryker.conf.js' });
+        sut = createSut({ configFile: 'testResources/config-reader/deprecatedFunction.conf.js' });
       });
 
       it('should report deprecation on module.export = function(config) {}', () => {
         expect(testInjector.logger.warn).called.with(
-          'Usage of `module.export = function(config) {}` is deprecated. Please use `module.export = {} or JSON file respectively'
+          'Usage of `module.export = function(config) {}` is deprecated. Please use `module.export = {}` or a "stryker.conf.json" file. For more details, see https://stryker-mutator.io/blog/2020-03-11/stryker-version-3#new-config-format'
         );
       });
     });

--- a/packages/core/testResources/config-reader/deprecated.conf.js
+++ b/packages/core/testResources/config-reader/deprecated.conf.js
@@ -1,23 +1,21 @@
-module.exports = function(config){
-  config.set({
-    mutator: {
-      name: 'javascript',
-      excludedMutations: [
-        'ArrayLiteral',
-        'ArrayNewExpression',
-        'BinaryExpression',
-        'Block',
-        'BooleanSubstitution',
-        'DoStatement',
-        'ForStatement',
-        'IfStatement',
-        'PrefixUnaryExpression',
-        'PostfixUnaryExpression',
-        'SwitchCase',
-        'WhileStatement',
-        'ObjectLiteral',
-        'ArrowFunctionMutator'
-      ]
-    }
-  });
-};
+module.exports = {
+  mutator: {
+    name: 'javascript',
+    excludedMutations: [
+      'ArrayLiteral',
+      'ArrayNewExpression',
+      'BinaryExpression',
+      'Block',
+      'BooleanSubstitution',
+      'DoStatement',
+      'ForStatement',
+      'IfStatement',
+      'PrefixUnaryExpression',
+      'PostfixUnaryExpression',
+      'SwitchCase',
+      'WhileStatement',
+      'ObjectLiteral',
+      'ArrowFunctionMutator'
+    ]
+  }
+}

--- a/packages/core/testResources/config-reader/deprecatedFunction.conf.js
+++ b/packages/core/testResources/config-reader/deprecatedFunction.conf.js
@@ -1,0 +1,8 @@
+module.exports = function(config){
+  config.set({
+    'valid': 'config',
+    'should': 'be',
+    'read': true,
+    'type': 'js'
+  });
+};

--- a/packages/core/testResources/config-reader/js/stryker.conf.js
+++ b/packages/core/testResources/config-reader/js/stryker.conf.js
@@ -1,9 +1,7 @@
 
-module.exports = function(config){
-  config.set({
-    'valid': 'config',
-    'should': 'be',
-    'read': true,
-    'type': 'js'
-  });
-};
+module.exports = {
+  'valid': 'config',
+  'should': 'be',
+  'read': true,
+  'type': 'js'
+}

--- a/packages/core/testResources/config-reader/json-and-js/stryker.conf.js
+++ b/packages/core/testResources/config-reader/json-and-js/stryker.conf.js
@@ -1,9 +1,7 @@
 
-module.exports = function(config){
-  config.set({
-    'valid': 'config',
-    'should': 'be',
-    'read': true,
-    'type': 'js'
-  });
-};
+module.exports = {
+  'valid': 'config',
+  'should': 'be',
+  'read': true,
+  'type': 'js'
+}

--- a/packages/jasmine-runner/.mocharc.jsonc
+++ b/packages/jasmine-runner/.mocharc.jsonc
@@ -1,4 +1,4 @@
 {
   "require": ["test/setup.js"],
-  "timeout": 10000
+  "timeout": 30000
 }


### PR DESCRIPTION
Export a function from you're config file is deprecated. Please export an object, or use a json file.

Fixes: #2429 