### PR TITLE
fix(instrumenter): don't mutate generics

### DIFF
--- a/packages/instrumenter/src/util/syntax-helpers.ts
+++ b/packages/instrumenter/src/util/syntax-helpers.ts
@@ -175,6 +175,7 @@ const tsTypeAnnotationNodeTypes: ReadonlyArray<types.Node['type']> = Object.free
   'TSModuleDeclaration',
   'TSEnumDeclaration',
   'TSDeclareFunction',
+  'TSTypeParameterInstantiation',
 ]);
 
 const flowTypeAnnotationNodeTypes: ReadonlyArray<types.Node['type']> = Object.freeze([

--- a/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
+++ b/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
@@ -124,6 +124,12 @@ describe('babel-transformer', () => {
       expectMutateNotCalledWith((t) => t.isVariableDeclaration());
       expectMutateNotCalledWith((t) => t.isStringLiteral());
     });
+
+    it('should skip generic parameters', () => {
+      const ast = createTSAst({ rawContent: 'React.useState<string | false>()' });
+      transformBabel(ast, mutantCollectorMock, context);
+      expectMutateNotCalledWith((t) => t.isTSTypeParameterInstantiation());
+    });
   });
 
   it('should skip import declarations', () => {

--- a/packages/instrumenter/testResources/instrumenter/ts-declarations.ts
+++ b/packages/instrumenter/testResources/instrumenter/ts-declarations.ts
@@ -2,3 +2,5 @@ export declare const globalNamespace = "globalNamespace";
 declare function foo(): 'foo';
 declare module 'express' {
 }
+
+React.useState<false>();

--- a/packages/instrumenter/testResources/instrumenter/ts-declarations.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/ts-declarations.ts.out.snap
@@ -3,5 +3,6 @@
 exports[`instrumenter integration type declarations should not produce mutants for a TS declaration file 1`] = `
 "export declare const globalNamespace = \\"globalNamespace\\";
 declare function foo(): 'foo';
-declare module 'express' {}"
+declare module 'express' {}
+React.useState<false>();"
 `;


### PR DESCRIPTION
Don't mutate `TSTypeParameterInstantiation` like `React.useState<true>()`

Fixes #2527