### PR TITLE
fix(string-literal-mutator): don't mutate class property keys

### DIFF
--- a/packages/instrumenter/src/mutators/string-literal-mutator.ts
+++ b/packages/instrumenter/src/mutators/string-literal-mutator.ts
@@ -40,6 +40,7 @@ export class StringLiteralMutator implements NodeMutator {
       types.isExpressionStatement(parent) ||
       types.isTSLiteralType(parent) ||
       (types.isObjectProperty(parent) && parent.key === child.node) ||
+      (types.isClassProperty(parent) && parent.key === child.node) ||
       (types.isCallExpression(parent) && types.isIdentifier(parent.callee, { name: 'require' }))
     );
   }

--- a/packages/instrumenter/test/integration/instrumenter.it.spec.ts
+++ b/packages/instrumenter/test/integration/instrumenter.it.spec.ts
@@ -55,6 +55,9 @@ describe('instrumenter integration', () => {
   it('should be able to instrument switch case statements (using the switchCaseMutantPlacer)', async () => {
     await arrangeAndActAssert('switch-case.js');
   });
+  it('should be able to instrument string literals in different places', async () => {
+    await arrangeAndActAssert('string-mutations.ts');
+  });
 
   describe('type declarations', () => {
     it('should not produce mutants for TS type definitions', async () => {

--- a/packages/instrumenter/test/unit/mutators/string-literal-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/string-literal-mutator.spec.ts
@@ -87,6 +87,12 @@ describe(StringLiteralMutator.name, () => {
     it('should still mutate inside object property values', () => {
       expectJSMutation(sut, 'const foo = { bar: "baz" };', 'const foo = { bar: "" };');
     });
+    it('should not mutate class property keys', () => {
+      expectJSMutation(sut, 'class Foo { "baz-bar" = 4; }');
+    });
+    it('should mutate class property values', () => {
+      expectJSMutation(sut, 'class Foo { bar = "4"; }', 'class Foo { bar = ""; }');
+    });
   });
 
   describe('jsx', () => {

--- a/packages/instrumenter/testResources/instrumenter/string-mutations.ts
+++ b/packages/instrumenter/testResources/instrumenter/string-mutations.ts
@@ -1,0 +1,7 @@
+require('foo'); // no mutation
+import 'foo'; // no mutation
+
+class Foo {
+  public 'bar-baz': string; // no mutation
+}
+

--- a/packages/instrumenter/testResources/instrumenter/string-mutations.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/string-mutations.ts.out.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`instrumenter integration should be able to instrument string literals in different places 1`] = `
+"require('foo'); // no mutation
+
+
+import 'foo'; // no mutation
+
+class Foo {
+  public 'bar-baz': string; // no mutation
+
+}"
+`;


### PR DESCRIPTION
Don't mutate class property keys that are written as a string literal.

```ts
class Foo { 
  'bar-baz': 4 // don't mutate
}
```

Fixes #2543 