### PR TITLE
feature (reporter):  issue #1814 Add json reporter

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -133,6 +133,18 @@
         }
       }
     },
+    "jsonReporterOptions": {
+      "title": "JsonReporterOptions",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "baseDir": {
+          "description": "The output folder for the json report.",
+          "type": "string",
+          "default": "reports/mutation/json"
+        }
+      }
+    },
     "mutationScoreThresholds": {
       "title": "MutationScoreThresholds",
       "additionalProperties": false,
@@ -348,6 +360,10 @@
     "htmlReporter": {
       "description": "The options for the html reporter",
       "$ref": "#/definitions/htmlReporterOptions"
+    },
+    "jsonReporter": {
+      "description": "The options for the json reporter",
+      "$ref": "#/definitions/jsonReporterOptions"
     },
     "disableTypeChecks": {
       "description": "Configure a pattern that matches the files of which type checking has to be disabled. This is needed because Stryker will create (typescript) type errors when inserting the mutants in your code. Stryker disables type checking by inserting `// @ts-nocheck` atop those files and removing other `// @ts-xxx` directives (so they won't interfere with `@ts-nocheck`). The default setting allows these directives to be stripped from all JavaScript and friend files in `lib`, `src` and `test` directories. You can specify a different glob expression or set it to `false` to completely disable this behavior.",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -301,16 +301,22 @@ you can consult [npm](https://www.npmjs.com/search?q=stryker-plugin) or
 ### `reporters` [`string[]`]
 
 Default: `['clear-text', 'progress', 'html']`
-Command line: `--reporters clear-text,progress,dots,dashboard,html`
-Config file: `reporters: ['clear-text', 'progress', 'dots', 'dashboard', 'html']`
+Command line: `--reporters clear-text,progress,dots,dashboard,html,json`
+Config file: `reporters: ['clear-text', 'progress', 'dots', 'dashboard', 'html', 'json']`
 
 With `reporters`, you can set the reporters for stryker to use.
-These reporters can be used out of the box: `html`, `progress`, `clear-text`, `dots`, `dashboard` and `event-recorder`.
+These reporters can be used out of the box: `html`, `json`, `progress`, `clear-text`, `dots`, `dashboard` and `event-recorder`.
 By default, `clear-text`, `progress`, `html` are active if no reporters are configured.
 You can load additional plugins to get more reporters. See [stryker-mutator.io](https://stryker-mutator.io)
 for an up-to-date list of supported reporter plugins and a description on each reporter.
 
 The `html` reporter allows you to specify an output folder. This defaults to `reports/mutation/html`. The config for your config file is: `htmlReporter: { baseDir: 'mypath/reports/stryker' }`
+
+The `json` reporter supports the following options: 
+* `baseDir` allows you to specify an output folder. This defaults to `reports/mutation/json`.
+
+
+The config for your config file is: `jsonReporter: { baseDir: 'mypath/reports/stryker' }`
 
 The `clear-text` reporter supports three additional config options:
 * `allowColor` to use cyan and yellow in printing source file names and positions. This defaults to `true`, so specify as `clearTextReporter: { allowColor: false },` to disable if you must.

--- a/packages/core/src/reporters/index.ts
+++ b/packages/core/src/reporters/index.ts
@@ -7,6 +7,7 @@ import EventRecorderReporter from './event-recorder-reporter';
 import ProgressAppendOnlyReporter from './progress-append-only-reporter';
 import ProgressReporter from './progress-reporter';
 import HtmlReporter from './html/html-reporter';
+import JsonReporter from './json/json-reporter';
 
 export const strykerPlugins = [
   declareClassPlugin(PluginKind.Reporter, 'clear-text', ClearTextReporter),
@@ -15,5 +16,6 @@ export const strykerPlugins = [
   declareClassPlugin(PluginKind.Reporter, 'dots', DotsReporter),
   declareClassPlugin(PluginKind.Reporter, 'event-recorder', EventRecorderReporter),
   declareClassPlugin(PluginKind.Reporter, 'html', HtmlReporter),
+  declareClassPlugin(PluginKind.Reporter, 'json', JsonReporter),
   declareFactoryPlugin(PluginKind.Reporter, 'dashboard', dashboardReporterFactory),
 ];

--- a/packages/core/src/reporters/json/json-reporter-util.ts
+++ b/packages/core/src/reporters/json/json-reporter-util.ts
@@ -1,0 +1,19 @@
+import * as path from 'path';
+import { promisify } from 'util';
+import { promises as fs } from 'fs';
+
+import mkdirp = require('mkdirp');
+import * as rimraf from 'rimraf';
+import { throwError } from 'rxjs';
+
+export const deleteDir = promisify(rimraf);
+export const mkdir = mkdirp;
+
+export async function writeFile(fileName: string, content: string) {
+  try {
+    await mkdirp(path.dirname(fileName));
+    await fs.writeFile(fileName, content, 'utf8');
+  } catch (error) {
+    throwError(error);
+  }
+}

--- a/packages/core/src/reporters/json/json-reporter.ts
+++ b/packages/core/src/reporters/json/json-reporter.ts
@@ -1,0 +1,58 @@
+import * as path from 'path';
+
+import fileUrl = require('file-url');
+
+import { Logger } from '@stryker-mutator/api/logging';
+import { mutationTestReportSchema, Reporter } from '@stryker-mutator/api/report';
+import { StrykerOptions } from '@stryker-mutator/api/core';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
+
+import { mkdir, deleteDir, writeFile } from './json-reporter-util';
+
+const DEFAULT_BASE_FOLDER = path.normalize('reports/mutation/json');
+
+export default class JsonReporter implements Reporter {
+  private _baseDir!: string;
+  private mainPromise: Promise<void> | undefined;
+
+  constructor(private readonly options: StrykerOptions, private readonly log: Logger) {}
+
+  public static readonly inject = tokens(commonTokens.options, commonTokens.logger);
+
+  public onMutationTestReportReady(report: mutationTestReportSchema.MutationTestResult) {
+    this.mainPromise = this.generateReport(report);
+  }
+
+  public wrapUp() {
+    return this.mainPromise;
+  }
+
+  public async generateReport(report: mutationTestReportSchema.MutationTestResult) {
+    const indexFileName = path.resolve(this.baseDir, 'report.json');
+
+    await this.cleanBaseFolder();
+    await writeFile(indexFileName, JSON.stringify(report));
+
+    this.log.info(`Your report can be found at: ${fileUrl(indexFileName)}`);
+  }
+
+  private get baseDir(): string {
+    if (!this._baseDir) {
+      if (this.options.jsonReporter && this.options.jsonReporter.baseDir) {
+        this._baseDir = this.options.jsonReporter.baseDir;
+        this.log.debug(`Using configured output folder ${this._baseDir}`);
+      } else {
+        this.log.debug(
+          `No base folder configuration found (using configuration: jsonReporter: { baseDir: 'output/folder' }), using default ${DEFAULT_BASE_FOLDER}`
+        );
+        this._baseDir = DEFAULT_BASE_FOLDER;
+      }
+    }
+    return this._baseDir;
+  }
+
+  private async cleanBaseFolder(): Promise<void> {
+    await deleteDir(this.baseDir);
+    await mkdir(this.baseDir);
+  }
+}

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -245,6 +245,13 @@ describe(markUnknownOptions.name, () => {
     expect(testInjector.logger.warn).not.called;
   });
 
+  it('should not warn when there are no unknown properties for jsonReporter', () => {
+    testInjector.options.jsonReporter = {
+      baseDir: 'test',
+    };
+    expect(testInjector.logger.warn).not.called;
+  });
+
   it('should return the options, no matter what', () => {
     testInjector.options['this key does not exist'] = 'foo';
     const output = markUnknownOptions(testInjector.options, strykerCoreSchema, testInjector.logger);

--- a/packages/core/test/unit/reporters/json/json-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/json/json-reporter.spec.ts
@@ -1,0 +1,97 @@
+import * as path from 'path';
+
+import { mutationTestReportSchema } from '@stryker-mutator/api/report';
+import { testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import JsonReporter from '../../../../src/reporters/json/json-reporter';
+import * as JsonReporterUtil from '../../../../src/reporters/json/json-reporter-util';
+
+describe(JsonReporter.name, () => {
+  let writeFileStub: sinon.SinonStub;
+  let mkdirStub: sinon.SinonStub;
+  let deleteDirStub: sinon.SinonStub;
+  let sut: JsonReporter;
+
+  beforeEach(() => {
+    writeFileStub = sinon.stub(JsonReporterUtil, 'writeFile');
+    deleteDirStub = sinon.stub(JsonReporterUtil, 'deleteDir');
+    mkdirStub = sinon.stub(JsonReporterUtil, 'mkdir');
+    sut = testInjector.injector.injectClass(JsonReporter);
+  });
+
+  describe('onMutationTestReportReady', () => {
+    it('should use configured base directory', async () => {
+      testInjector.options.jsonReporter = { baseDir: 'foo/bar' };
+      actReportReady();
+      await sut.wrapUp();
+      expect(testInjector.logger.debug).calledWith('Using configured output folder foo/bar');
+      expect(deleteDirStub).calledWith('foo/bar');
+    });
+
+    it('should use default base directory when no override is configured', async () => {
+      const expectedBaseDir = path.normalize('reports/mutation/json');
+      actReportReady();
+      await sut.wrapUp();
+      expect(testInjector.logger.debug).calledWith(
+        `No base folder configuration found (using configuration: jsonReporter: { baseDir: 'output/folder' }), using default ${expectedBaseDir}`
+      );
+      expect(deleteDirStub).calledWith(expectedBaseDir);
+    });
+
+    it('should clean the base directory', async () => {
+      actReportReady();
+      await sut.wrapUp();
+      expect(deleteDirStub).calledWith(path.normalize('reports/mutation/json'));
+      expect(mkdirStub).calledWith(path.normalize('reports/mutation/json'));
+      expect(deleteDirStub).calledBefore(mkdirStub);
+    });
+
+    it('should write the mutation report to disk', async () => {
+      const report: mutationTestReportSchema.MutationTestResult = {
+        files: {},
+        schemaVersion: '1.0',
+        thresholds: {
+          high: 80,
+          low: 60,
+        },
+      };
+      sut.onMutationTestReportReady(report);
+      await sut.wrapUp();
+      expect(writeFileStub).calledWith(path.resolve('reports', 'mutation', 'json', 'report.json'), JSON.stringify(report));
+    });
+  });
+
+  describe('wrapUp', () => {
+    it('should resolve when everything is OK', () => {
+      actReportReady();
+      return expect(sut.wrapUp()).eventually.undefined;
+    });
+
+    it('should reject when "deleteDir" rejects', () => {
+      const expectedError = new Error('delete dir');
+      deleteDirStub.rejects(expectedError);
+      actReportReady();
+      return expect(sut.wrapUp()).rejectedWith(expectedError);
+    });
+
+    it('should reject when "mkdir" rejects', () => {
+      const expectedError = new Error('mkdir');
+      mkdirStub.rejects(expectedError);
+      actReportReady();
+      return expect(sut.wrapUp()).rejectedWith(expectedError);
+    });
+
+    it('should reject when "writeFile" rejects', () => {
+      const expectedError = new Error('writeFile');
+      writeFileStub.rejects(expectedError);
+      actReportReady();
+      return expect(sut.wrapUp()).rejectedWith(expectedError);
+    });
+  });
+
+  function actReportReady() {
+    sut.onMutationTestReportReady({ files: {}, schemaVersion: '', thresholds: { high: 0, low: 0 } });
+  }
+});

--- a/stryker.parent.conf.json
+++ b/stryker.parent.conf.json
@@ -5,7 +5,8 @@
   "reporters": [
     "progress",
     "html",
-    "dashboard"
+    "dashboard",
+    "json"
   ],  
   "plugins": [
     "../mocha-runner",

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -102,7 +102,8 @@
       "preprocessors",
       "serializable",
       "surrialize"
-    ]
+    ],
+    "compile-hero.disable-compile-files-on-did-save-code": false
   },
   "extensions": {
     "recommendations": [


### PR DESCRIPTION
This is a solution for issue #1814 that I opened ages ago! This is my second attempt!

I used HTML reporter as the guideline and tried to keep the code as faithfully to current code style as possible.

It is a very simple solution. I just dump the `report: MutationTestResult` POJO that is generated `onMutationTestReportReady` in a JSON file.

`json-reporter-util.ts` is almost the same as `html-reporter-util.ts` but I decided to go with it because I didn't know if you'd like to generalise and move file handling util functions outside reporters.

Please drop me a line If I've done something wrong!!!