### PR TITLE
feat(karma-runner): resolve local karma version

### DIFF
--- a/packages/karma-runner/src/starters/angular-starter.ts
+++ b/packages/karma-runner/src/starters/angular-starter.ts
@@ -4,8 +4,9 @@ import decamelize = require('decamelize');
 import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
 import * as semver from 'semver';
 
+import { requireResolve } from '@stryker-mutator/util';
+
 import { NgConfigOptions, NgTestArguments } from '../../src-generated/karma-runner-options';
-import { requireModule } from '../utils';
 
 const MIN_ANGULAR_CLI_VERSION = '6.1.0';
 
@@ -14,7 +15,7 @@ export async function start(getLogger: LoggerFactoryMethod, ngConfig?: NgConfigO
   verifyAngularCliVersion();
 
   // Make sure require angular cli from inside this function, that way it won't break if angular isn't installed and this file is required.
-  let cli = requireModule('@angular/cli');
+  let cli: any = requireResolve('@angular/cli');
   if ('default' in cli) {
     cli = cli.default;
   }
@@ -47,7 +48,8 @@ export async function start(getLogger: LoggerFactoryMethod, ngConfig?: NgConfigO
 }
 
 function verifyAngularCliVersion() {
-  const version = semver.coerce(requireModule('@angular/cli/package').version);
+  const pkg = requireResolve('@angular/cli/package') as { version: string };
+  const version = semver.coerce(pkg.version);
   if (!version || semver.lt(version, MIN_ANGULAR_CLI_VERSION)) {
     throw new Error(`Your @angular/cli version (${version}) is not supported. Please install ${MIN_ANGULAR_CLI_VERSION} or higher`);
   }

--- a/packages/karma-runner/src/starters/karma-starter.ts
+++ b/packages/karma-runner/src/starters/karma-starter.ts
@@ -1,8 +1,8 @@
-import { requireModule } from '../utils';
+import { requireResolve } from '@stryker-mutator/util';
 
 export async function start(): Promise<void> {
   // Make sure require karma from inside this function, that way it won't break if karma isn't installed and this file is required.
-  const karma = requireModule('karma');
+  const karma: any = requireResolve('karma');
   await new karma.Server({
     configFile: require.resolve('./stryker-karma.conf'),
   }).start();

--- a/packages/karma-runner/src/starters/stryker-karma.conf.ts
+++ b/packages/karma-runner/src/starters/stryker-karma.conf.ts
@@ -2,11 +2,10 @@ import * as path from 'path';
 
 import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
 import { Config, ConfigOptions, ClientOptions, InlinePluginType } from 'karma';
-import { noopLogger } from '@stryker-mutator/util';
+import { noopLogger, requireResolve } from '@stryker-mutator/util';
 
 import StrykerReporter from '../karma-plugins/stryker-reporter';
 import TestHooksMiddleware, { TEST_HOOKS_FILE_NAME } from '../karma-plugins/test-hooks-middleware';
-import { requireModule } from '../utils';
 
 function setDefaultOptions(config: Config) {
   config.set({
@@ -20,7 +19,10 @@ function setUserKarmaConfigFile(config: Config, log: Logger) {
     const configFileName = path.resolve(globalSettings.karmaConfigFile);
     log.debug('Importing config from "%s"', configFileName);
     try {
-      const userConfig = requireModule(configFileName);
+      const userConfig = requireResolve(configFileName);
+      if (typeof userConfig !== 'function') {
+        throw new TypeError(`Karma config file "${configFileName}" should export a function! Found: ${typeof userConfig}`);
+      }
       userConfig(config);
       config.configFile = configFileName; // override config to ensure karma is as user-like as possible
     } catch (error) {

--- a/packages/karma-runner/src/utils.ts
+++ b/packages/karma-runner/src/utils.ts
@@ -1,3 +1,0 @@
-export function requireModule(name: string): any {
-  return require(name);
-}

--- a/packages/karma-runner/test/integration/read-config.it.spec.ts
+++ b/packages/karma-runner/test/integration/read-config.it.spec.ts
@@ -46,8 +46,4 @@ describe('read config integration', () => {
     expect(test2.status).eq(TestStatus.Success);
     expect(test3.status).eq(TestStatus.Success);
   });
-
-  it('should be able to require a local dependency', () => {
-    
-  });
 });

--- a/packages/karma-runner/test/integration/read-config.it.spec.ts
+++ b/packages/karma-runner/test/integration/read-config.it.spec.ts
@@ -46,4 +46,8 @@ describe('read config integration', () => {
     expect(test2.status).eq(TestStatus.Success);
     expect(test3.status).eq(TestStatus.Success);
   });
+
+  it('should be able to require a local dependency', () => {
+    
+  });
 });

--- a/packages/karma-runner/test/unit/starters/angular-starter.spec.ts
+++ b/packages/karma-runner/test/unit/starters/angular-starter.spec.ts
@@ -1,10 +1,10 @@
 import { LoggerFactoryMethod } from '@stryker-mutator/api/logging';
 import { testInjector } from '@stryker-mutator/test-helpers';
+import * as utils from '@stryker-mutator/util';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
 import * as sut from '../../../src/starters/angular-starter';
-import * as utils from '../../../src/utils';
 
 describe('angularStarter', () => {
   let requireModuleStub: sinon.SinonStub;
@@ -13,7 +13,7 @@ describe('angularStarter', () => {
 
   beforeEach(() => {
     cliStub = sinon.stub();
-    requireModuleStub = sinon.stub(utils, 'requireModule');
+    requireModuleStub = sinon.stub(utils, 'requireResolve');
     requireModuleStub.withArgs('@angular/cli').returns(cliStub);
     getLogger = () => testInjector.logger;
   });

--- a/packages/karma-runner/test/unit/starters/stryker-karma.conf.spec.ts
+++ b/packages/karma-runner/test/unit/starters/stryker-karma.conf.spec.ts
@@ -4,11 +4,11 @@ import { testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import { Config, ConfigOptions, ClientOptions } from 'karma';
 import * as sinon from 'sinon';
+import * as utils from '@stryker-mutator/util';
 
 import sut = require('../../../src/starters/stryker-karma.conf');
 import StrykerReporter from '../../../src/karma-plugins/stryker-reporter';
 import TestHooksMiddleware, { TEST_HOOKS_FILE_NAME } from '../../../src/karma-plugins/test-hooks-middleware';
-import * as utils from '../../../src/utils';
 
 describe('stryker-karma.conf.js', () => {
   let getLogger: sinon.SinonStub;
@@ -19,7 +19,7 @@ describe('stryker-karma.conf.js', () => {
     config = new KarmaConfigMock();
     getLogger = sinon.stub();
     getLogger.returns(testInjector.logger);
-    requireModuleStub = sinon.stub(utils, 'requireModule');
+    requireModuleStub = sinon.stub(utils, 'requireResolve');
     sut.setGlobals({
       getLogger,
     });

--- a/packages/util/.vscode/launch.json
+++ b/packages/util/.vscode/launch.json
@@ -7,14 +7,15 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Unit tests",
+      "name": "Tests",
       "program": "${workspaceFolder}/../../node_modules/mocha/bin/_mocha",
       "args": [
         "--timeout",
         "999999",
         "--colors",
         "${workspaceFolder}/test/helpers/**/*.js",
-        "${workspaceFolder}/test/unit/**/*.js"
+        "${workspaceFolder}/test/unit/**/*.js",
+        "${workspaceFolder}/test/integration/**/*.js"
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "outFiles": [

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -4,8 +4,10 @@
   "description": "Contains utilities for Stryker, the mutation testing framework for JavaScript and friends",
   "main": "src/index.js",
   "scripts": {
-    "test": "nyc npm run test:unit",
+    "test": "nyc npm run test:all",
+    "test:all": "npm run test:unit && npm run test:integration",
     "test:unit": "mocha \"test/unit/**/*.js\"",
+    "test:integration": "mocha \"test/integration/**/*.js\"",
     "stryker": "node ../core/bin/stryker run"
   },
   "repository": {

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -10,3 +10,4 @@ export * from './flat-map';
 export * from './i';
 export * from './task';
 export * from './directory-require-cache';
+export * from './require-resolve';

--- a/packages/util/src/require-resolve.ts
+++ b/packages/util/src/require-resolve.ts
@@ -1,0 +1,7 @@
+/**
+ * Require a module from the current working directory (or a different base dir)
+ * @see https://nodejs.org/api/modules.html#modules_require_resolve_paths_request
+ */
+export function requireResolve(id: string, from = process.cwd()): unknown {
+  return require(require.resolve(id, { paths: [from] }));
+}

--- a/packages/util/test/integration/require-resolve.it.spec.ts
+++ b/packages/util/test/integration/require-resolve.it.spec.ts
@@ -1,0 +1,26 @@
+import path = require('path');
+
+import sinon = require('sinon');
+import { expect } from 'chai';
+
+import { requireResolve } from '../../src';
+
+const resolveTestResource: typeof path.resolve = path.resolve.bind(path, __dirname, '..', '..', 'testResources', 'require-resolve');
+
+describe(requireResolve.name, () => {
+  it('should be able to require from parent', () => {
+    const bar = requireResolve('bar', resolveTestResource());
+    expect(bar).eq('bar from parent');
+  });
+
+  it('should be able to require from child', () => {
+    const bar = requireResolve('bar', resolveTestResource('foo'));
+    expect(bar).eq('bar from foo');
+  });
+
+  it('should be able to require from current working directory', () => {
+    sinon.stub(process, 'cwd').returns(resolveTestResource('baz'));
+    const bar = requireResolve('bar');
+    expect(bar).eq('bar from baz');
+  });
+});

--- a/packages/util/testResources/.gitignore
+++ b/packages/util/testResources/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/util/testResources/require-resolve/baz/node_modules/bar/index.js
+++ b/packages/util/testResources/require-resolve/baz/node_modules/bar/index.js
@@ -1,0 +1,1 @@
+module.exports = 'bar from baz';

--- a/packages/util/testResources/require-resolve/foo/node_modules/bar/index.js
+++ b/packages/util/testResources/require-resolve/foo/node_modules/bar/index.js
@@ -1,0 +1,1 @@
+module.exports = 'bar from foo';

--- a/packages/util/testResources/require-resolve/node_modules/bar/index.js
+++ b/packages/util/testResources/require-resolve/node_modules/bar/index.js
@@ -1,0 +1,1 @@
+module.exports = 'bar from parent';


### PR DESCRIPTION
Require `karma` or `@angular/cli` from the current working directory (cwd), instead of from `@stryker-mutator/karma-runner/src/util.js` (where the old `requireModule` function lived).