### PR TITLE
chore(ci): run pipeline on node 14 (instead of 12).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 14.x]
         os: ['ubuntu-latest', 'windows-latest']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We keep the strategy of running the pipeline on the lowest active LTS and highest active LTS.
