### PR TITLE
Change serialization

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "mutation-testing-report-schema": "~1.4.0",
-    "surrial": "~2.0.2",
     "tslib": "~2.0.0"
   },
   "devDependencies": {

--- a/packages/api/src/core/File.ts
+++ b/packages/api/src/core/File.ts
@@ -1,9 +1,7 @@
-import { Surrializable, surrial } from 'surrial';
-
 /**
  * Represents a file within Stryker. Could be a strictly in-memory file.
  */
-export default class File implements Surrializable {
+export default class File {
   private _textContent: string | undefined;
   private readonly _content: Buffer;
 
@@ -36,13 +34,5 @@ export default class File implements Surrializable {
       this._textContent = this.content.toString();
     }
     return this._textContent;
-  }
-
-  /**
-   * This fixes the issue of different File versions not being compatible.
-   * @see https://github.com/stryker-mutator/stryker/issues/2025
-   */
-  public surrialize(): string {
-    return surrial`new File(${this.name}, ${this.content})`;
   }
 }

--- a/packages/api/test/unit/core/File.spec.ts
+++ b/packages/api/test/unit/core/File.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { deserialize, serialize } from 'surrial';
 
 import { File } from '../../../core';
 
@@ -12,20 +11,5 @@ describe('File', () => {
   it('should allow buffered content in the constructor', () => {
     const actual = new File('foobar.js', Buffer.from('string-content'));
     expect(actual.textContent).deep.eq('string-content');
-  });
-
-  it('should be serializable', () => {
-    const expected = new File('foo', Buffer.from('bar'));
-    const serialized = serialize(expected);
-    const actual = deserialize(serialized, [File]);
-    expect(actual).deep.eq(expected);
-    expect(actual).instanceOf(File);
-  });
-
-  /**
-   * @see https://github.com/stryker-mutator/stryker/issues/2025
-   */
-  it('should customize serialization to allow different instances of the class file to be compatible', () => {
-    expect(new File('foo', Buffer.from('bar')).surrialize()).eq('new File("foo", Buffer.from("bar", "binary"))');
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,6 @@
     "rxjs": "~6.6.0",
     "source-map": "~0.7.3",
     "strip-comments": "~2.0.1",
-    "surrial": "~2.0.2",
     "tree-kill": "~1.2.2",
     "tslib": "~2.0.0",
     "typed-inject": "~3.0.0",

--- a/packages/core/src/child-proxy/ChildProcessProxy.ts
+++ b/packages/core/src/child-proxy/ChildProcessProxy.ts
@@ -1,14 +1,14 @@
 import { ChildProcess, fork } from 'child_process';
 import * as os from 'os';
 
-import { File, StrykerOptions } from '@stryker-mutator/api/core';
+import { StrykerOptions } from '@stryker-mutator/api/core';
 import { PluginContext } from '@stryker-mutator/api/plugin';
 import { isErrnoException, Task, ExpirableTask } from '@stryker-mutator/util';
 import { getLogger } from 'log4js';
 import { Disposable, InjectableClass, InjectionToken } from 'typed-inject';
 
 import { LoggingClientContext } from '../logging';
-import { kill, padLeft, serialize } from '../utils/objectUtils';
+import { kill, padLeft } from '../utils/objectUtils';
 import StringBuilder from '../utils/StringBuilder';
 
 import ChildProcessCrashedError from './ChildProcessCrashedError';
@@ -110,7 +110,7 @@ export default class ChildProcessProxy<T> implements Disposable {
         const correlationId = this.workerTasks.push(workerTask) - 1;
         this.initTask.promise.then(() => {
           this.send({
-            args: args.map((arg) => (arg instanceof File ? serialize(arg, [File]) : arg)),
+            args,
             correlationId,
             kind: WorkerMessageKind.Call,
             methodName,

--- a/packages/core/src/child-proxy/ChildProcessProxy.ts
+++ b/packages/core/src/child-proxy/ChildProcessProxy.ts
@@ -1,14 +1,14 @@
 import { ChildProcess, fork } from 'child_process';
 import * as os from 'os';
 
-import { File, StrykerOptions } from '@stryker-mutator/api/core';
+import { StrykerOptions } from '@stryker-mutator/api/core';
 import { PluginContext } from '@stryker-mutator/api/plugin';
 import { isErrnoException, Task, ExpirableTask } from '@stryker-mutator/util';
 import { getLogger } from 'log4js';
 import { Disposable, InjectableClass, InjectionToken } from 'typed-inject';
 
 import { LoggingClientContext } from '../logging';
-import { deserialize, kill, padLeft, serialize } from '../utils/objectUtils';
+import { kill, padLeft } from '../utils/objectUtils';
 import StringBuilder from '../utils/StringBuilder';
 
 import ChildProcessCrashedError from './ChildProcessCrashedError';
@@ -83,7 +83,7 @@ export default class ChildProcessProxy<T> implements Disposable {
   }
 
   private send(message: WorkerMessage) {
-    this.worker.send(serialize(message, [File]));
+    this.worker.send(JSON.stringify(message));
   }
 
   private initProxy(): Promisified<T> {
@@ -123,7 +123,7 @@ export default class ChildProcessProxy<T> implements Disposable {
 
   private listenForMessages() {
     this.worker.on('message', (serializedMessage: string) => {
-      const message: ParentMessage = deserialize(serializedMessage, [File]);
+      const message: ParentMessage = JSON.parse(serializedMessage);
       switch (message.kind) {
         case ParentMessageKind.Initialized:
           this.initTask.resolve(undefined);

--- a/packages/core/src/child-proxy/ChildProcessProxy.ts
+++ b/packages/core/src/child-proxy/ChildProcessProxy.ts
@@ -1,14 +1,14 @@
 import { ChildProcess, fork } from 'child_process';
 import * as os from 'os';
 
-import { StrykerOptions } from '@stryker-mutator/api/core';
+import { File, StrykerOptions } from '@stryker-mutator/api/core';
 import { PluginContext } from '@stryker-mutator/api/plugin';
 import { isErrnoException, Task, ExpirableTask } from '@stryker-mutator/util';
 import { getLogger } from 'log4js';
 import { Disposable, InjectableClass, InjectionToken } from 'typed-inject';
 
 import { LoggingClientContext } from '../logging';
-import { kill, padLeft } from '../utils/objectUtils';
+import { kill, padLeft, serialize } from '../utils/objectUtils';
 import StringBuilder from '../utils/StringBuilder';
 
 import ChildProcessCrashedError from './ChildProcessCrashedError';
@@ -110,7 +110,7 @@ export default class ChildProcessProxy<T> implements Disposable {
         const correlationId = this.workerTasks.push(workerTask) - 1;
         this.initTask.promise.then(() => {
           this.send({
-            args,
+            args: args.map((arg) => (arg instanceof File ? serialize(arg, [File]) : arg)),
             correlationId,
             kind: WorkerMessageKind.Call,
             methodName,

--- a/packages/core/src/child-proxy/ChildProcessProxyWorker.ts
+++ b/packages/core/src/child-proxy/ChildProcessProxyWorker.ts
@@ -3,10 +3,6 @@ import * as path from 'path';
 import { errorToString } from '@stryker-mutator/util';
 import { getLogger, Logger } from 'log4js';
 
-import { deserialize } from 'surrial';
-
-import { File } from '@stryker-mutator/api/core';
-
 import { buildChildProcessInjector } from '../di';
 import { LogConfigurator } from '../logging';
 
@@ -36,7 +32,6 @@ export default class ChildProcessProxyWorker {
         this.removeAnyAdditionalMessageListeners(this.handleMessage);
         break;
       case WorkerMessageKind.Call:
-        message.args = message.args.map((arg) => (typeof arg === 'string' && arg.startsWith('new File(') ? deserialize(arg, [File]) : arg));
         this.handleCall(message);
         this.removeAnyAdditionalMessageListeners(this.handleMessage);
         break;

--- a/packages/core/src/child-proxy/ChildProcessProxyWorker.ts
+++ b/packages/core/src/child-proxy/ChildProcessProxyWorker.ts
@@ -1,14 +1,12 @@
 import * as path from 'path';
 
-import { File } from '@stryker-mutator/api/core';
 import { errorToString } from '@stryker-mutator/util';
 import { getLogger, Logger } from 'log4js';
 
 import { buildChildProcessInjector } from '../di';
 import { LogConfigurator } from '../logging';
-import { deserialize, serialize } from '../utils/objectUtils';
 
-import { autoStart, CallMessage, ParentMessage, ParentMessageKind, WorkerMessage, WorkerMessageKind, InitMessage } from './messageProtocol';
+import { autoStart, CallMessage, ParentMessage, ParentMessageKind, WorkerMessageKind, InitMessage } from './messageProtocol';
 
 export default class ChildProcessProxyWorker {
   private log: Logger;
@@ -23,12 +21,11 @@ export default class ChildProcessProxyWorker {
 
   private send(value: ParentMessage) {
     if (process.send) {
-      const str = serialize(value, [File]);
-      process.send(str);
+      process.send(JSON.stringify(value));
     }
   }
   private handleMessage(serializedMessage: string) {
-    const message = deserialize<WorkerMessage>(serializedMessage, [File]);
+    const message = JSON.parse(serializedMessage);
     switch (message.kind) {
       case WorkerMessageKind.Init:
         this.handleInit(message);

--- a/packages/core/src/utils/objectUtils.ts
+++ b/packages/core/src/utils/objectUtils.ts
@@ -2,8 +2,6 @@ import treeKill = require('tree-kill');
 import { StrykerError, KnownKeys } from '@stryker-mutator/util';
 import { WarningOptions } from '@stryker-mutator/api/core';
 
-export { serialize, deserialize } from 'surrial';
-
 export function wrapInClosure(codeFragment: string) {
   return `
     (function (window) {

--- a/packages/core/test/integration/child-proxy/ChildProcessProxy.it.spec.ts
+++ b/packages/core/test/integration/child-proxy/ChildProcessProxy.it.spec.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import { File, LogLevel } from '@stryker-mutator/api/core';
+import { LogLevel } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens } from '@stryker-mutator/api/plugin';
 import { testInjector, LoggingServer } from '@stryker-mutator/test-helpers';
@@ -55,17 +55,6 @@ describe(ChildProcessProxy.name, () => {
   it('should set the current working directory', async () => {
     const actual = await sut.proxy.cwd();
     expect(actual).eq(path.resolve(workingDir));
-  });
-
-  it('should be able to receive files', async () => {
-    const actual: string = await sut.proxy.echoFile(new File('hello.txt', 'hello world from file'));
-    expect(actual).eq('hello world from file');
-  });
-
-  it('should be able to send files', async () => {
-    const actual: File = await sut.proxy.readFile();
-    expect(actual.textContent).eq('hello foobar');
-    expect(actual.name).eq('foobar.txt');
   });
 
   it('should be able to receive a promise rejection', async () => {

--- a/packages/core/test/integration/child-proxy/Echo.ts
+++ b/packages/core/test/integration/child-proxy/Echo.ts
@@ -1,4 +1,3 @@
-import { File } from '@stryker-mutator/api/core';
 import { tokens } from '@stryker-mutator/api/plugin';
 import { getLogger } from 'log4js';
 
@@ -20,19 +19,8 @@ export class Echo {
     });
   }
 
-  public echoFile(file: File) {
-    return file.textContent;
-  }
-
   public exit(code: number) {
     process.exit(code);
-    return new Promise(() => {
-      /* Never resolve */
-    });
-  }
-
-  public readFile() {
-    return new File('foobar.txt', 'hello foobar');
   }
 
   public cwd() {

--- a/packages/core/test/integration/child-proxy/Echo.ts
+++ b/packages/core/test/integration/child-proxy/Echo.ts
@@ -21,6 +21,9 @@ export class Echo {
 
   public exit(code: number) {
     process.exit(code);
+    return new Promise(() => {
+      /* Never resolve */
+    });
   }
 
   public cwd() {

--- a/packages/core/test/integration/test-runner/AdditionalTestRunners.ts
+++ b/packages/core/test/integration/test-runner/AdditionalTestRunners.ts
@@ -161,7 +161,6 @@ export const strykerPlugins = [
   declareClassPlugin(PluginKind.TestRunner, 'slow-init-dispose', SlowInitAndDisposeTestRunner),
   declareClassPlugin(PluginKind.TestRunner, 'never-resolved', NeverResolvedTestRunner),
   declareClassPlugin(PluginKind.TestRunner, 'errored', ErroredTestRunner),
-  declareClassPlugin(PluginKind.TestRunner, 'discover-regex', DiscoverRegexTestRunner),
   declareClassPlugin(PluginKind.TestRunner, 'direct-resolved', DirectResolvedTestRunner),
   declareClassPlugin(PluginKind.TestRunner, 'coverage-reporting', CoverageReportingTestRunner),
   declareClassPlugin(PluginKind.TestRunner, 'time-bomb', TimeBombTestRunner),

--- a/packages/core/test/integration/test-runner/AdditionalTestRunners.ts
+++ b/packages/core/test/integration/test-runner/AdditionalTestRunners.ts
@@ -1,8 +1,6 @@
 import * as os from 'os';
-import { isRegExp } from 'util';
 
-import { StrykerOptions } from '@stryker-mutator/api/core';
-import { commonTokens, declareClassPlugin, PluginKind, tokens } from '@stryker-mutator/api/plugin';
+import { declareClassPlugin, PluginKind } from '@stryker-mutator/api/plugin';
 import { TestRunner, DryRunResult, DryRunStatus, MutantRunResult } from '@stryker-mutator/api/test_runner';
 import { factory } from '@stryker-mutator/test-helpers';
 
@@ -59,22 +57,6 @@ class DirectResolvedTestRunner implements TestRunner {
   public async dryRun(): Promise<DryRunResult> {
     (global as any).__mutantCoverage__ = 'coverageObject';
     return factory.completeDryRunResult();
-  }
-  public async mutantRun(): Promise<MutantRunResult> {
-    throw new Error('Method not implemented.');
-  }
-}
-
-class DiscoverRegexTestRunner implements TestRunner {
-  public static inject = tokens(commonTokens.options);
-  constructor(private readonly options: StrykerOptions) {}
-
-  public async dryRun(): Promise<DryRunResult> {
-    if (isRegExp(this.options.someRegex)) {
-      return factory.completeDryRunResult();
-    } else {
-      return factory.errorDryRunResult({ errorMessage: 'No regex found in runnerOptions.strykerOptions.someRegex' });
-    }
   }
   public async mutantRun(): Promise<MutantRunResult> {
     throw new Error('Method not implemented.');

--- a/packages/core/test/integration/test-runner/createTestRunnerFactory.it.spec.ts
+++ b/packages/core/test/integration/test-runner/createTestRunnerFactory.it.spec.ts
@@ -31,7 +31,6 @@ describe(`${createTestRunnerFactory.name} integration`, () => {
     const port = await loggingServer.listen();
     loggingContext = { port, level: LogLevel.Trace };
     testInjector.options.plugins = [require.resolve('./AdditionalTestRunners')];
-    testInjector.options.someRegex = /someRegex/;
     testInjector.options.testRunner = 'karma';
     testInjector.options.maxTestRunnerReuse = 0;
     alreadyDisposed = false;
@@ -69,12 +68,6 @@ describe(`${createTestRunnerFactory.name} integration`, () => {
   function actMutantRun() {
     return sut.mutantRun(factory.mutantRunOptions());
   }
-
-  it('should be able to receive a regex', async () => {
-    await arrangeSut('discover-regex');
-    const result = await actDryRun();
-    expect(result.status).eq(DryRunStatus.Complete);
-  });
 
   it('should pass along the coverage result from the test runner behind', async () => {
     await arrangeSut('coverage-reporting');

--- a/packages/core/test/unit/child-proxy/ChildProcessProxy.spec.ts
+++ b/packages/core/test/unit/child-proxy/ChildProcessProxy.spec.ts
@@ -19,7 +19,6 @@ import {
   WorkerMessageKind,
 } from '../../../src/child-proxy/messageProtocol';
 import { LoggingClientContext } from '../../../src/logging';
-import { serialize } from '../../../src/utils/objectUtils';
 import * as objectUtils from '../../../src/utils/objectUtils';
 import currentLogMock from '../../helpers/logMock';
 import { Mock } from '../../helpers/producers';
@@ -88,7 +87,7 @@ describe(ChildProcessProxy.name, () => {
       });
 
       // Assert
-      expect(childProcessMock.send).calledWith(serialize(expectedMessage));
+      expect(childProcessMock.send).calledWith(JSON.stringify(expectedMessage));
     });
 
     it('should listen to worker process', () => {
@@ -178,7 +177,7 @@ describe(ChildProcessProxy.name, () => {
 
       // Assert
       expect(result).eq('ack');
-      expect(childProcessMock.send).calledWith(serialize(expectedWorkerMessage));
+      expect(childProcessMock.send).calledWith(JSON.stringify(expectedWorkerMessage));
     });
   });
 
@@ -190,7 +189,7 @@ describe(ChildProcessProxy.name, () => {
     it('should send a dispose message', async () => {
       await actDispose();
       const expectedWorkerMessage: DisposeMessage = { kind: WorkerMessageKind.Dispose };
-      expect(childProcessMock.send).calledWith(serialize(expectedWorkerMessage));
+      expect(childProcessMock.send).calledWith(JSON.stringify(expectedWorkerMessage));
     });
 
     it('should kill the child process', async () => {
@@ -233,7 +232,7 @@ describe(ChildProcessProxy.name, () => {
   });
 
   function receiveMessage(workerResponse: ParentMessage) {
-    childProcessMock.emit('message', serialize(workerResponse));
+    childProcessMock.emit('message', JSON.stringify(workerResponse));
   }
 });
 

--- a/packages/core/test/unit/child-proxy/ChildProcessWorker.spec.ts
+++ b/packages/core/test/unit/child-proxy/ChildProcessWorker.spec.ts
@@ -19,7 +19,6 @@ import {
 import * as di from '../../../src/di';
 import { LogConfigurator } from '../../../src/logging';
 import { LoggingClientContext } from '../../../src/logging';
-import { serialize } from '../../../src/utils/objectUtils';
 import currentLogMock from '../../helpers/logMock';
 import { Mock } from '../../helpers/producers';
 
@@ -107,7 +106,7 @@ describe(ChildProcessProxyWorker.name, () => {
       processOnMessage(initMessage);
       const expectedWorkerResponse: ParentMessage = { kind: ParentMessageKind.Initialized };
       await tick(); // make sure promise is resolved
-      expect(processSendStub).calledWith(serialize(expectedWorkerResponse));
+      expect(processSendStub).calledWith(JSON.stringify(expectedWorkerResponse));
     });
 
     it('should remove any additional listeners', async () => {
@@ -124,7 +123,7 @@ describe(ChildProcessProxyWorker.name, () => {
     });
 
     it('should set global log level', () => {
-      processOnStub.callArgWith(1, serialize(initMessage));
+      processOnStub.callArgWith(1, JSON.stringify(initMessage));
       expect(configureChildProcessStub).calledWith(LOGGING_CONTEXT);
     });
 
@@ -148,7 +147,7 @@ describe(ChildProcessProxyWorker.name, () => {
         processOnMessage(workerMessage);
         await tick();
         // Assert
-        expect(processSendStub).calledWith(serialize(expectedResult));
+        expect(processSendStub).calledWith(JSON.stringify(expectedResult));
       }
 
       async function actAndAssertRejection(workerMessage: CallMessage, expectedError: string) {
@@ -238,7 +237,7 @@ describe(ChildProcessProxyWorker.name, () => {
   });
 
   function processOnMessage(message: WorkerMessage) {
-    processOnStub.withArgs('message').callArgWith(1, [serialize(message)]);
+    processOnStub.withArgs('message').callArgWith(1, [JSON.stringify(message)]);
   }
 });
 


### PR DESCRIPTION
I was looking at the interfaces and I think we could use JSON.stringify instead of serialize. E2E tests pass. Unit won't for now since we are testing `File`. Although I think it is possible to solve it too. Since the only place it can occur is "CallMessage" in args (its any type), so we could just map through args, find if there is File instance, serialize it, and JSON.stringify entire object.
Deserialization would be opposite, JSON.parse and then map serialize on args