### PR TITLE
refactor(cache): clear modules from any parent module

### DIFF
--- a/packages/jasmine-runner/src/jasmine-test-runner.ts
+++ b/packages/jasmine-runner/src/jasmine-test-runner.ts
@@ -60,10 +60,6 @@ export class JasmineTestRunner implements TestRunner {
     return toMutantRunResult(runResult);
   }
 
-  public async init(): Promise<void> {
-    this.requireCache.init({ initFiles: [] });
-  }
-
   public async dispose(): Promise<void> {
     this.requireCache.clear();
   }

--- a/packages/jasmine-runner/src/jasmine-test-runner.ts
+++ b/packages/jasmine-runner/src/jasmine-test-runner.ts
@@ -61,7 +61,7 @@ export class JasmineTestRunner implements TestRunner {
   }
 
   public async init(): Promise<void> {
-    this.requireCache.init({ rootModuleId: require.resolve('jasmine'), initFiles: [] });
+    this.requireCache.init({ initFiles: [] });
   }
 
   public async dispose(): Promise<void> {

--- a/packages/jasmine-runner/test/integration/jasmine-runner.it.spec.ts
+++ b/packages/jasmine-runner/test/integration/jasmine-runner.it.spec.ts
@@ -18,11 +18,10 @@ describe('JasmineRunner integration', () => {
   });
 
   describe('using the jasmine-init project', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       process.chdir(path.resolve(__dirname, '../../testResources/jasmine-init'));
       testInjector.options.jasmineConfigFile = 'spec/support/jasmine.json';
       sut = testInjector.injector.injectFunction(createJasmineTestRunnerFactory('__stryker2__'));
-      await sut.init();
     });
 
     it('should run the specs', async () => {
@@ -88,7 +87,6 @@ describe('JasmineRunner integration', () => {
     beforeEach(async () => {
       process.chdir(path.resolve(__dirname, '../../testResources/errors'));
       sut = testInjector.injector.injectFunction(createJasmineTestRunnerFactory('__stryker2__'));
-      await sut.init();
     });
 
     it('should be able to tell the error', async () => {
@@ -101,10 +99,9 @@ describe('JasmineRunner integration', () => {
   });
 
   describe('when it includes failed tests', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       process.chdir(path.resolve(__dirname, '../../testResources/test-failures'));
       sut = testInjector.injector.injectFunction(createJasmineTestRunnerFactory('__stryker2__'));
-      await sut.init();
     });
 
     it('should complete with one test failure', async () => {

--- a/packages/jasmine-runner/test/integration/memory-leak.worker.ts
+++ b/packages/jasmine-runner/test/integration/memory-leak.worker.ts
@@ -27,7 +27,6 @@ if (require.main === module) {
 async function main() {
   process.chdir(path.resolve(__dirname, '..', '..', 'testResources', 'big-project'));
   const jasmineRunner = testInjector.injector.injectFunction(createJasmineTestRunnerFactory('__stryker2__'));
-  await jasmineRunner.init();
   await doDryRun();
 
   async function doDryRun(n = 40) {

--- a/packages/jasmine-runner/test/unit/jasmine-test-runner.spec.ts
+++ b/packages/jasmine-runner/test/unit/jasmine-test-runner.spec.ts
@@ -34,13 +34,6 @@ describe(JasmineTestRunner.name, () => {
       .injectClass(JasmineTestRunner);
   });
 
-  describe('init', () => {
-    it('should initialize the require cache', async () => {
-      await sut.init();
-      expect(directoryRequireCacheMock.init).calledWithExactly({ initFiles: [], rootModuleId: require.resolve('jasmine') });
-    });
-  });
-
   describe('mutantRun', () => {
     it('should configure jasmine on run', async () => {
       await actEmptyMutantRun();

--- a/packages/jasmine-runner/testResources/big-project/lib/big-text.js
+++ b/packages/jasmine-runner/testResources/big-project/lib/big-text.js
@@ -1,6 +1,6 @@
 
 // Change the text each iteration to prevent nodejs from optimizing it into one value on the heap
 if (!global.n) {
-  global.n = 400000;
+  global.n = 300000;
 }
 module.exports.text = new Array(global.n++).fill('i').join(',');

--- a/packages/jasmine-runner/typings/jasmine-types.d.ts
+++ b/packages/jasmine-runner/typings/jasmine-types.d.ts
@@ -860,7 +860,7 @@ declare module 'jasmine' {
     addSpecFile(filePath: string): void;
     addSpecFiles(files: string[]): void;
     configureDefaultReporter(options: any, ...args: any[]): void;
-    execute(files?: string[], filterString?: string): any;
+    execute(files?: string[], filterString?: string): Promise<void> | undefined;
     exitCodeCompletion(passed: any): void;
     loadConfig(config: any): void;
     loadConfigFile(configFilePath: any): void;

--- a/packages/karma-runner/package.json
+++ b/packages/karma-runner/package.json
@@ -7,7 +7,7 @@
     "test": "nyc npm run test:all",
     "test:all": "npm run test:unit && npm run test:integration",
     "test:unit": "mocha \"test/unit/**/*.js\"",
-    "test:integration": "mocha --timeout 30000 --exit \"test/integration/**/*.js\"",
+    "test:integration": "mocha --timeout 60000 --exit \"test/integration/**/*.js\"",
     "stryker": "node ../core/bin/stryker run"
   },
   "repository": {

--- a/packages/mocha-runner/src/mocha-test-runner.ts
+++ b/packages/mocha-runner/src/mocha-test-runner.ts
@@ -50,7 +50,6 @@ export class MochaTestRunner implements TestRunner {
   public async init(): Promise<void> {
     this.mochaOptions = this.loader.load(this.options as MochaRunnerWithStrykerOptions);
     this.testFileNames = this.mochaAdapter.collectFiles(this.mochaOptions);
-    this.requireCache.init({ initFiles: this.testFileNames });
     if (this.mochaOptions.require) {
       this.rootHooks = await this.mochaAdapter.handleRequires(this.mochaOptions.require);
     }
@@ -100,11 +99,13 @@ export class MochaTestRunner implements TestRunner {
     this.addFiles(mocha);
     try {
       await this.runMocha(mocha);
+      // Call `requireCache.record` before `mocha.dispose`.
+      // `Mocha.dispose` already deletes test files from require cache, but its important that they are recorded before that.
+      this.requireCache.record();
       if ((mocha as any).dispose) {
         // Since mocha 7.2
         (mocha as any).dispose();
       }
-      this.requireCache.record();
       const reporter = StrykerMochaReporter.currentInstance;
       if (reporter) {
         const result: CompleteDryRunResult = {

--- a/packages/mocha-runner/src/mocha-test-runner.ts
+++ b/packages/mocha-runner/src/mocha-test-runner.ts
@@ -50,7 +50,7 @@ export class MochaTestRunner implements TestRunner {
   public async init(): Promise<void> {
     this.mochaOptions = this.loader.load(this.options as MochaRunnerWithStrykerOptions);
     this.testFileNames = this.mochaAdapter.collectFiles(this.mochaOptions);
-    this.requireCache.init({ initFiles: this.testFileNames, rootModuleId: require.resolve('mocha/lib/mocha') });
+    this.requireCache.init({ initFiles: this.testFileNames });
     if (this.mochaOptions.require) {
       this.rootHooks = await this.mochaAdapter.handleRequires(this.mochaOptions.require);
     }

--- a/packages/mocha-runner/test/integration/mocha-file-resolving.it.spec.ts
+++ b/packages/mocha-runner/test/integration/mocha-file-resolving.it.spec.ts
@@ -8,16 +8,11 @@ import { MochaRunnerWithStrykerOptions } from '../../src/mocha-runner-with-stryk
 import { createMochaTestRunnerFactory } from '../../src';
 
 describe('Mocha 6 file resolving integration', () => {
-  const cwd = process.cwd();
   let options: MochaRunnerWithStrykerOptions;
 
   beforeEach(() => {
     options = testInjector.options as MochaRunnerWithStrykerOptions;
     options.mochaOptions = {};
-  });
-
-  afterEach(() => {
-    process.chdir(cwd);
   });
 
   it('should resolve test files while respecting "files", "spec", "extension" and "exclude" properties', () => {

--- a/packages/mocha-runner/test/integration/mocha-options-loader.it.spec.ts
+++ b/packages/mocha-runner/test/integration/mocha-options-loader.it.spec.ts
@@ -9,14 +9,9 @@ import { MochaRunnerWithStrykerOptions } from '../../src/mocha-runner-with-stryk
 
 describe(`${MochaOptionsLoader.name} integration`, () => {
   let sut: MochaOptionsLoader;
-  const cwd = process.cwd();
 
   beforeEach(() => {
     sut = createSut();
-  });
-
-  afterEach(() => {
-    process.chdir(cwd);
   });
 
   it('should support loading from ".mocharc.js"', () => {

--- a/packages/mocha-runner/test/integration/project-with-root-hooks.it.spec.ts
+++ b/packages/mocha-runner/test/integration/project-with-root-hooks.it.spec.ts
@@ -8,18 +8,12 @@ import { expectCompleted } from '@stryker-mutator/test-helpers/src/assertions';
 import { createMochaTestRunnerFactory, MochaTestRunner } from '../../src';
 
 describe('Running a project with root hooks', () => {
-  const cwd = process.cwd();
-
   let sut: MochaTestRunner;
 
   beforeEach(async () => {
     process.chdir(path.resolve(__dirname, '..', '..', 'testResources', 'parallel-with-root-hooks-sample'));
     sut = testInjector.injector.injectFunction(createMochaTestRunnerFactory('__stryker2__'));
     await sut.init();
-  });
-
-  afterEach(() => {
-    process.chdir(cwd);
   });
 
   it('should have run the root hooks', async () => {

--- a/packages/mocha-runner/test/unit/mocha-test-runner.spec.ts
+++ b/packages/mocha-runner/test/unit/mocha-test-runner.spec.ts
@@ -75,19 +75,6 @@ describe(MochaTestRunner.name, () => {
       expect(sut.testFileNames).eq(expectedTestFileNames);
     });
 
-    it('should init the directory require cache', async () => {
-      const expectedTestFileNames = ['foo.js', 'foo.spec.js'];
-      mochaAdapterMock.collectFiles.returns(expectedTestFileNames);
-      mochaOptionsLoaderMock.load.returns({});
-
-      await sut.init();
-
-      expect(directoryRequireCacheMock.init).calledWithExactly({
-        initFiles: expectedTestFileNames,
-        rootModuleId: require.resolve('mocha/lib/mocha'),
-      });
-    });
-
     it('should not handle requires when there are no `requires`', async () => {
       mochaOptionsLoaderMock.load.returns({});
       await sut.init();

--- a/packages/mocha-runner/testResources/big-project/src/big-text.js
+++ b/packages/mocha-runner/testResources/big-project/src/big-text.js
@@ -1,6 +1,6 @@
 
 // Change the text each iteration to prevent nodejs from optimizing it into one value on the heap
 if (!global.n) {
-  global.n = 400000;
+  global.n = 300000;
 }
 module.exports.text = new Array(global.n++).fill('i').join(',');

--- a/packages/util/.vscode/launch.json
+++ b/packages/util/.vscode/launch.json
@@ -19,8 +19,8 @@
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "outFiles": [
-        "${workspaceRoot}/test/**/*.js",
-        "${workspaceRoot}/src/**/*.js"
+        "${workspaceFolder}/test/**/*.js",
+        "${workspaceFolder}/src/**/*.js"
       ]
     },
     {
@@ -37,8 +37,8 @@
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "outFiles": [
-        "${workspaceRoot}/test/**/*.js",
-        "${workspaceRoot}/src/**/*.js"
+        "${workspaceFolder}/test/**/*.js",
+        "${workspaceFolder}/src/**/*.js"
       ]
     }
   ]

--- a/packages/util/test/unit/directory-require-cache.spec.ts
+++ b/packages/util/test/unit/directory-require-cache.spec.ts
@@ -9,11 +9,11 @@ import { DirectoryRequireCache } from '../../src';
 describe(DirectoryRequireCache.name, () => {
   let workingDirectory: string;
   let sut: DirectoryRequireCache;
-  let loadedFiles: Map<string, string>;
+  let loadedFiles: Set<string>;
   let rootModule: NodeModule;
 
   beforeEach(() => {
-    loadedFiles = new Map();
+    loadedFiles = new Set();
     workingDirectory = path.join('stub', 'working', 'dir');
     const cwdStub = sinon.stub(process, 'cwd').returns(workingDirectory);
     cwdStub.returns(workingDirectory);
@@ -23,117 +23,171 @@ describe(DirectoryRequireCache.name, () => {
   });
 
   afterEach(() => {
-    for (const fileName of loadedFiles.keys()) {
+    for (const fileName of loadedFiles) {
       delete require.cache[fileName];
     }
+    delete require.cache.root;
   });
 
-  function fakeRequireFile(fileName: string, content = fileName, requiredBy = rootModule) {
-    loadedFiles.set(fileName, content);
-    const child = createModule(content, fileName);
+  function fakeRequireFile(fileName: string, content = fileName, parent: NodeModule | null = rootModule) {
+    loadedFiles.add(fileName);
+    const child = createModule(content, fileName, parent);
     require.cache[fileName] = child;
-    requiredBy.children.push(child);
+    parent?.children.push(child);
+    return child;
   }
 
-  describe(DirectoryRequireCache.prototype.clear.name, () => {
-    it('should clear the init files', () => {
-      // Arrange
-      const dir2 = path.join('stub', 'working', 'dir2');
-      const fooFileName = path.join(dir2, 'foo.js');
-      const barFileName = path.join(dir2, 'bar.js');
-      const bazFileName = path.join(dir2, 'baz.js');
-      fakeRequireFile(fooFileName, 'foo');
-      fakeRequireFile(barFileName, 'foo');
-      fakeRequireFile(bazFileName, 'baz');
-      sut.init({ initFiles: [fooFileName, barFileName], rootModuleId: 'root' });
-      sut.record();
+  it('should clear the init files', () => {
+    // Arrange
+    const dir2 = path.join('stub', 'working', 'dir2');
+    const fooFileName = path.join(dir2, 'foo.js');
+    const barFileName = path.join(dir2, 'bar.js');
+    const bazFileName = path.join(dir2, 'baz.js');
+    fakeRequireFile(fooFileName, 'foo');
+    fakeRequireFile(barFileName, 'foo');
+    fakeRequireFile(bazFileName, 'baz');
+    sut.init({ initFiles: [fooFileName, barFileName] });
+    sut.record();
 
-      // Act
-      sut.clear();
+    // Act
+    sut.clear();
 
-      // Assert
-      expect(require.cache[fooFileName]).undefined;
-      expect(require.cache[barFileName]).undefined;
-      expect(require.cache[bazFileName]?.exports).eq('baz');
-    });
-
-    it('should clear recorded files', () => {
-      // Arrange
-      const dir2 = path.join('stub', 'working', 'dir2');
-      const fooFileName = path.join(workingDirectory, 'foo.js');
-      const barFileName = path.join(workingDirectory, 'bar.js');
-      const bazFileName = path.join(dir2, 'baz.js');
-      fakeRequireFile(fooFileName, 'foo');
-      fakeRequireFile(barFileName, 'foo');
-      fakeRequireFile(bazFileName, 'baz');
-      sut.record();
-
-      // Act
-      sut.clear();
-
-      // Assert
-      expect(require.cache[fooFileName]).undefined;
-      expect(require.cache[barFileName]).undefined;
-      expect(require.cache[bazFileName]?.exports).eq('baz');
-    });
-
-    it('should clear recorded children from the root', () => {
-      // Arrange
-      const dir2 = path.join('stub', 'working', 'dir2');
-      const fooFileName = path.join(workingDirectory, 'foo.js');
-      const barFileName = path.join(workingDirectory, 'bar.js');
-      const bazFileName = path.join(dir2, 'baz.js');
-      fakeRequireFile(fooFileName, 'foo');
-      fakeRequireFile(barFileName, 'foo');
-      fakeRequireFile(bazFileName, 'baz');
-      expect(rootModule.children).lengthOf(3);
-      sut.init({ initFiles: [], rootModuleId: 'root' });
-      sut.record();
-
-      // Act
-      sut.clear();
-
-      // Assert
-      expect(rootModule.children).lengthOf(1);
-      expect(rootModule.children[0].filename).eq(bazFileName);
-    });
-
-    it("should throw when the root module wasn't loaded", () => {
-      // Arrange
-      sut.init({ initFiles: [], rootModuleId: 'not-exists' });
-      sut.record();
-
-      // Act
-      expect(() => sut.clear()).throws('Could not find "not-exists" in require cache.');
-    });
-
-    it('should not clear files from node_modules', () => {
-      // Arrange
-      const fooFileName = path.join(workingDirectory, 'foo.js');
-      const bazFileName = path.join(workingDirectory, 'node_modules', 'baz.js');
-      fakeRequireFile(fooFileName, 'foo');
-      fakeRequireFile(bazFileName, 'baz');
-      sut.record();
-
-      // Act
-      sut.clear();
-
-      // Assert
-      expect(require.cache[fooFileName]).undefined;
-      expect(require.cache[bazFileName]?.exports).eq('baz');
-    });
+    // Assert
+    expect(require.cache[fooFileName]).undefined;
+    expect(require.cache[barFileName]).undefined;
+    expect(require.cache[bazFileName]?.exports).eq('baz');
   });
+
+  it('should clear recorded files', () => {
+    // Arrange
+    const dir2 = path.join('stub', 'working', 'dir2');
+    const fooFileName = path.join(workingDirectory, 'foo.js');
+    const barFileName = path.join(workingDirectory, 'bar.js');
+    const bazFileName = path.join(dir2, 'baz.js');
+    fakeRequireFile(fooFileName, 'foo');
+    fakeRequireFile(barFileName, 'foo');
+    fakeRequireFile(bazFileName, 'baz');
+    sut.record();
+
+    // Act
+    sut.clear();
+
+    // Assert
+    expect(require.cache[fooFileName]).undefined;
+    expect(require.cache[barFileName]).undefined;
+    expect(require.cache[bazFileName]?.exports).eq('baz');
+  });
+
+  it('should only record the first time (perf optimization)', () => {
+    // Arrange
+    const fooFileName = path.join(workingDirectory, 'foo.js');
+    const barFileName = path.join(workingDirectory, 'bar.js');
+    fakeRequireFile(fooFileName, 'foo');
+    sut.record();
+    fakeRequireFile(barFileName, 'bar');
+    sut.record();
+
+    // Act
+    sut.clear();
+
+    // Assert
+    expect(require.cache[fooFileName]).undefined;
+    expect(require.cache[barFileName]).not.undefined;
+    expect(rootModule.children).lengthOf(1);
+  });
+
+  it('should clear recorded children from their respective parent', () => {
+    // Arrange
+    const dir2 = path.join('stub', 'working', 'dir2');
+    const fooFileName = path.join(workingDirectory, 'foo.js');
+    const barFileName = path.join(workingDirectory, 'bar.js');
+    const bazFileName = path.join(dir2, 'baz.js');
+    fakeRequireFile(fooFileName, 'foo');
+    fakeRequireFile(barFileName, 'foo');
+    fakeRequireFile(bazFileName, 'baz');
+    expect(rootModule.children).lengthOf(3);
+    sut.init({ initFiles: [] });
+    sut.record();
+
+    // Act
+    sut.clear();
+
+    // Assert
+    expect(rootModule.children).lengthOf(1);
+    expect(rootModule.children[0].filename).eq(bazFileName);
+  });
+
+  it('should clear recorded separate unique parents', () => {
+    // Arrange
+    const fooParent = fakeRequireFile('parent1');
+    const barParent = fakeRequireFile('parent2');
+    const fooFileName = path.join(workingDirectory, 'foo.js');
+    const barFileName = path.join(workingDirectory, 'bar.js');
+    fakeRequireFile(fooFileName, 'foo', fooParent);
+    fakeRequireFile(barFileName, 'bar', barParent);
+    expect(fooParent.children).lengthOf(1);
+    expect(barParent.children).lengthOf(1);
+    sut.init({ initFiles: [] });
+    sut.record();
+
+    // Act
+    sut.clear();
+
+    // Assert
+    expect(fooParent.children).lengthOf(0);
+    expect(barParent.children).lengthOf(0);
+  });
+
+  it("should throw when the parent module wasn't loaded", () => {
+    // Arrange
+    sut.init({ initFiles: [] });
+    fakeRequireFile(path.join(workingDirectory, 'foo.js'));
+    sut.record();
+    delete require.cache[rootModule.filename];
+
+    // Act & assert
+    expect(() => sut.clear()).throws('Could not find "root" in require cache.');
+  });
+
+  it('should not clear files from node_modules', () => {
+    // Arrange
+    const fooFileName = path.join(workingDirectory, 'foo.js');
+    const bazFileName = path.join(workingDirectory, 'node_modules', 'baz.js');
+    fakeRequireFile(fooFileName, 'foo');
+    fakeRequireFile(bazFileName, 'baz');
+    sut.record();
+
+    // Act
+    sut.clear();
+
+    // Assert
+    expect(require.cache[fooFileName]).undefined;
+    expect(require.cache[bazFileName]?.exports).eq('baz');
+  });
+
+  it("should not fail when recorded file doesn't have a parent", () => {
+    // Arrange
+    const fooFileName = path.join(workingDirectory, 'foo.js');
+    fakeRequireFile(fooFileName, 'foo', null);
+    sut.record();
+
+    // Act
+    sut.clear();
+
+    // Assert
+    expect(require.cache[fooFileName]).undefined;
+  });
+  function createModule(content: string, fileName: string, parent: NodeModule | null = rootModule): NodeModule {
+    return {
+      exports: content,
+      children: [],
+      filename: fileName,
+      id: fileName,
+      loaded: true,
+      parent,
+      paths: [],
+      require,
+      path: '',
+    };
+  }
 });
-function createModule(content: string, fileName: string): NodeModule {
-  return {
-    exports: content,
-    children: [],
-    filename: fileName,
-    id: fileName,
-    loaded: true,
-    parent: null,
-    paths: [],
-    require,
-    path: '',
-  };
-}

--- a/packages/util/test/unit/string-utils.spec.ts
+++ b/packages/util/test/unit/string-utils.spec.ts
@@ -28,7 +28,9 @@ describe('stringUtils', () => {
     }
 
     it('should be able to point to a path', () => {
-      expect(PropertyPathBuilder.create<Foo>().prop('bar').prop('baz').build()).eq('bar.baz');
+      const path = PropertyPathBuilder.create<Foo>().prop('bar').prop('baz');
+      expect(path.build()).eq('bar.baz');
+      expect(path.toString()).eq('bar.baz');
     });
   });
 


### PR DESCRIPTION
Allow modules to be cleared while it is loaded from any parent module. This allows us to handle clearing files from any parent, regardless of whether it moved around.
