### PR TITLE
chore(deps): remove unused dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,7 +78,6 @@
     "rimraf": "~3.0.0",
     "rxjs": "~6.6.0",
     "source-map": "~0.7.3",
-    "strip-comments": "~2.0.1",
     "surrial": "~2.0.2",
     "tree-kill": "~1.2.2",
     "tslib": "~2.0.0",
@@ -94,7 +93,6 @@
     "@types/minimatch": "~3.0.3",
     "@types/node": "^14.0.1",
     "@types/progress": "~2.0.1",
-    "@types/strip-comments": "~2.0.0",
     "flatted": "~3.1.0"
   }
 }


### PR DESCRIPTION
Remove the `strip-comments` dependency, it was used in the betas but is no longer used.