### PR TITLE
feat(jest-runner): resolve local jest version

### DIFF
--- a/packages/jest-runner/src/utils/jest-wrapper.ts
+++ b/packages/jest-runner/src/utils/jest-wrapper.ts
@@ -1,10 +1,14 @@
-import * as jest from 'jest';
+import { requireResolve } from '@stryker-mutator/util';
+import type * as jestModule from 'jest';
+
+// Use requireResolve, that way you can use this plugin from a different directory
+const jest = requireResolve('jest') as typeof jestModule;
 
 /**
  * Direct stubbing on jest is no longer possible since jest > 25
  */
 class JestWrapper {
-  public runCLI: typeof jest.runCLI = (...args) => {
+  public runCLI: typeof jestModule.runCLI = (...args) => {
     return jest.runCLI(...args);
   };
 }


### PR DESCRIPTION
Require `jest` from the current working directory, instead of from the `@stryker-mutator/jest-runner` itself.