### PR TITLE
fix(instrumentor): Do not run the arithmetic operator mutator on obvious string concatenations

### DIFF
--- a/e2e/test/angular-project/verify/verify.ts
+++ b/e2e/test/angular-project/verify/verify.ts
@@ -3,15 +3,15 @@ import { expectMetrics } from '../../../helpers';
 describe('After running stryker on angular project', () => {
   it('should report mutation score', async () => {
     await expectMetrics({
-      mutationScore: 42.86,
-      killed: 3,
+      mutationScore: 33.33,
+      killed: 2,
       survived: 0,
       noCoverage: 4,
       compileErrors: 0,
-    })
+    });
     //  -------------------|---------|----------|-----------|------------|----------|---------|
     //  File               | % score | # killed | # timeout | # survived | # no cov | # error |
     //  -------------------|---------|----------|-----------|------------|----------|---------|
-    //  All files          |   42.86 |        3 |         0 |          0 |        4 |       0 |
+    //  All files          |   33.33 |        2 |         0 |          0 |        4 |       0 |
   });
 });

--- a/e2e/test/jest-react/verify/verify.ts
+++ b/e2e/test/jest-react/verify/verify.ts
@@ -4,22 +4,22 @@ describe('After running stryker on jest-react project', () => {
   it('should report expected scores', async () => {
     await expectMetricsResult({
       metrics: produceMetrics({
-        killed: 33,
+        killed: 32,
         timeout: 0,
-        mutationScore: 67.35,
-        mutationScoreBasedOnCoveredCode: 67.35,
+        mutationScore: 66.67,
+        mutationScoreBasedOnCoveredCode: 66.67,
         survived: 16,
-        totalCovered: 49,
-        totalDetected: 33,
-        totalMutants: 49,
+        totalCovered: 48,
+        totalDetected: 32,
+        totalMutants: 48,
         totalUndetected: 16,
-        totalValid: 49
+        totalValid: 48
       }),
     });
     /*
       ---------------|---------|----------|-----------|------------|----------|---------|
       File           | % score | # killed | # timeout | # survived | # no cov | # error |
       ---------------|---------|----------|-----------|------------|----------|---------|
-      All files      |   67.35 |       33 |         0 |         16 |        0 |       0 |*/
+      All files      |   66.67 |       32 |         0 |         16 |        0 |       0 |*/
   });
 });

--- a/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
@@ -34,8 +34,9 @@ export class ArithmeticOperatorMutator implements NodeMutator {
     }
 
     const stringTypes = ['StringLiteral', 'TemplateLiteral'];
+    const leftType = node.left.type === 'BinaryExpression' ? node.left.right.type : node.left.type;
 
-    if (stringTypes.includes(node.right.type) || stringTypes.includes(node.left.type)) {
+    if (stringTypes.includes(node.right.type) || stringTypes.includes(leftType)) {
       return false;
     }
 

--- a/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
@@ -18,7 +18,7 @@ export class ArithmeticOperatorMutator implements NodeMutator {
   public name = 'ArithmeticOperator';
 
   public mutate(path: NodePath): NodeMutation[] {
-    if (path.isBinaryExpression() && this.isSupported(path.node.operator)) {
+    if (path.isBinaryExpression() && this.isSupported(path.node.operator, path.node)) {
       const mutatedOperator = this.operators[path.node.operator];
       const replacement = types.cloneNode(path.node, false);
       replacement.operator = mutatedOperator;
@@ -28,7 +28,15 @@ export class ArithmeticOperatorMutator implements NodeMutator {
     return [];
   }
 
-  private isSupported(operator: string): operator is keyof typeof ArithmeticOperators {
-    return Object.keys(this.operators).includes(operator);
+  private isSupported(operator: string, node: types.BinaryExpression): operator is keyof typeof ArithmeticOperators {
+    if (!Object.keys(this.operators).includes(operator)) {
+      return false;
+    }
+
+    if (node.left.type === 'StringLiteral' || node.right.type === 'StringLiteral') {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
@@ -33,7 +33,9 @@ export class ArithmeticOperatorMutator implements NodeMutator {
       return false;
     }
 
-    if (node.left.type === 'StringLiteral' || node.right.type === 'StringLiteral') {
+    const stringTypes = ['StringLiteral', 'TemplateLiteral'];
+
+    if (stringTypes.includes(node.right.type) || stringTypes.includes(node.left.type)) {
       return false;
     }
 

--- a/packages/instrumenter/test/unit/mutators/arithmatic-operator-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/arithmatic-operator-mutator.spec.ts
@@ -28,5 +28,9 @@ describe(ArithmeticOperatorMutator.name, () => {
     expectJSMutation(sut, '"a" + "b"');
     expectJSMutation(sut, 'const a = 1; "a" + a');
     expectJSMutation(sut, '3 + "a"');
+
+    expectJSMutation(sut, '`a` + `b`');
+    expectJSMutation(sut, 'const a = 1; `a` + a');
+    expectJSMutation(sut, '3 + `a`');
   });
 });

--- a/packages/instrumenter/test/unit/mutators/arithmatic-operator-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/arithmatic-operator-mutator.spec.ts
@@ -32,5 +32,7 @@ describe(ArithmeticOperatorMutator.name, () => {
     expectJSMutation(sut, '`a` + `b`');
     expectJSMutation(sut, 'const a = 1; `a` + a');
     expectJSMutation(sut, '3 + `a`');
+
+    expectJSMutation(sut, '"a" + b + "c" + d + "e"');
   });
 });

--- a/packages/instrumenter/test/unit/mutators/arithmatic-operator-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/arithmatic-operator-mutator.spec.ts
@@ -23,4 +23,10 @@ describe(ArithmeticOperatorMutator.name, () => {
     expectJSMutation(sut, 'a / b', 'a * b');
     expectJSMutation(sut, 'a % b', 'a * b');
   });
+
+  it('should not mutate string literal concatenation', () => {
+    expectJSMutation(sut, '"a" + "b"');
+    expectJSMutation(sut, 'const a = 1; "a" + a');
+    expectJSMutation(sut, '3 + "a"');
+  });
 });


### PR DESCRIPTION
As discussed in #2646, this is a shallow "Best-effort" approach to not mutating obvious string concatenations