### PR TITLE
chore(eslint): remove per-package config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     sourceType: 'module',
     project: [require.resolve('./tsconfig.lint.json')]
   },
+  root: true,
   parser: '@typescript-eslint/parser',
   extends: ['prettier', 'eslint:recommended'],
   plugins: ['@typescript-eslint', 'prettier', 'import', 'unicorn'],

--- a/packages/api/.eslintrc
+++ b/packages/api/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/core/.eslintrc
+++ b/packages/core/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/grunt-stryker/.eslintrc
+++ b/packages/grunt-stryker/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/instrumenter/.eslintrc
+++ b/packages/instrumenter/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/jasmine-runner/.eslintrc
+++ b/packages/jasmine-runner/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/jest-runner/.eslintrc
+++ b/packages/jest-runner/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/karma-runner/.eslintrc
+++ b/packages/karma-runner/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/mocha-runner/.eslintrc
+++ b/packages/mocha-runner/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/test-helpers/.eslintrc
+++ b/packages/test-helpers/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/typescript-checker/.eslintrc
+++ b/packages/typescript-checker/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}

--- a/packages/util/.eslintrc
+++ b/packages/util/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "../../.eslintrc.js"
-}


### PR DESCRIPTION
Remove eslint config per package. The vscode-eslint plugin now supports mono-repo config.