### PR TITLE
Inital timeout parameter

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -399,8 +399,9 @@
       "default": 5000
     },
     "dryRunTimeoutMinutes": {
-      "description": "Configure an absolute timeout for the initial test run. (It can take a while.)",
+      "description": "Configure an absolute timeout for the initial test run. (It can take a while, therefore we use minutes as time unit.)",
       "type": "number",
+      "minimum": 0,
       "default": 5
     },
     "tsconfigFile": {

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -398,7 +398,7 @@
       "type": "number",
       "default": 5000
     },
-    "initialTimeoutMIN": {
+    "dryRunTimeoutMinutes": {
       "description": "Configure an absolute timeout for the initial test run. (It can take a while.)",
       "type": "number",
       "default": 5

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -398,6 +398,11 @@
       "type": "number",
       "default": 5000
     },
+    "initialTimeoutMIN": {
+      "description": "Configure an absolute timeout for the initial test run. (It can take a while.)",
+      "type": "number",
+      "default": 5
+    },
     "tsconfigFile": {
       "description": "Configure the (root) tsconfig file for typescript projects. This will allow Stryker to rewrite the `extends` and `references` settings in this and related tsconfig files in your sandbox. Defaults to `tsconfig.json`. This setting is also used when you enable the `@stryker-mutator/typescript-checker plugin",
       "type": "string",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -240,9 +240,9 @@ You can *ignore* files by adding an exclamation mark (`!`) at the start of an ex
 <a name="dryRunTimeoutMinutes"></a>
 ### `dryRunTimeoutMinutes` [`number`]
 
-Default: `5`
-Command line: `--dryRunTimeoutMinutes 5`
-Config file: `dryRunTimeoutMinutes: 5`
+Default: `5`  
+Command line: `--dryRunTimeoutMinutes 5`  
+Config file: `dryRunTimeoutMinutes: 5`  
 
 Use this option to configure an absolute timeout for the initial test run. Since it can take a while we use minutes as time unit.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -107,9 +107,9 @@ You can *ignore* files by adding an exclamation mark (`!`) at the start of an ex
 * [commandRunner](#commandRunner)
 * [coverageAnalysis](#coverageAnalysis)
 * [dashboard.*](#dashboard)
+* [dryRunTimeoutMinutes](#dryRunTimeoutMinutes)
 * [fileLogLevel](#fileLogLevel)
 * [files](#files-string)
-* [initialTimeoutMIN](#initialTimeoutMIN)
 * [logLevel](#logLevel)
 * [maxConcurrentTestRunners](#maxConcurrentTestRunners)
 * [mutate](#mutate)
@@ -237,12 +237,12 @@ When using the config file you can provide an array with `string`s
 
 You can *ignore* files by adding an exclamation mark (`!`) at the start of an expression.
 
-<a name="initialTimeoutMIN"></a>
-### `initialTimeoutMIN` [`number`]
+<a name="dryRunTimeoutMinutes"></a>
+### `dryRunTimeoutMinutes` [`number`]
 
 Default: `5`
-Command line: `--initialTimeoutMIN 5`
-Config file: `initialTimeoutMIN: 5`
+Command line: `--dryRunTimeoutMinutes 5`
+Config file: `dryRunTimeoutMinutes: 5`
 
 Use this option to configure an absolute timeout for the initial test run. Since it can take a while we use minutes as time unit.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -109,6 +109,7 @@ You can *ignore* files by adding an exclamation mark (`!`) at the start of an ex
 * [dashboard.*](#dashboard)
 * [fileLogLevel](#fileLogLevel)
 * [files](#files-string)
+* [initialTimeoutMIN](#initialTimeoutMIN)
 * [logLevel](#logLevel)
 * [maxConcurrentTestRunners](#maxConcurrentTestRunners)
 * [mutate](#mutate)
@@ -235,6 +236,15 @@ When using the command line, the list can only contain a comma separated list of
 When using the config file you can provide an array with `string`s
 
 You can *ignore* files by adding an exclamation mark (`!`) at the start of an expression.
+
+<a name="initialTimeoutMIN"></a>
+### `initialTimeoutMIN` [`number`]
+
+Default: `5`
+Command line: `--initialTimeoutMIN 5`
+Config file: `initialTimeoutMIN: 5`
+
+Use this option to configure an absolute timeout for the initial test run. Since it can take a while we use minutes as time unit.
 
 <a name="logLevel"></a>
 ### `logLevel` [`string`]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 import Stryker from './stryker';
 import StrykerCli from './stryker-cli';
+
 export { Stryker, StrykerCli };
 export default Stryker;

--- a/packages/core/src/process/3-dry-run-executor.ts
+++ b/packages/core/src/process/3-dry-run-executor.ts
@@ -66,7 +66,7 @@ function isFailedTest(testResult: TestResult): testResult is FailedTestResult {
 }
 
 export class DryRunExecutor {
-  private initialRunTimeout: number;
+  private readonly initialRunTimeout: number;
 
   public static readonly inject = tokens(
     commonTokens.injector,

--- a/packages/core/src/process/3-dry-run-executor.ts
+++ b/packages/core/src/process/3-dry-run-executor.ts
@@ -82,9 +82,7 @@ export class DryRunExecutor {
     private readonly options: StrykerOptions,
     private readonly timer: I<Timer>,
     private readonly concurrencyTokenProvider: I<ConcurrencyTokenProvider>
-  ) {
-    this.dryRunTimeout = this.options.dryRunTimeoutMinutes * 1000 * 60;
-  }
+  ) {}
 
   public async execute(): Promise<Injector<MutationTestContext>> {
     const testRunnerInjector = this.injector
@@ -125,9 +123,11 @@ export class DryRunExecutor {
   }
 
   private async timeDryRun(testRunner: TestRunner): Promise<{ dryRunResult: CompleteDryRunResult; timing: Timing }> {
+    const dryRunTimeout = this.options.dryRunTimeoutMinutes * 1000 * 60;
     this.timer.mark(INITIAL_TEST_RUN_MARKER);
     this.log.info('Starting initial test run. This may take a while.');
-    const dryRunResult = await testRunner.dryRun({ timeout: this.dryRunTimeout, coverageAnalysis: this.options.coverageAnalysis });
+    this.log.debug(`Using timeout of ${this.dryRunTimeout} ms.`);
+    const dryRunResult = await testRunner.dryRun({ timeout: dryRunTimeout, coverageAnalysis: this.options.coverageAnalysis });
     const grossTimeMS = this.timer.elapsedMs(INITIAL_TEST_RUN_MARKER);
     const humanReadableTimeElapsed = this.timer.humanReadableElapsed(INITIAL_TEST_RUN_MARKER);
     this.validateResultCompleted(dryRunResult);

--- a/packages/core/src/process/3-dry-run-executor.ts
+++ b/packages/core/src/process/3-dry-run-executor.ts
@@ -66,7 +66,7 @@ function isFailedTest(testResult: TestResult): testResult is FailedTestResult {
 }
 
 export class DryRunExecutor {
-  private readonly initialRunTimeout: number;
+  private readonly dryRunTimeout: number;
 
   public static readonly inject = tokens(
     commonTokens.injector,
@@ -83,7 +83,7 @@ export class DryRunExecutor {
     private readonly timer: I<Timer>,
     private readonly concurrencyTokenProvider: I<ConcurrencyTokenProvider>
   ) {
-    this.initialRunTimeout = this.options.initialTimeoutMIN * 1000 * 60;
+    this.dryRunTimeout = this.options.dryRunTimeoutMinutes * 1000 * 60;
   }
 
   public async execute(): Promise<Injector<MutationTestContext>> {
@@ -127,7 +127,7 @@ export class DryRunExecutor {
   private async timeDryRun(testRunner: TestRunner): Promise<{ dryRunResult: CompleteDryRunResult; timing: Timing }> {
     this.timer.mark(INITIAL_TEST_RUN_MARKER);
     this.log.info('Starting initial test run. This may take a while.');
-    const dryRunResult = await testRunner.dryRun({ timeout: this.initialRunTimeout, coverageAnalysis: this.options.coverageAnalysis });
+    const dryRunResult = await testRunner.dryRun({ timeout: this.dryRunTimeout, coverageAnalysis: this.options.coverageAnalysis });
     const grossTimeMS = this.timer.elapsedMs(INITIAL_TEST_RUN_MARKER);
     const humanReadableTimeElapsed = this.timer.humanReadableElapsed(INITIAL_TEST_RUN_MARKER);
     this.validateResultCompleted(dryRunResult);

--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -86,7 +86,7 @@ export default class StrykerCli {
       )
       .option('--timeoutMS <number>', 'Tweak the absolute timeout used to wait for a test runner to complete', parseInt)
       .option('--timeoutFactor <number>', 'Tweak the standard deviation relative to the normal test run of a mutated test', parseFloat)
-      .option('--initialtimeoutMIN <number>', 'Configure an absolute timeout for the initial test run. (It can take a while.)', parseFloat)
+      .option('--dryRunTimeoutMinutes <number>', 'Configure an absolute timeout for the initial test run. (It can take a while.)', parseFloat)
       .option('--maxConcurrentTestRunners <n>', 'Set the number of max concurrent test runner to spawn (default: cpuCount)', parseInt)
       .option(
         '-c, --concurrency <n>',

--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -86,6 +86,7 @@ export default class StrykerCli {
       )
       .option('--timeoutMS <number>', 'Tweak the absolute timeout used to wait for a test runner to complete', parseInt)
       .option('--timeoutFactor <number>', 'Tweak the standard deviation relative to the normal test run of a mutated test', parseFloat)
+      .option('--initialtimeoutMIN <number>', 'Configure an absolute timeout for the initial test run. (It can take a while.)', parseFloat)
       .option('--maxConcurrentTestRunners <n>', 'Set the number of max concurrent test runner to spawn (default: cpuCount)', parseInt)
       .option(
         '-c, --concurrency <n>',

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -61,6 +61,16 @@ describe(OptionsValidator.name, () => {
     actValidationErrors('Config option "timeoutFactor" has the wrong type. It should be a number, but was a string.');
   });
 
+  it('should be invalid with non-numeric dryRunTimeout', () => {
+    breakConfig('dryRunTimeoutMinutes', 'break');
+    actValidationErrors('Config option "dryRunTimeoutMinutes" has the wrong type. It should be a number, but was a string.');
+  });
+
+  it('should be invalid with negative numeric dryRunTimeout', () => {
+    breakConfig('dryRunTimeoutMinutes', -1);
+    actValidationErrors('Config option "dryRunTimeoutMinutes" should be >= 0, was -1.');
+  });
+
   describe('plugins', () => {
     it('should be invalid with non-array plugins', () => {
       breakConfig('plugins', '@stryker-mutator/typescript');

--- a/packages/core/test/unit/process/3-dry-run-executor.spec.ts
+++ b/packages/core/test/unit/process/3-dry-run-executor.spec.ts
@@ -38,6 +38,33 @@ describe(DryRunExecutor.name, () => {
     await expect(sut.execute()).rejectedWith(expectedError);
   });
 
+  describe('check timeout', () => {
+    let runResult: CompleteDryRunResult;
+
+    beforeEach(() => {
+      runResult = factory.completeDryRunResult();
+      testRunnerMock.dryRun.resolves(runResult);
+      runResult.tests.push(factory.successTestResult());
+    });
+
+    it('should use the configured timeout in ms if option provided', async () => {
+      testInjector.options.dryRunTimeoutMinutes = 7.5;
+      const timeoutMS = testInjector.options.dryRunTimeoutMinutes * 60 * 1000;
+      await sut.execute();
+      expect(testRunnerMock.dryRun).calledWithMatch({
+        timeout: timeoutMS,
+      });
+    });
+
+    it('should use the default timeout value if option not provided', async () => {
+      const defaultTimeoutMS = 5 * 60 * 1000;
+      await sut.execute();
+      expect(testRunnerMock.dryRun).calledWithMatch({
+        timeout: defaultTimeoutMS,
+      });
+    });
+  });
+
   describe('when the dryRun completes', () => {
     let runResult: CompleteDryRunResult;
 

--- a/packages/core/test/unit/stryker-cli.spec.ts
+++ b/packages/core/test/unit/stryker-cli.spec.ts
@@ -36,6 +36,7 @@ describe(StrykerCli.name, () => {
       [['--appendPlugins', 'foo,bar'], { appendPlugins: ['foo', 'bar'] }],
       [['--timeoutMS', '42'], { timeoutMS: 42 }],
       [['--timeoutFactor', '42'], { timeoutFactor: 42 }],
+      [['--dryRunTimeoutMinutes', '10'], { dryRunTimeoutMinutes: 10 }],
       [['--maxConcurrentTestRunners', '42'], { maxConcurrentTestRunners: 42 }],
       [['--tempDirName', 'foo-tmp'], { tempDirName: 'foo-tmp' }],
       [['--testRunner', 'foo-running'], { testRunner: 'foo-running' }],


### PR DESCRIPTION
Fixes #2302 (partly) by introducing a new optional timeout parameter for the initial test run.