### PR TITLE
feat(report): Change theme together with mutation-test-report-app

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,7 @@
     "log4js": "~6.2.1",
     "minimatch": "~3.0.4",
     "mkdirp": "~1.0.3",
-    "mutation-testing-elements": "~1.4.0",
+    "mutation-testing-elements": "~1.4.1",
     "mutation-testing-metrics": "~1.4.0",
     "npm-run-path": "~4.0.1",
     "progress": "~2.0.0",

--- a/packages/core/src/reporters/html/templates/index.html
+++ b/packages/core/src/reporters/html/templates/index.html
@@ -13,6 +13,14 @@
         Your browser doesn't support <a href="https://caniuse.com/#search=custom%20elements">custom elements</a>.
         Please use a latest version of an evergreen browser (Firefox, Chrome, Safari, Opera, etc).
     </mutation-test-report-app>
+    <script>
+        const app = document.getElementsByTagName('mutation-test-report-app').item(0)
+        function updateTheme() {
+            document.body.style.backgroundColor = app.theme === 'dark' ? '#222' : '#fff';
+        }
+        app.addEventListener('theme-changed', updateTheme);
+        updateTheme();
+    </script>
     <script src="bind-mutation-test-report.js"></script>
 </body>
 


### PR DESCRIPTION
The parent html page of the mutation-test-report-app listens to the theme-changed event, and changes it's background color according to the new theme.