### PR TITLE
fix(babel-transformer): respect top of the file comments/pragma

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -515,6 +515,23 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.13.tgz",
+      "integrity": "sha512-J/RYxnlSLXZLVR7wTRsozxKT8qbsx1mNKJzXEEjQ0Kjx1ZACcyHgbanNWNCFtc36IzuWhYWPpvJFFoexoOWFmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -729,6 +746,24 @@
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.1",
         "@babel/helper-plugin-utils": "^7.10.1"
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.13.0.tgz",
+      "integrity": "sha512-EXAGFMJgSX8gxWD7PZtW/P6M+z74jpx3wm/+9pn+c2dOawPpBkUX7BrfyPvo6ZpXbgRIEuwgwDb/MGlKvu2pOg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-flow": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -1004,6 +1039,24 @@
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/preset-flow": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.12.13.tgz",
+      "integrity": "sha512-gcEjiwcGHa3bo9idURBp5fmJPcyFPOszPQjztXrOjUE2wWVqc6fIVJPgWPIQksaQ5XZ2HWiRsf2s1fRGVjUtVw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/plugin-transform-flow-strip-types": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
           "dev": true
         }
       }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "@babel/plugin-proposal-class-properties": "~7.8.3",
     "@babel/plugin-proposal-pipeline-operator": "~7.8.3",
     "@babel/preset-env": "~7.8.3",
+    "@babel/preset-flow": "7.12.13",
     "@types/node": "^10.12.18",
     "@types/semver": "~6.2.0",
     "ajv": "~7.0.2",

--- a/e2e/test/flow-test-project/.babelrc
+++ b/e2e/test/flow-test-project/.babelrc
@@ -1,0 +1,16 @@
+{
+    "presets": [
+        "@babel/preset-flow",
+        [
+            "@babel/preset-env",
+            {
+                "targets": {
+                    "edge": "16",
+                    "firefox": "57",
+                    "chrome": "62",
+                    "safari": "11"
+                }
+            }
+        ]
+    ]
+}

--- a/e2e/test/flow-test-project/package-lock.json
+++ b/e2e/test/flow-test-project/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "flow-jest-project",
+  "version": "0.0.0",
+  "lockfileVersion": 1
+}

--- a/e2e/test/flow-test-project/package.json
+++ b/e2e/test/flow-test-project/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "flow-jest-project",
+  "version": "0.0.0",
+  "private": true,
+  "description": "A module to test a flow project, see https://flow.org/",
+  "scripts": {
+    "test:unit": "jest",
+    "test": "stryker run",
+    "posttest": "mocha --no-config --require ../../tasks/ts-node-register.js verify/*.ts"
+  }
+}

--- a/e2e/test/flow-test-project/src/square.js
+++ b/e2e/test/flow-test-project/src/square.js
@@ -1,0 +1,6 @@
+// @flow
+export function square(n: number): number {
+  const result: Array<?number> = [];
+  const cat = new Set<string>();
+  return n * n;
+}

--- a/e2e/test/flow-test-project/src/square.spec.js
+++ b/e2e/test/flow-test-project/src/square.spec.js
@@ -1,0 +1,8 @@
+import { square } from './square';
+import { expect } from 'chai';
+
+describe('square', () => {
+  it('should provide 4 when given 2', () => {
+    expect(square(2)).eq(4);
+  });
+});

--- a/e2e/test/flow-test-project/stryker.conf.json
+++ b/e2e/test/flow-test-project/stryker.conf.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "reporters": [
+    "clear-text",
+    "event-recorder"
+  ],
+  "concurrency": 2,
+  "commandRunner": {
+    "command": "npm run test:unit"
+  },
+  "symlinkNodeModules": false,
+  "fileLogLevel": "info"
+}

--- a/e2e/test/flow-test-project/verify/.babelrc
+++ b/e2e/test/flow-test-project/verify/.babelrc
@@ -1,0 +1,16 @@
+{
+    "presets": [
+        "@babel/preset-flow",
+        [
+            "@babel/preset-env",
+            {
+                "targets": {
+                    "edge": "16",
+                    "firefox": "57",
+                    "chrome": "62",
+                    "safari": "11"
+                }
+            }
+        ]
+    ]
+}

--- a/e2e/test/flow-test-project/verify/verify.ts
+++ b/e2e/test/flow-test-project/verify/verify.ts
@@ -1,0 +1,19 @@
+import { expectMetrics } from '../../../helpers';
+
+describe('After running stryker on jest-react project', () => {
+  it('should report expected scores', async () => {
+    await expectMetrics({
+      killed: 2,
+      ignored: 0,
+      survived: 1,
+      mutationScore: 66.67,
+    });
+    /*
+    -----------|---------|----------|-----------|------------|----------|---------|
+    File       | % score | # killed | # timeout | # survived | # no cov | # error |
+    -----------|---------|----------|-----------|------------|----------|---------|
+    All files  |   66.67 |        2 |         0 |          1 |        0 |       0 |
+     square.js |   66.67 |        2 |         0 |          1 |        0 |       0 |
+    -----------|---------|----------|-----------|------------|----------|---------|*/
+  });
+});

--- a/packages/instrumenter/src/transformers/babel-transformer.ts
+++ b/packages/instrumenter/src/transformers/babel-transformer.ts
@@ -36,6 +36,11 @@ export const transformBabel: AstTransformer<AstFormat.JS | AstFormat.TS> = ({ ro
     },
   });
   if (mutantCollector.hasPlacedMutants(originFileName)) {
+    const innerComments = root.program.innerComments ?? [];
+    const leadingComments = root.program.body[0]?.leadingComments ?? [];
+    if (Array.isArray(leadingComments)) {
+      instrumentationBabelHeader[0].leadingComments = [...innerComments, ...leadingComments];
+    }
     root.program.body.unshift(...instrumentationBabelHeader);
   }
 };

--- a/packages/instrumenter/src/transformers/babel-transformer.ts
+++ b/packages/instrumenter/src/transformers/babel-transformer.ts
@@ -36,11 +36,17 @@ export const transformBabel: AstTransformer<AstFormat.JS | AstFormat.TS> = ({ ro
     },
   });
   if (mutantCollector.hasPlacedMutants(originFileName)) {
-    const innerComments = root.program.innerComments ?? [];
-    const leadingComments = root.program.body[0]?.leadingComments ?? [];
-    if (Array.isArray(leadingComments)) {
-      instrumentationBabelHeader[0].leadingComments = [...innerComments, ...leadingComments];
+    // Be sure to leave comments like `// @flow` in.
+    let header = instrumentationBabelHeader;
+    if (Array.isArray(root.program.body[0]?.leadingComments)) {
+      header = [
+        {
+          ...instrumentationBabelHeader[0],
+          leadingComments: root.program.body[0]?.leadingComments,
+        },
+        ...instrumentationBabelHeader.slice(1),
+      ];
     }
-    root.program.body.unshift(...instrumentationBabelHeader);
+    root.program.body.unshift(...header);
   }
 };

--- a/packages/instrumenter/src/util/syntax-helpers.ts
+++ b/packages/instrumenter/src/util/syntax-helpers.ts
@@ -2,6 +2,7 @@ import { INSTRUMENTER_CONSTANTS as ID } from '@stryker-mutator/api/core';
 import { types, NodePath } from '@babel/core';
 import traverse from '@babel/traverse';
 import { parse } from '@babel/parser';
+import { deepFreeze } from '@stryker-mutator/util';
 
 import { Mutant } from '../mutant';
 
@@ -14,7 +15,8 @@ const IS_MUTANT_ACTIVE_HELPER = 'stryMutAct_9fa48';
 /**
  * Returns syntax for the header if JS/TS files
  */
-export const instrumentationBabelHeader = parse(`function ${STRYKER_NAMESPACE_HELPER}(){
+export const instrumentationBabelHeader = deepFreeze(
+  parse(`function ${STRYKER_NAMESPACE_HELPER}(){
   var g = new Function("return this")();
   var ns = g.${ID.NAMESPACE} || (g.${ID.NAMESPACE} = {});
   if (ns.${ID.ACTIVE_MUTANT} === undefined && g.process && g.process.env && g.process.env.${ID.ACTIVE_MUTANT_ENV_VARIABLE}) {
@@ -51,7 +53,8 @@ function ${IS_MUTANT_ACTIVE_HELPER}(id) {
   }
   ${IS_MUTANT_ACTIVE_HELPER} = isActive;
   return isActive(id);
-}`).program.body;
+}`).program.body
+) as readonly types.Statement[]; // cast here, otherwise the thing gets unwieldy to handle
 
 /**
  * returns syntax for `global.activeMutant === $mutantId`

--- a/packages/instrumenter/test/integration/transformers.it.spec.ts.snap
+++ b/packages/instrumenter/test/integration/transformers.it.spec.ts.snap
@@ -26,28 +26,28 @@ Object {
     },
     "program": Node {
       "body": Array [
-        Node {
+        Object {
           "async": false,
-          "body": Node {
+          "body": Object {
             "body": Array [
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 64,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 32,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 7,
                           "line": 2,
                         },
                         "filename": undefined,
                         "identifierName": "g",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 2,
                         },
@@ -58,11 +58,11 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "arguments": Array [],
-                      "callee": Node {
+                      "callee": Object {
                         "arguments": Array [
-                          Node {
+                          Object {
                             "end": 61,
                             "extra": Object {
                               "raw": "\\"return this\\"",
@@ -70,14 +70,14 @@ Object {
                             },
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 36,
                                 "line": 2,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 23,
                                 "line": 2,
                               },
@@ -89,19 +89,19 @@ Object {
                             "value": "return this",
                           },
                         ],
-                        "callee": Node {
+                        "callee": Object {
                           "end": 47,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 22,
                               "line": 2,
                             },
                             "filename": undefined,
                             "identifierName": "Function",
-                            "start": Position {
+                            "start": Object {
                               "column": 14,
                               "line": 2,
                             },
@@ -116,14 +116,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 37,
                             "line": 2,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 10,
                             "line": 2,
                           },
@@ -137,14 +137,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 39,
                           "line": 2,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 10,
                           "line": 2,
                         },
@@ -156,14 +156,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 39,
                         "line": 2,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 2,
                       },
@@ -179,14 +179,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 40,
                     "line": 2,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 2,
                   },
@@ -196,24 +196,24 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 114,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 74,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 8,
                           "line": 3,
                         },
                         "filename": undefined,
                         "identifierName": "ns",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 3,
                         },
@@ -224,42 +224,42 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "end": 114,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "left": Node {
+                      "left": Object {
                         "computed": false,
                         "end": 90,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 24,
                             "line": 3,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 3,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 78,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 12,
                               "line": 3,
                             },
                             "filename": undefined,
                             "identifierName": "g",
-                            "start": Position {
+                            "start": Object {
                               "column": 11,
                               "line": 3,
                             },
@@ -270,19 +270,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 90,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 24,
                               "line": 3,
                             },
                             "filename": undefined,
                             "identifierName": "__stryker__",
-                            "start": Position {
+                            "start": Object {
                               "column": 13,
                               "line": 3,
                             },
@@ -298,21 +298,21 @@ Object {
                         "trailingComments": undefined,
                         "type": "MemberExpression",
                       },
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 48,
                           "line": 3,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 11,
                           "line": 3,
                         },
                       },
                       "operator": "||",
                       "range": undefined,
-                      "right": Node {
+                      "right": Object {
                         "end": 113,
                         "extra": Object {
                           "parenStart": 94,
@@ -320,37 +320,37 @@ Object {
                         },
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 108,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 42,
                               "line": 3,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 29,
                               "line": 3,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 96,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 30,
                                 "line": 3,
                               },
                               "filename": undefined,
                               "identifierName": "g",
-                              "start": Position {
+                              "start": Object {
                                 "column": 29,
                                 "line": 3,
                               },
@@ -361,19 +361,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 108,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 42,
                                 "line": 3,
                               },
                               "filename": undefined,
                               "identifierName": "__stryker__",
-                              "start": Position {
+                              "start": Object {
                                 "column": 31,
                                 "line": 3,
                               },
@@ -389,33 +389,33 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 47,
                             "line": 3,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 29,
                             "line": 3,
                           },
                         },
                         "operator": "=",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 113,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 47,
                               "line": 3,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 45,
                               "line": 3,
                             },
@@ -436,14 +436,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 48,
                         "line": 3,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 3,
                       },
@@ -459,14 +459,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 49,
                     "line": 3,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 3,
                   },
@@ -476,48 +476,48 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "alternate": null,
-                "consequent": Node {
+                "consequent": Object {
                   "body": Array [
-                    Node {
+                    Object {
                       "end": 298,
-                      "expression": Node {
+                      "expression": Object {
                         "end": 297,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 247,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 19,
                               "line": 5,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 4,
                               "line": 5,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 234,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 6,
                                 "line": 5,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 4,
                                 "line": 5,
                               },
@@ -528,19 +528,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 247,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 19,
                                 "line": 5,
                               },
                               "filename": undefined,
                               "identifierName": "activeMutant",
-                              "start": Position {
+                              "start": Object {
                                 "column": 7,
                                 "line": 5,
                               },
@@ -556,89 +556,89 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 69,
                             "line": 5,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 4,
                             "line": 5,
                           },
                         },
                         "operator": "=",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "arguments": Array [
-                            Node {
+                            Object {
                               "computed": false,
                               "end": 296,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 68,
                                   "line": 5,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 29,
                                   "line": 5,
                                 },
                               },
-                              "object": Node {
+                              "object": Object {
                                 "computed": false,
                                 "end": 270,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 42,
                                     "line": 5,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 29,
                                     "line": 5,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "computed": false,
                                   "end": 266,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 38,
                                       "line": 5,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 29,
                                       "line": 5,
                                     },
                                   },
-                                  "object": Node {
+                                  "object": Object {
                                     "end": 258,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 30,
                                         "line": 5,
                                       },
                                       "filename": undefined,
                                       "identifierName": "g",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 29,
                                         "line": 5,
                                       },
@@ -649,19 +649,19 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "Identifier",
                                   },
-                                  "property": Node {
+                                  "property": Object {
                                     "end": 266,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 38,
                                         "line": 5,
                                       },
                                       "filename": undefined,
                                       "identifierName": "process",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 31,
                                         "line": 5,
                                       },
@@ -677,19 +677,19 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "MemberExpression",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "end": 270,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 42,
                                       "line": 5,
                                     },
                                     "filename": undefined,
                                     "identifierName": "env",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 39,
                                       "line": 5,
                                     },
@@ -705,19 +705,19 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "MemberExpression",
                               },
-                              "property": Node {
+                              "property": Object {
                                 "end": 296,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 68,
                                     "line": 5,
                                   },
                                   "filename": undefined,
                                   "identifierName": "__STRYKER_ACTIVE_MUTANT__",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 43,
                                     "line": 5,
                                   },
@@ -734,19 +734,19 @@ Object {
                               "type": "MemberExpression",
                             },
                           ],
-                          "callee": Node {
+                          "callee": Object {
                             "end": 256,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 28,
                                 "line": 5,
                               },
                               "filename": undefined,
                               "identifierName": "Number",
-                              "start": Position {
+                              "start": Object {
                                 "column": 22,
                                 "line": 5,
                               },
@@ -761,14 +761,14 @@ Object {
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 69,
                               "line": 5,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 22,
                               "line": 5,
                             },
@@ -785,14 +785,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 70,
                           "line": 5,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 5,
                         },
@@ -808,14 +808,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 3,
                       "line": 6,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 110,
                       "line": 4,
                     },
@@ -829,71 +829,71 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 3,
                     "line": 6,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 4,
                   },
                 },
                 "range": undefined,
                 "start": 118,
-                "test": Node {
+                "test": Object {
                   "end": 224,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "left": Node {
+                  "left": Object {
                     "end": 181,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "left": Node {
+                    "left": Object {
                       "end": 164,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "left": Node {
+                      "left": Object {
                         "end": 151,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 137,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 21,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 6,
                               "line": 4,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 124,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 8,
                                 "line": 4,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 4,
                               },
@@ -904,19 +904,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 137,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 21,
                                 "line": 4,
                               },
                               "filename": undefined,
                               "identifierName": "activeMutant",
-                              "start": Position {
+                              "start": Object {
                                 "column": 9,
                                 "line": 4,
                               },
@@ -932,33 +932,33 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 35,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 6,
                             "line": 4,
                           },
                         },
                         "operator": "===",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 151,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 35,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "undefined",
-                            "start": Position {
+                            "start": Object {
                               "column": 26,
                               "line": 4,
                             },
@@ -973,51 +973,51 @@ Object {
                         "trailingComments": undefined,
                         "type": "BinaryExpression",
                       },
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 48,
                           "line": 4,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 4,
                         },
                       },
                       "operator": "&&",
                       "range": undefined,
-                      "right": Node {
+                      "right": Object {
                         "computed": false,
                         "end": 164,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 48,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 39,
                             "line": 4,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 156,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 40,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "g",
-                            "start": Position {
+                            "start": Object {
                               "column": 39,
                               "line": 4,
                             },
@@ -1028,19 +1028,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 164,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 48,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "process",
-                            "start": Position {
+                            "start": Object {
                               "column": 41,
                               "line": 4,
                             },
@@ -1060,69 +1060,69 @@ Object {
                       "trailingComments": undefined,
                       "type": "LogicalExpression",
                     },
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 65,
                         "line": 4,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 4,
                       },
                     },
                     "operator": "&&",
                     "range": undefined,
-                    "right": Node {
+                    "right": Object {
                       "computed": false,
                       "end": 181,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 65,
                           "line": 4,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 52,
                           "line": 4,
                         },
                       },
-                      "object": Node {
+                      "object": Object {
                         "computed": false,
                         "end": 177,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 61,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 52,
                             "line": 4,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 169,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 53,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "g",
-                            "start": Position {
+                            "start": Object {
                               "column": 52,
                               "line": 4,
                             },
@@ -1133,19 +1133,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 177,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 61,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "process",
-                            "start": Position {
+                            "start": Object {
                               "column": 54,
                               "line": 4,
                             },
@@ -1161,19 +1161,19 @@ Object {
                         "trailingComments": undefined,
                         "type": "MemberExpression",
                       },
-                      "property": Node {
+                      "property": Object {
                         "end": 181,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 65,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": "env",
-                          "start": Position {
+                          "start": Object {
                             "column": 62,
                             "line": 4,
                           },
@@ -1193,87 +1193,87 @@ Object {
                     "trailingComments": undefined,
                     "type": "LogicalExpression",
                   },
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 108,
                       "line": 4,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 6,
                       "line": 4,
                     },
                   },
                   "operator": "&&",
                   "range": undefined,
-                  "right": Node {
+                  "right": Object {
                     "computed": false,
                     "end": 224,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 108,
                         "line": 4,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 69,
                         "line": 4,
                       },
                     },
-                    "object": Node {
+                    "object": Object {
                       "computed": false,
                       "end": 198,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 82,
                           "line": 4,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 69,
                           "line": 4,
                         },
                       },
-                      "object": Node {
+                      "object": Object {
                         "computed": false,
                         "end": 194,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 78,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 69,
                             "line": 4,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 186,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 70,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "g",
-                            "start": Position {
+                            "start": Object {
                               "column": 69,
                               "line": 4,
                             },
@@ -1284,19 +1284,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 194,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 78,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "process",
-                            "start": Position {
+                            "start": Object {
                               "column": 71,
                               "line": 4,
                             },
@@ -1312,19 +1312,19 @@ Object {
                         "trailingComments": undefined,
                         "type": "MemberExpression",
                       },
-                      "property": Node {
+                      "property": Object {
                         "end": 198,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 82,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": "env",
-                          "start": Position {
+                          "start": Object {
                             "column": 79,
                             "line": 4,
                           },
@@ -1340,19 +1340,19 @@ Object {
                       "trailingComments": undefined,
                       "type": "MemberExpression",
                     },
-                    "property": Node {
+                    "property": Object {
                       "end": 224,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 108,
                           "line": 4,
                         },
                         "filename": undefined,
                         "identifierName": "__STRYKER_ACTIVE_MUTANT__",
-                        "start": Position {
+                        "start": Object {
                           "column": 83,
                           "line": 4,
                         },
@@ -1375,24 +1375,24 @@ Object {
                 "trailingComments": undefined,
                 "type": "IfStatement",
               },
-              Node {
+              Object {
                 "async": false,
-                "body": Node {
+                "body": Object {
                   "body": Array [
-                    Node {
-                      "argument": Node {
+                    Object {
+                      "argument": Object {
                         "end": 341,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 13,
                             "line": 8,
                           },
                           "filename": undefined,
                           "identifierName": "ns",
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 8,
                           },
@@ -1407,14 +1407,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 14,
                           "line": 8,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 8,
                         },
@@ -1430,14 +1430,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 3,
                       "line": 9,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 23,
                       "line": 7,
                     },
@@ -1450,19 +1450,19 @@ Object {
                 "end": 346,
                 "extra": undefined,
                 "generator": false,
-                "id": Node {
+                "id": Object {
                   "end": 324,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 21,
                       "line": 7,
                     },
                     "filename": undefined,
                     "identifierName": "retrieveNS",
-                    "start": Position {
+                    "start": Object {
                       "column": 11,
                       "line": 7,
                     },
@@ -1475,14 +1475,14 @@ Object {
                 },
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 3,
                     "line": 9,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 7,
                   },
@@ -1493,26 +1493,26 @@ Object {
                 "trailingComments": undefined,
                 "type": "FunctionDeclaration",
               },
-              Node {
+              Object {
                 "end": 375,
-                "expression": Node {
+                "expression": Object {
                   "end": 374,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "left": Node {
+                  "left": Object {
                     "end": 361,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 14,
                         "line": 10,
                       },
                       "filename": undefined,
                       "identifierName": "stryNS_9fa48",
-                      "start": Position {
+                      "start": Object {
                         "column": 2,
                         "line": 10,
                       },
@@ -1523,33 +1523,33 @@ Object {
                     "trailingComments": undefined,
                     "type": "Identifier",
                   },
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 27,
                       "line": 10,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 2,
                       "line": 10,
                     },
                   },
                   "operator": "=",
                   "range": undefined,
-                  "right": Node {
+                  "right": Object {
                     "end": 374,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 27,
                         "line": 10,
                       },
                       "filename": undefined,
                       "identifierName": "retrieveNS",
-                      "start": Position {
+                      "start": Object {
                         "column": 17,
                         "line": 10,
                       },
@@ -1567,14 +1567,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 28,
                     "line": 10,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 10,
                   },
@@ -1584,22 +1584,22 @@ Object {
                 "trailingComments": undefined,
                 "type": "ExpressionStatement",
               },
-              Node {
-                "argument": Node {
+              Object {
+                "argument": Object {
                   "arguments": Array [],
-                  "callee": Node {
+                  "callee": Object {
                     "end": 395,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 19,
                         "line": 11,
                       },
                       "filename": undefined,
                       "identifierName": "retrieveNS",
-                      "start": Position {
+                      "start": Object {
                         "column": 9,
                         "line": 11,
                       },
@@ -1614,14 +1614,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 21,
                       "line": 11,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 9,
                       "line": 11,
                     },
@@ -1635,14 +1635,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 22,
                     "line": 11,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 11,
                   },
@@ -1658,14 +1658,14 @@ Object {
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 1,
                 "line": 12,
               },
               "filename": undefined,
               "identifierName": undefined,
-              "start": Position {
+              "start": Object {
                 "column": 23,
                 "line": 1,
               },
@@ -1678,19 +1678,19 @@ Object {
           "end": 400,
           "extra": undefined,
           "generator": false,
-          "id": Node {
+          "id": Object {
             "end": 21,
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 21,
                 "line": 1,
               },
               "filename": undefined,
               "identifierName": "stryNS_9fa48",
-              "start": Position {
+              "start": Object {
                 "column": 9,
                 "line": 1,
               },
@@ -1702,15 +1702,15 @@ Object {
             "type": "Identifier",
           },
           "innerComments": undefined,
-          "leadingComments": Array [],
-          "loc": SourceLocation {
-            "end": Position {
+          "leadingComments": undefined,
+          "loc": Object {
+            "end": Object {
               "column": 1,
               "line": 12,
             },
             "filename": undefined,
             "identifierName": undefined,
-            "start": Position {
+            "start": Object {
               "column": 0,
               "line": 1,
             },
@@ -1721,23 +1721,23 @@ Object {
           "trailingComments": undefined,
           "type": "FunctionDeclaration",
         },
-        Node {
+        Object {
           "end": 416,
-          "expression": Node {
+          "expression": Object {
             "arguments": Array [],
-            "callee": Node {
+            "callee": Object {
               "end": 413,
               "extra": undefined,
               "innerComments": undefined,
               "leadingComments": undefined,
-              "loc": SourceLocation {
-                "end": Position {
+              "loc": Object {
+                "end": Object {
                   "column": 12,
                   "line": 13,
                 },
                 "filename": undefined,
                 "identifierName": "stryNS_9fa48",
-                "start": Position {
+                "start": Object {
                   "column": 0,
                   "line": 13,
                 },
@@ -1752,14 +1752,14 @@ Object {
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 14,
                 "line": 13,
               },
               "filename": undefined,
               "identifierName": undefined,
-              "start": Position {
+              "start": Object {
                 "column": 0,
                 "line": 13,
               },
@@ -1772,14 +1772,14 @@ Object {
           "extra": undefined,
           "innerComments": undefined,
           "leadingComments": undefined,
-          "loc": SourceLocation {
-            "end": Position {
+          "loc": Object {
+            "end": Object {
               "column": 15,
               "line": 13,
             },
             "filename": undefined,
             "identifierName": undefined,
-            "start": Position {
+            "start": Object {
               "column": 0,
               "line": 13,
             },
@@ -1789,28 +1789,28 @@ Object {
           "trailingComments": undefined,
           "type": "ExpressionStatement",
         },
-        Node {
+        Object {
           "async": false,
-          "body": Node {
+          "body": Object {
             "body": Array [
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 470,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 453,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 8,
                           "line": 16,
                         },
                         "filename": undefined,
                         "identifierName": "ns",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 16,
                         },
@@ -1821,21 +1821,21 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "arguments": Array [],
-                      "callee": Node {
+                      "callee": Object {
                         "end": 468,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 23,
                             "line": 16,
                           },
                           "filename": undefined,
                           "identifierName": "stryNS_9fa48",
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 16,
                           },
@@ -1850,14 +1850,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 25,
                           "line": 16,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 11,
                           "line": 16,
                         },
@@ -1869,14 +1869,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 25,
                         "line": 16,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 16,
                       },
@@ -1892,14 +1892,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 26,
                     "line": 16,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 16,
                   },
@@ -1909,24 +1909,24 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 554,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 481,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 9,
                           "line": 17,
                         },
                         "filename": undefined,
                         "identifierName": "cov",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 17,
                         },
@@ -1937,42 +1937,42 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "end": 554,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "left": Node {
+                      "left": Object {
                         "computed": false,
                         "end": 501,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 29,
                             "line": 17,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 12,
                             "line": 17,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 486,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 14,
                               "line": 17,
                             },
                             "filename": undefined,
                             "identifierName": "ns",
-                            "start": Position {
+                            "start": Object {
                               "column": 12,
                               "line": 17,
                             },
@@ -1983,19 +1983,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 501,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 29,
                               "line": 17,
                             },
                             "filename": undefined,
                             "identifierName": "mutantCoverage",
-                            "start": Position {
+                            "start": Object {
                               "column": 15,
                               "line": 17,
                             },
@@ -2011,21 +2011,21 @@ Object {
                         "trailingComments": undefined,
                         "type": "MemberExpression",
                       },
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 82,
                           "line": 17,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 12,
                           "line": 17,
                         },
                       },
                       "operator": "||",
                       "range": undefined,
-                      "right": Node {
+                      "right": Object {
                         "end": 553,
                         "extra": Object {
                           "parenStart": 505,
@@ -2033,37 +2033,37 @@ Object {
                         },
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 523,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 51,
                               "line": 17,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 34,
                               "line": 17,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 508,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 36,
                                 "line": 17,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 34,
                                 "line": 17,
                               },
@@ -2074,19 +2074,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 523,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 51,
                                 "line": 17,
                               },
                               "filename": undefined,
                               "identifierName": "mutantCoverage",
-                              "start": Position {
+                              "start": Object {
                                 "column": 37,
                                 "line": 17,
                               },
@@ -2102,56 +2102,56 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 81,
                             "line": 17,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 34,
                             "line": 17,
                           },
                         },
                         "operator": "=",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 553,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 81,
                               "line": 17,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 54,
                               "line": 17,
                             },
                           },
                           "properties": Array [
-                            Node {
+                            Object {
                               "computed": false,
                               "end": 538,
                               "extra": undefined,
                               "innerComments": undefined,
-                              "key": Node {
+                              "key": Object {
                                 "end": 534,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 62,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": "static",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 56,
                                     "line": 17,
                                   },
@@ -2163,14 +2163,14 @@ Object {
                                 "type": "Identifier",
                               },
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 66,
                                   "line": 17,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 56,
                                   "line": 17,
                                 },
@@ -2181,19 +2181,19 @@ Object {
                               "start": 528,
                               "trailingComments": undefined,
                               "type": "ObjectProperty",
-                              "value": Node {
+                              "value": Object {
                                 "end": 538,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 66,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 64,
                                     "line": 17,
                                   },
@@ -2205,24 +2205,24 @@ Object {
                                 "type": "ObjectExpression",
                               },
                             },
-                            Node {
+                            Object {
                               "computed": false,
                               "end": 551,
                               "extra": undefined,
                               "innerComments": undefined,
-                              "key": Node {
+                              "key": Object {
                                 "end": 547,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 75,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": "perTest",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 68,
                                     "line": 17,
                                   },
@@ -2234,14 +2234,14 @@ Object {
                                 "type": "Identifier",
                               },
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 79,
                                   "line": 17,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 68,
                                   "line": 17,
                                 },
@@ -2252,19 +2252,19 @@ Object {
                               "start": 540,
                               "trailingComments": undefined,
                               "type": "ObjectProperty",
-                              "value": Node {
+                              "value": Object {
                                 "end": 551,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 79,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 77,
                                     "line": 17,
                                   },
@@ -2292,14 +2292,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 82,
                         "line": 17,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 17,
                       },
@@ -2315,14 +2315,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 83,
                     "line": 17,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 17,
                   },
@@ -2332,28 +2332,28 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "async": false,
-                "body": Node {
+                "body": Object {
                   "body": Array [
-                    Node {
+                    Object {
                       "declarations": Array [
-                        Node {
+                        Object {
                           "end": 599,
                           "extra": undefined,
-                          "id": Node {
+                          "id": Object {
                             "end": 586,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 9,
                                 "line": 19,
                               },
                               "filename": undefined,
                               "identifierName": "c",
-                              "start": Position {
+                              "start": Object {
                                 "column": 8,
                                 "line": 19,
                               },
@@ -2364,37 +2364,37 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "init": Node {
+                          "init": Object {
                             "computed": false,
                             "end": 599,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 22,
                                 "line": 19,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 12,
                                 "line": 19,
                               },
                             },
-                            "object": Node {
+                            "object": Object {
                               "end": 592,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 15,
                                   "line": 19,
                                 },
                                 "filename": undefined,
                                 "identifierName": "cov",
-                                "start": Position {
+                                "start": Object {
                                   "column": 12,
                                   "line": 19,
                                 },
@@ -2405,19 +2405,19 @@ Object {
                               "trailingComments": undefined,
                               "type": "Identifier",
                             },
-                            "property": Node {
+                            "property": Object {
                               "end": 599,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 22,
                                   "line": 19,
                                 },
                                 "filename": undefined,
                                 "identifierName": "static",
-                                "start": Position {
+                                "start": Object {
                                   "column": 16,
                                   "line": 19,
                                 },
@@ -2435,14 +2435,14 @@ Object {
                           },
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 22,
                               "line": 19,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 8,
                               "line": 19,
                             },
@@ -2458,14 +2458,14 @@ Object {
                       "innerComments": undefined,
                       "kind": "var",
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 23,
                           "line": 19,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 19,
                         },
@@ -2475,30 +2475,30 @@ Object {
                       "trailingComments": undefined,
                       "type": "VariableDeclaration",
                     },
-                    Node {
+                    Object {
                       "alternate": null,
-                      "consequent": Node {
+                      "consequent": Object {
                         "body": Array [
-                          Node {
+                          Object {
                             "end": 707,
-                            "expression": Node {
+                            "expression": Object {
                               "end": 706,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "end": 636,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 7,
                                     "line": 21,
                                   },
                                   "filename": undefined,
                                   "identifierName": "c",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 6,
                                     "line": 21,
                                   },
@@ -2509,74 +2509,74 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "Identifier",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 77,
                                   "line": 21,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 6,
                                   "line": 21,
                                 },
                               },
                               "operator": "=",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "end": 706,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "left": Node {
+                                "left": Object {
                                   "computed": true,
                                   "end": 668,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 39,
                                       "line": 21,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 10,
                                       "line": 21,
                                     },
                                   },
-                                  "object": Node {
+                                  "object": Object {
                                     "computed": false,
                                     "end": 650,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 21,
                                         "line": 21,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 10,
                                         "line": 21,
                                       },
                                     },
-                                    "object": Node {
+                                    "object": Object {
                                       "end": 642,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 13,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": "cov",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 10,
                                           "line": 21,
                                         },
@@ -2587,19 +2587,19 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "Identifier",
                                     },
-                                    "property": Node {
+                                    "property": Object {
                                       "end": 650,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 21,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": "perTest",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 14,
                                           "line": 21,
                                         },
@@ -2615,37 +2615,37 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "MemberExpression",
                                   },
-                                  "property": Node {
+                                  "property": Object {
                                     "computed": false,
                                     "end": 667,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 38,
                                         "line": 21,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 22,
                                         "line": 21,
                                       },
                                     },
-                                    "object": Node {
+                                    "object": Object {
                                       "end": 653,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 24,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": "ns",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 22,
                                           "line": 21,
                                         },
@@ -2656,19 +2656,19 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "Identifier",
                                     },
-                                    "property": Node {
+                                    "property": Object {
                                       "end": 667,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 38,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": "currentTestId",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 25,
                                           "line": 21,
                                         },
@@ -2689,74 +2689,74 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "MemberExpression",
                                 },
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 77,
                                     "line": 21,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 10,
                                     "line": 21,
                                   },
                                 },
                                 "operator": "=",
                                 "range": undefined,
-                                "right": Node {
+                                "right": Object {
                                   "end": 706,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "left": Node {
+                                  "left": Object {
                                     "computed": true,
                                     "end": 700,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 71,
                                         "line": 21,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 42,
                                         "line": 21,
                                       },
                                     },
-                                    "object": Node {
+                                    "object": Object {
                                       "computed": false,
                                       "end": 682,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 53,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 42,
                                           "line": 21,
                                         },
                                       },
-                                      "object": Node {
+                                      "object": Object {
                                         "end": 674,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 45,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": "cov",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 42,
                                             "line": 21,
                                           },
@@ -2767,19 +2767,19 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "Identifier",
                                       },
-                                      "property": Node {
+                                      "property": Object {
                                         "end": 682,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 53,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": "perTest",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 46,
                                             "line": 21,
                                           },
@@ -2795,37 +2795,37 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "MemberExpression",
                                     },
-                                    "property": Node {
+                                    "property": Object {
                                       "computed": false,
                                       "end": 699,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 70,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 54,
                                           "line": 21,
                                         },
                                       },
-                                      "object": Node {
+                                      "object": Object {
                                         "end": 685,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 56,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": "ns",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 54,
                                             "line": 21,
                                           },
@@ -2836,19 +2836,19 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "Identifier",
                                       },
-                                      "property": Node {
+                                      "property": Object {
                                         "end": 699,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 70,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": "currentTestId",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 57,
                                             "line": 21,
                                           },
@@ -2869,33 +2869,33 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "MemberExpression",
                                   },
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 77,
                                       "line": 21,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 42,
                                       "line": 21,
                                     },
                                   },
                                   "operator": "||",
                                   "range": undefined,
-                                  "right": Node {
+                                  "right": Object {
                                     "end": 706,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 77,
                                         "line": 21,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 75,
                                         "line": 21,
                                       },
@@ -2921,14 +2921,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 78,
                                 "line": 21,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 21,
                               },
@@ -2944,14 +2944,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 5,
                             "line": 22,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 26,
                             "line": 20,
                           },
@@ -2965,51 +2965,51 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 5,
                           "line": 22,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 20,
                         },
                       },
                       "range": undefined,
                       "start": 605,
-                      "test": Node {
+                      "test": Object {
                         "computed": false,
                         "end": 625,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 24,
                             "line": 20,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 8,
                             "line": 20,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 611,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 10,
                               "line": 20,
                             },
                             "filename": undefined,
                             "identifierName": "ns",
-                            "start": Position {
+                            "start": Object {
                               "column": 8,
                               "line": 20,
                             },
@@ -3020,19 +3020,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 625,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 24,
                               "line": 20,
                             },
                             "filename": undefined,
                             "identifierName": "currentTestId",
-                            "start": Position {
+                            "start": Object {
                               "column": 11,
                               "line": 20,
                             },
@@ -3051,24 +3051,24 @@ Object {
                       "trailingComments": undefined,
                       "type": "IfStatement",
                     },
-                    Node {
+                    Object {
                       "declarations": Array [
-                        Node {
+                        Object {
                           "end": 735,
                           "extra": undefined,
-                          "id": Node {
+                          "id": Object {
                             "end": 723,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 9,
                                 "line": 23,
                               },
                               "filename": undefined,
                               "identifierName": "a",
-                              "start": Position {
+                              "start": Object {
                                 "column": 8,
                                 "line": 23,
                               },
@@ -3079,19 +3079,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "init": Node {
+                          "init": Object {
                             "end": 735,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 21,
                                 "line": 23,
                               },
                               "filename": undefined,
                               "identifierName": "arguments",
-                              "start": Position {
+                              "start": Object {
                                 "column": 12,
                                 "line": 23,
                               },
@@ -3104,14 +3104,14 @@ Object {
                           },
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 21,
                               "line": 23,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 8,
                               "line": 23,
                             },
@@ -3127,14 +3127,14 @@ Object {
                       "innerComments": undefined,
                       "kind": "var",
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 22,
                           "line": 23,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 23,
                         },
@@ -3144,47 +3144,47 @@ Object {
                       "trailingComments": undefined,
                       "type": "VariableDeclaration",
                     },
-                    Node {
-                      "body": Node {
+                    Object {
+                      "body": Object {
                         "body": Array [
-                          Node {
+                          Object {
                             "end": 809,
-                            "expression": Node {
+                            "expression": Object {
                               "end": 808,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "computed": true,
                                 "end": 787,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 13,
                                     "line": 25,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 6,
                                     "line": 25,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "end": 781,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 7,
                                       "line": 25,
                                     },
                                     "filename": undefined,
                                     "identifierName": "c",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 6,
                                       "line": 25,
                                     },
@@ -3195,37 +3195,37 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "computed": true,
                                   "end": 786,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 12,
                                       "line": 25,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 8,
                                       "line": 25,
                                     },
                                   },
-                                  "object": Node {
+                                  "object": Object {
                                     "end": 783,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 9,
                                         "line": 25,
                                       },
                                       "filename": undefined,
                                       "identifierName": "a",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 8,
                                         "line": 25,
                                       },
@@ -3236,19 +3236,19 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "Identifier",
                                   },
-                                  "property": Node {
+                                  "property": Object {
                                     "end": 785,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 11,
                                         "line": 25,
                                       },
                                       "filename": undefined,
                                       "identifierName": "i",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 10,
                                         "line": 25,
                                       },
@@ -3269,26 +3269,26 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "MemberExpression",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 34,
                                   "line": 25,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 6,
                                   "line": 25,
                                 },
                               },
                               "operator": "=",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "end": 808,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "left": Node {
+                                "left": Object {
                                   "end": 803,
                                   "extra": Object {
                                     "parenStart": 790,
@@ -3296,37 +3296,37 @@ Object {
                                   },
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "left": Node {
+                                  "left": Object {
                                     "computed": true,
                                     "end": 798,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 24,
                                         "line": 25,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 17,
                                         "line": 25,
                                       },
                                     },
-                                    "object": Node {
+                                    "object": Object {
                                       "end": 792,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 18,
                                           "line": 25,
                                         },
                                         "filename": undefined,
                                         "identifierName": "c",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 17,
                                           "line": 25,
                                         },
@@ -3337,37 +3337,37 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "Identifier",
                                     },
-                                    "property": Node {
+                                    "property": Object {
                                       "computed": true,
                                       "end": 797,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 23,
                                           "line": 25,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 19,
                                           "line": 25,
                                         },
                                       },
-                                      "object": Node {
+                                      "object": Object {
                                         "end": 794,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 20,
                                             "line": 25,
                                           },
                                           "filename": undefined,
                                           "identifierName": "a",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 19,
                                             "line": 25,
                                           },
@@ -3378,19 +3378,19 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "Identifier",
                                       },
-                                      "property": Node {
+                                      "property": Object {
                                         "end": 796,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 22,
                                             "line": 25,
                                           },
                                           "filename": undefined,
                                           "identifierName": "i",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 21,
                                             "line": 25,
                                           },
@@ -3411,21 +3411,21 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "MemberExpression",
                                   },
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 29,
                                       "line": 25,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 17,
                                       "line": 25,
                                     },
                                   },
                                   "operator": "||",
                                   "range": undefined,
-                                  "right": Node {
+                                  "right": Object {
                                     "end": 803,
                                     "extra": Object {
                                       "raw": "0",
@@ -3433,14 +3433,14 @@ Object {
                                     },
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 29,
                                         "line": 25,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 28,
                                         "line": 25,
                                       },
@@ -3455,21 +3455,21 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "LogicalExpression",
                                 },
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 34,
                                     "line": 25,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 16,
                                     "line": 25,
                                   },
                                 },
                                 "operator": "+",
                                 "range": undefined,
-                                "right": Node {
+                                "right": Object {
                                   "end": 808,
                                   "extra": Object {
                                     "raw": "1",
@@ -3477,14 +3477,14 @@ Object {
                                   },
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 34,
                                       "line": 25,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 33,
                                       "line": 25,
                                     },
@@ -3506,14 +3506,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 35,
                                 "line": 25,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 25,
                               },
@@ -3529,14 +3529,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 5,
                             "line": 26,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 35,
                             "line": 24,
                           },
@@ -3548,24 +3548,24 @@ Object {
                       },
                       "end": 815,
                       "extra": undefined,
-                      "init": Node {
+                      "init": Object {
                         "declarations": Array [
-                          Node {
+                          Object {
                             "end": 752,
                             "extra": undefined,
-                            "id": Node {
+                            "id": Object {
                               "end": 750,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 13,
                                   "line": 24,
                                 },
                                 "filename": undefined,
                                 "identifierName": "i",
-                                "start": Position {
+                                "start": Object {
                                   "column": 12,
                                   "line": 24,
                                 },
@@ -3576,7 +3576,7 @@ Object {
                               "trailingComments": undefined,
                               "type": "Identifier",
                             },
-                            "init": Node {
+                            "init": Object {
                               "end": 752,
                               "extra": Object {
                                 "raw": "0",
@@ -3584,14 +3584,14 @@ Object {
                               },
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 15,
                                   "line": 24,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 14,
                                   "line": 24,
                                 },
@@ -3604,14 +3604,14 @@ Object {
                             },
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 15,
                                 "line": 24,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 12,
                                 "line": 24,
                               },
@@ -3627,14 +3627,14 @@ Object {
                         "innerComments": undefined,
                         "kind": "var",
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 15,
                             "line": 24,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 8,
                             "line": 24,
                           },
@@ -3646,38 +3646,38 @@ Object {
                       },
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 5,
                           "line": 26,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 24,
                         },
                       },
                       "range": undefined,
                       "start": 741,
-                      "test": Node {
+                      "test": Object {
                         "end": 766,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "end": 755,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 18,
                               "line": 24,
                             },
                             "filename": undefined,
                             "identifierName": "i",
-                            "start": Position {
+                            "start": Object {
                               "column": 17,
                               "line": 24,
                             },
@@ -3688,51 +3688,51 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 29,
                             "line": 24,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 17,
                             "line": 24,
                           },
                         },
                         "operator": "<",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "computed": false,
                           "end": 766,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 29,
                               "line": 24,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 21,
                               "line": 24,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 759,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 22,
                                 "line": 24,
                               },
                               "filename": undefined,
                               "identifierName": "a",
-                              "start": Position {
+                              "start": Object {
                                 "column": 21,
                                 "line": 24,
                               },
@@ -3743,19 +3743,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 766,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 29,
                                 "line": 24,
                               },
                               "filename": undefined,
                               "identifierName": "length",
-                              "start": Position {
+                              "start": Object {
                                 "column": 23,
                                 "line": 24,
                               },
@@ -3777,20 +3777,20 @@ Object {
                       },
                       "trailingComments": undefined,
                       "type": "ForStatement",
-                      "update": Node {
-                        "argument": Node {
+                      "update": Object {
+                        "argument": Object {
                           "end": 769,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 32,
                               "line": 24,
                             },
                             "filename": undefined,
                             "identifierName": "i",
-                            "start": Position {
+                            "start": Object {
                               "column": 31,
                               "line": 24,
                             },
@@ -3805,14 +3805,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 34,
                             "line": 24,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 31,
                             "line": 24,
                           },
@@ -3831,14 +3831,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 3,
                       "line": 27,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 19,
                       "line": 18,
                     },
@@ -3851,19 +3851,19 @@ Object {
                 "end": 819,
                 "extra": undefined,
                 "generator": false,
-                "id": Node {
+                "id": Object {
                   "end": 572,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 16,
                       "line": 18,
                     },
                     "filename": undefined,
                     "identifierName": "cover",
-                    "start": Position {
+                    "start": Object {
                       "column": 11,
                       "line": 18,
                     },
@@ -3876,14 +3876,14 @@ Object {
                 },
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 3,
                     "line": 27,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 18,
                   },
@@ -3894,26 +3894,26 @@ Object {
                 "trailingComments": undefined,
                 "type": "FunctionDeclaration",
               },
-              Node {
+              Object {
                 "end": 844,
-                "expression": Node {
+                "expression": Object {
                   "end": 843,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "left": Node {
+                  "left": Object {
                     "end": 835,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 15,
                         "line": 28,
                       },
                       "filename": undefined,
                       "identifierName": "stryCov_9fa48",
-                      "start": Position {
+                      "start": Object {
                         "column": 2,
                         "line": 28,
                       },
@@ -3924,33 +3924,33 @@ Object {
                     "trailingComments": undefined,
                     "type": "Identifier",
                   },
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 23,
                       "line": 28,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 2,
                       "line": 28,
                     },
                   },
                   "operator": "=",
                   "range": undefined,
-                  "right": Node {
+                  "right": Object {
                     "end": 843,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 23,
                         "line": 28,
                       },
                       "filename": undefined,
                       "identifierName": "cover",
-                      "start": Position {
+                      "start": Object {
                         "column": 18,
                         "line": 28,
                       },
@@ -3968,14 +3968,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 24,
                     "line": 28,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 28,
                   },
@@ -3985,23 +3985,23 @@ Object {
                 "trailingComments": undefined,
                 "type": "ExpressionStatement",
               },
-              Node {
+              Object {
                 "end": 876,
-                "expression": Node {
+                "expression": Object {
                   "arguments": Array [
-                    Node {
+                    Object {
                       "end": 863,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 18,
                           "line": 29,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 14,
                           "line": 29,
                         },
@@ -4011,19 +4011,19 @@ Object {
                       "trailingComments": undefined,
                       "type": "NullLiteral",
                     },
-                    Node {
+                    Object {
                       "end": 874,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 29,
                           "line": 29,
                         },
                         "filename": undefined,
                         "identifierName": "arguments",
-                        "start": Position {
+                        "start": Object {
                           "column": 20,
                           "line": 29,
                         },
@@ -4035,37 +4035,37 @@ Object {
                       "type": "Identifier",
                     },
                   ],
-                  "callee": Node {
+                  "callee": Object {
                     "computed": false,
                     "end": 858,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 13,
                         "line": 29,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 2,
                         "line": 29,
                       },
                     },
-                    "object": Node {
+                    "object": Object {
                       "end": 852,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 7,
                           "line": 29,
                         },
                         "filename": undefined,
                         "identifierName": "cover",
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 29,
                         },
@@ -4076,19 +4076,19 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "property": Node {
+                    "property": Object {
                       "end": 858,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 13,
                           "line": 29,
                         },
                         "filename": undefined,
                         "identifierName": "apply",
-                        "start": Position {
+                        "start": Object {
                           "column": 8,
                           "line": 29,
                         },
@@ -4108,14 +4108,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 30,
                       "line": 29,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 2,
                       "line": 29,
                     },
@@ -4128,14 +4128,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 31,
                     "line": 29,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 29,
                   },
@@ -4151,14 +4151,14 @@ Object {
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 1,
                 "line": 30,
               },
               "filename": undefined,
               "identifierName": undefined,
-              "start": Position {
+              "start": Object {
                 "column": 25,
                 "line": 15,
               },
@@ -4171,19 +4171,19 @@ Object {
           "end": 878,
           "extra": undefined,
           "generator": false,
-          "id": Node {
+          "id": Object {
             "end": 440,
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 22,
                 "line": 15,
               },
               "filename": undefined,
               "identifierName": "stryCov_9fa48",
-              "start": Position {
+              "start": Object {
                 "column": 9,
                 "line": 15,
               },
@@ -4196,14 +4196,14 @@ Object {
           },
           "innerComments": undefined,
           "leadingComments": undefined,
-          "loc": SourceLocation {
-            "end": Position {
+          "loc": Object {
+            "end": Object {
               "column": 1,
               "line": 30,
             },
             "filename": undefined,
             "identifierName": undefined,
-            "start": Position {
+            "start": Object {
               "column": 0,
               "line": 15,
             },
@@ -4214,28 +4214,28 @@ Object {
           "trailingComments": undefined,
           "type": "FunctionDeclaration",
         },
-        Node {
+        Object {
           "async": false,
-          "body": Node {
+          "body": Object {
             "body": Array [
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 936,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 919,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 8,
                           "line": 32,
                         },
                         "filename": undefined,
                         "identifierName": "ns",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 32,
                         },
@@ -4246,21 +4246,21 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "arguments": Array [],
-                      "callee": Node {
+                      "callee": Object {
                         "end": 934,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 23,
                             "line": 32,
                           },
                           "filename": undefined,
                           "identifierName": "stryNS_9fa48",
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 32,
                           },
@@ -4275,14 +4275,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 25,
                           "line": 32,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 11,
                           "line": 32,
                         },
@@ -4294,14 +4294,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 25,
                         "line": 32,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 32,
                       },
@@ -4317,14 +4317,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 26,
                     "line": 32,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 32,
                   },
@@ -4334,47 +4334,47 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "async": false,
-                "body": Node {
+                "body": Object {
                   "body": Array [
-                    Node {
-                      "argument": Node {
+                    Object {
+                      "argument": Object {
                         "end": 997,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 990,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 26,
                               "line": 34,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 11,
                               "line": 34,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 977,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 13,
                                 "line": 34,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 11,
                                 "line": 34,
                               },
@@ -4385,19 +4385,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 990,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 26,
                                 "line": 34,
                               },
                               "filename": undefined,
                               "identifierName": "activeMutant",
-                              "start": Position {
+                              "start": Object {
                                 "column": 14,
                                 "line": 34,
                               },
@@ -4413,33 +4413,33 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 33,
                             "line": 34,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 34,
                           },
                         },
                         "operator": "===",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 997,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 33,
                               "line": 34,
                             },
                             "filename": undefined,
                             "identifierName": "id",
-                            "start": Position {
+                            "start": Object {
                               "column": 31,
                               "line": 34,
                             },
@@ -4458,14 +4458,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 34,
                           "line": 34,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 34,
                         },
@@ -4481,14 +4481,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 3,
                       "line": 35,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 24,
                       "line": 33,
                     },
@@ -4501,19 +4501,19 @@ Object {
                 "end": 1002,
                 "extra": undefined,
                 "generator": false,
-                "id": Node {
+                "id": Object {
                   "end": 957,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 19,
                       "line": 33,
                     },
                     "filename": undefined,
                     "identifierName": "isActive",
-                    "start": Position {
+                    "start": Object {
                       "column": 11,
                       "line": 33,
                     },
@@ -4526,32 +4526,32 @@ Object {
                 },
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 3,
                     "line": 35,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 33,
                   },
                 },
                 "params": Array [
-                  Node {
+                  Object {
                     "end": 960,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 22,
                         "line": 33,
                       },
                       "filename": undefined,
                       "identifierName": "id",
-                      "start": Position {
+                      "start": Object {
                         "column": 20,
                         "line": 33,
                       },
@@ -4568,26 +4568,26 @@ Object {
                 "trailingComments": undefined,
                 "type": "FunctionDeclaration",
               },
-              Node {
+              Object {
                 "end": 1033,
-                "expression": Node {
+                "expression": Object {
                   "end": 1032,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "left": Node {
+                  "left": Object {
                     "end": 1021,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 18,
                         "line": 36,
                       },
                       "filename": undefined,
                       "identifierName": "stryMutAct_9fa48",
-                      "start": Position {
+                      "start": Object {
                         "column": 2,
                         "line": 36,
                       },
@@ -4598,33 +4598,33 @@ Object {
                     "trailingComments": undefined,
                     "type": "Identifier",
                   },
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 29,
                       "line": 36,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 2,
                       "line": 36,
                     },
                   },
                   "operator": "=",
                   "range": undefined,
-                  "right": Node {
+                  "right": Object {
                     "end": 1032,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 29,
                         "line": 36,
                       },
                       "filename": undefined,
                       "identifierName": "isActive",
-                      "start": Position {
+                      "start": Object {
                         "column": 21,
                         "line": 36,
                       },
@@ -4642,14 +4642,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 30,
                     "line": 36,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 36,
                   },
@@ -4659,22 +4659,22 @@ Object {
                 "trailingComments": undefined,
                 "type": "ExpressionStatement",
               },
-              Node {
-                "argument": Node {
+              Object {
+                "argument": Object {
                   "arguments": Array [
-                    Node {
+                    Object {
                       "end": 1054,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 20,
                           "line": 37,
                         },
                         "filename": undefined,
                         "identifierName": "id",
-                        "start": Position {
+                        "start": Object {
                           "column": 18,
                           "line": 37,
                         },
@@ -4686,19 +4686,19 @@ Object {
                       "type": "Identifier",
                     },
                   ],
-                  "callee": Node {
+                  "callee": Object {
                     "end": 1051,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 17,
                         "line": 37,
                       },
                       "filename": undefined,
                       "identifierName": "isActive",
-                      "start": Position {
+                      "start": Object {
                         "column": 9,
                         "line": 37,
                       },
@@ -4713,14 +4713,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 21,
                       "line": 37,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 9,
                       "line": 37,
                     },
@@ -4734,14 +4734,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 22,
                     "line": 37,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 37,
                   },
@@ -4757,14 +4757,14 @@ Object {
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 1,
                 "line": 38,
               },
               "filename": undefined,
               "identifierName": undefined,
-              "start": Position {
+              "start": Object {
                 "column": 30,
                 "line": 31,
               },
@@ -4777,19 +4777,19 @@ Object {
           "end": 1058,
           "extra": undefined,
           "generator": false,
-          "id": Node {
+          "id": Object {
             "end": 904,
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 25,
                 "line": 31,
               },
               "filename": undefined,
               "identifierName": "stryMutAct_9fa48",
-              "start": Position {
+              "start": Object {
                 "column": 9,
                 "line": 31,
               },
@@ -4802,32 +4802,32 @@ Object {
           },
           "innerComments": undefined,
           "leadingComments": undefined,
-          "loc": SourceLocation {
-            "end": Position {
+          "loc": Object {
+            "end": Object {
               "column": 1,
               "line": 38,
             },
             "filename": undefined,
             "identifierName": undefined,
-            "start": Position {
+            "start": Object {
               "column": 0,
               "line": 31,
             },
           },
           "params": Array [
-            Node {
+            Object {
               "end": 907,
               "extra": undefined,
               "innerComments": undefined,
               "leadingComments": undefined,
-              "loc": SourceLocation {
-                "end": Position {
+              "loc": Object {
+                "end": Object {
                   "column": 28,
                   "line": 31,
                 },
                 "filename": undefined,
                 "identifierName": "id",
-                "start": Position {
+                "start": Object {
                   "column": 26,
                   "line": 31,
                 },
@@ -5162,28 +5162,28 @@ Object {
     },
     "program": Node {
       "body": Array [
-        Node {
+        Object {
           "async": false,
-          "body": Node {
+          "body": Object {
             "body": Array [
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 64,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 32,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 7,
                           "line": 2,
                         },
                         "filename": undefined,
                         "identifierName": "g",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 2,
                         },
@@ -5194,11 +5194,11 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "arguments": Array [],
-                      "callee": Node {
+                      "callee": Object {
                         "arguments": Array [
-                          Node {
+                          Object {
                             "end": 61,
                             "extra": Object {
                               "raw": "\\"return this\\"",
@@ -5206,14 +5206,14 @@ Object {
                             },
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 36,
                                 "line": 2,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 23,
                                 "line": 2,
                               },
@@ -5225,19 +5225,19 @@ Object {
                             "value": "return this",
                           },
                         ],
-                        "callee": Node {
+                        "callee": Object {
                           "end": 47,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 22,
                               "line": 2,
                             },
                             "filename": undefined,
                             "identifierName": "Function",
-                            "start": Position {
+                            "start": Object {
                               "column": 14,
                               "line": 2,
                             },
@@ -5252,14 +5252,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 37,
                             "line": 2,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 10,
                             "line": 2,
                           },
@@ -5273,14 +5273,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 39,
                           "line": 2,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 10,
                           "line": 2,
                         },
@@ -5292,14 +5292,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 39,
                         "line": 2,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 2,
                       },
@@ -5315,14 +5315,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 40,
                     "line": 2,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 2,
                   },
@@ -5332,24 +5332,24 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 114,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 74,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 8,
                           "line": 3,
                         },
                         "filename": undefined,
                         "identifierName": "ns",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 3,
                         },
@@ -5360,42 +5360,42 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "end": 114,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "left": Node {
+                      "left": Object {
                         "computed": false,
                         "end": 90,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 24,
                             "line": 3,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 3,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 78,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 12,
                               "line": 3,
                             },
                             "filename": undefined,
                             "identifierName": "g",
-                            "start": Position {
+                            "start": Object {
                               "column": 11,
                               "line": 3,
                             },
@@ -5406,19 +5406,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 90,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 24,
                               "line": 3,
                             },
                             "filename": undefined,
                             "identifierName": "__stryker__",
-                            "start": Position {
+                            "start": Object {
                               "column": 13,
                               "line": 3,
                             },
@@ -5434,21 +5434,21 @@ Object {
                         "trailingComments": undefined,
                         "type": "MemberExpression",
                       },
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 48,
                           "line": 3,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 11,
                           "line": 3,
                         },
                       },
                       "operator": "||",
                       "range": undefined,
-                      "right": Node {
+                      "right": Object {
                         "end": 113,
                         "extra": Object {
                           "parenStart": 94,
@@ -5456,37 +5456,37 @@ Object {
                         },
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 108,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 42,
                               "line": 3,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 29,
                               "line": 3,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 96,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 30,
                                 "line": 3,
                               },
                               "filename": undefined,
                               "identifierName": "g",
-                              "start": Position {
+                              "start": Object {
                                 "column": 29,
                                 "line": 3,
                               },
@@ -5497,19 +5497,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 108,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 42,
                                 "line": 3,
                               },
                               "filename": undefined,
                               "identifierName": "__stryker__",
-                              "start": Position {
+                              "start": Object {
                                 "column": 31,
                                 "line": 3,
                               },
@@ -5525,33 +5525,33 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 47,
                             "line": 3,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 29,
                             "line": 3,
                           },
                         },
                         "operator": "=",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 113,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 47,
                               "line": 3,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 45,
                               "line": 3,
                             },
@@ -5572,14 +5572,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 48,
                         "line": 3,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 3,
                       },
@@ -5595,14 +5595,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 49,
                     "line": 3,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 3,
                   },
@@ -5612,48 +5612,48 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "alternate": null,
-                "consequent": Node {
+                "consequent": Object {
                   "body": Array [
-                    Node {
+                    Object {
                       "end": 298,
-                      "expression": Node {
+                      "expression": Object {
                         "end": 297,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 247,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 19,
                               "line": 5,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 4,
                               "line": 5,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 234,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 6,
                                 "line": 5,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 4,
                                 "line": 5,
                               },
@@ -5664,19 +5664,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 247,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 19,
                                 "line": 5,
                               },
                               "filename": undefined,
                               "identifierName": "activeMutant",
-                              "start": Position {
+                              "start": Object {
                                 "column": 7,
                                 "line": 5,
                               },
@@ -5692,89 +5692,89 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 69,
                             "line": 5,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 4,
                             "line": 5,
                           },
                         },
                         "operator": "=",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "arguments": Array [
-                            Node {
+                            Object {
                               "computed": false,
                               "end": 296,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 68,
                                   "line": 5,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 29,
                                   "line": 5,
                                 },
                               },
-                              "object": Node {
+                              "object": Object {
                                 "computed": false,
                                 "end": 270,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 42,
                                     "line": 5,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 29,
                                     "line": 5,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "computed": false,
                                   "end": 266,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 38,
                                       "line": 5,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 29,
                                       "line": 5,
                                     },
                                   },
-                                  "object": Node {
+                                  "object": Object {
                                     "end": 258,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 30,
                                         "line": 5,
                                       },
                                       "filename": undefined,
                                       "identifierName": "g",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 29,
                                         "line": 5,
                                       },
@@ -5785,19 +5785,19 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "Identifier",
                                   },
-                                  "property": Node {
+                                  "property": Object {
                                     "end": 266,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 38,
                                         "line": 5,
                                       },
                                       "filename": undefined,
                                       "identifierName": "process",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 31,
                                         "line": 5,
                                       },
@@ -5813,19 +5813,19 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "MemberExpression",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "end": 270,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 42,
                                       "line": 5,
                                     },
                                     "filename": undefined,
                                     "identifierName": "env",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 39,
                                       "line": 5,
                                     },
@@ -5841,19 +5841,19 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "MemberExpression",
                               },
-                              "property": Node {
+                              "property": Object {
                                 "end": 296,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 68,
                                     "line": 5,
                                   },
                                   "filename": undefined,
                                   "identifierName": "__STRYKER_ACTIVE_MUTANT__",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 43,
                                     "line": 5,
                                   },
@@ -5870,19 +5870,19 @@ Object {
                               "type": "MemberExpression",
                             },
                           ],
-                          "callee": Node {
+                          "callee": Object {
                             "end": 256,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 28,
                                 "line": 5,
                               },
                               "filename": undefined,
                               "identifierName": "Number",
-                              "start": Position {
+                              "start": Object {
                                 "column": 22,
                                 "line": 5,
                               },
@@ -5897,14 +5897,14 @@ Object {
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 69,
                               "line": 5,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 22,
                               "line": 5,
                             },
@@ -5921,14 +5921,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 70,
                           "line": 5,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 5,
                         },
@@ -5944,14 +5944,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 3,
                       "line": 6,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 110,
                       "line": 4,
                     },
@@ -5965,71 +5965,71 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 3,
                     "line": 6,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 4,
                   },
                 },
                 "range": undefined,
                 "start": 118,
-                "test": Node {
+                "test": Object {
                   "end": 224,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "left": Node {
+                  "left": Object {
                     "end": 181,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "left": Node {
+                    "left": Object {
                       "end": 164,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "left": Node {
+                      "left": Object {
                         "end": 151,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 137,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 21,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 6,
                               "line": 4,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 124,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 8,
                                 "line": 4,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 4,
                               },
@@ -6040,19 +6040,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 137,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 21,
                                 "line": 4,
                               },
                               "filename": undefined,
                               "identifierName": "activeMutant",
-                              "start": Position {
+                              "start": Object {
                                 "column": 9,
                                 "line": 4,
                               },
@@ -6068,33 +6068,33 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 35,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 6,
                             "line": 4,
                           },
                         },
                         "operator": "===",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 151,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 35,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "undefined",
-                            "start": Position {
+                            "start": Object {
                               "column": 26,
                               "line": 4,
                             },
@@ -6109,51 +6109,51 @@ Object {
                         "trailingComments": undefined,
                         "type": "BinaryExpression",
                       },
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 48,
                           "line": 4,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 4,
                         },
                       },
                       "operator": "&&",
                       "range": undefined,
-                      "right": Node {
+                      "right": Object {
                         "computed": false,
                         "end": 164,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 48,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 39,
                             "line": 4,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 156,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 40,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "g",
-                            "start": Position {
+                            "start": Object {
                               "column": 39,
                               "line": 4,
                             },
@@ -6164,19 +6164,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 164,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 48,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "process",
-                            "start": Position {
+                            "start": Object {
                               "column": 41,
                               "line": 4,
                             },
@@ -6196,69 +6196,69 @@ Object {
                       "trailingComments": undefined,
                       "type": "LogicalExpression",
                     },
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 65,
                         "line": 4,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 4,
                       },
                     },
                     "operator": "&&",
                     "range": undefined,
-                    "right": Node {
+                    "right": Object {
                       "computed": false,
                       "end": 181,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 65,
                           "line": 4,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 52,
                           "line": 4,
                         },
                       },
-                      "object": Node {
+                      "object": Object {
                         "computed": false,
                         "end": 177,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 61,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 52,
                             "line": 4,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 169,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 53,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "g",
-                            "start": Position {
+                            "start": Object {
                               "column": 52,
                               "line": 4,
                             },
@@ -6269,19 +6269,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 177,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 61,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "process",
-                            "start": Position {
+                            "start": Object {
                               "column": 54,
                               "line": 4,
                             },
@@ -6297,19 +6297,19 @@ Object {
                         "trailingComments": undefined,
                         "type": "MemberExpression",
                       },
-                      "property": Node {
+                      "property": Object {
                         "end": 181,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 65,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": "env",
-                          "start": Position {
+                          "start": Object {
                             "column": 62,
                             "line": 4,
                           },
@@ -6329,87 +6329,87 @@ Object {
                     "trailingComments": undefined,
                     "type": "LogicalExpression",
                   },
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 108,
                       "line": 4,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 6,
                       "line": 4,
                     },
                   },
                   "operator": "&&",
                   "range": undefined,
-                  "right": Node {
+                  "right": Object {
                     "computed": false,
                     "end": 224,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 108,
                         "line": 4,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 69,
                         "line": 4,
                       },
                     },
-                    "object": Node {
+                    "object": Object {
                       "computed": false,
                       "end": 198,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 82,
                           "line": 4,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 69,
                           "line": 4,
                         },
                       },
-                      "object": Node {
+                      "object": Object {
                         "computed": false,
                         "end": 194,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 78,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 69,
                             "line": 4,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 186,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 70,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "g",
-                            "start": Position {
+                            "start": Object {
                               "column": 69,
                               "line": 4,
                             },
@@ -6420,19 +6420,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 194,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 78,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": "process",
-                            "start": Position {
+                            "start": Object {
                               "column": 71,
                               "line": 4,
                             },
@@ -6448,19 +6448,19 @@ Object {
                         "trailingComments": undefined,
                         "type": "MemberExpression",
                       },
-                      "property": Node {
+                      "property": Object {
                         "end": 198,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 82,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": "env",
-                          "start": Position {
+                          "start": Object {
                             "column": 79,
                             "line": 4,
                           },
@@ -6476,19 +6476,19 @@ Object {
                       "trailingComments": undefined,
                       "type": "MemberExpression",
                     },
-                    "property": Node {
+                    "property": Object {
                       "end": 224,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 108,
                           "line": 4,
                         },
                         "filename": undefined,
                         "identifierName": "__STRYKER_ACTIVE_MUTANT__",
-                        "start": Position {
+                        "start": Object {
                           "column": 83,
                           "line": 4,
                         },
@@ -6511,24 +6511,24 @@ Object {
                 "trailingComments": undefined,
                 "type": "IfStatement",
               },
-              Node {
+              Object {
                 "async": false,
-                "body": Node {
+                "body": Object {
                   "body": Array [
-                    Node {
-                      "argument": Node {
+                    Object {
+                      "argument": Object {
                         "end": 341,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 13,
                             "line": 8,
                           },
                           "filename": undefined,
                           "identifierName": "ns",
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 8,
                           },
@@ -6543,14 +6543,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 14,
                           "line": 8,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 8,
                         },
@@ -6566,14 +6566,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 3,
                       "line": 9,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 23,
                       "line": 7,
                     },
@@ -6586,19 +6586,19 @@ Object {
                 "end": 346,
                 "extra": undefined,
                 "generator": false,
-                "id": Node {
+                "id": Object {
                   "end": 324,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 21,
                       "line": 7,
                     },
                     "filename": undefined,
                     "identifierName": "retrieveNS",
-                    "start": Position {
+                    "start": Object {
                       "column": 11,
                       "line": 7,
                     },
@@ -6611,14 +6611,14 @@ Object {
                 },
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 3,
                     "line": 9,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 7,
                   },
@@ -6629,26 +6629,26 @@ Object {
                 "trailingComments": undefined,
                 "type": "FunctionDeclaration",
               },
-              Node {
+              Object {
                 "end": 375,
-                "expression": Node {
+                "expression": Object {
                   "end": 374,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "left": Node {
+                  "left": Object {
                     "end": 361,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 14,
                         "line": 10,
                       },
                       "filename": undefined,
                       "identifierName": "stryNS_9fa48",
-                      "start": Position {
+                      "start": Object {
                         "column": 2,
                         "line": 10,
                       },
@@ -6659,33 +6659,33 @@ Object {
                     "trailingComments": undefined,
                     "type": "Identifier",
                   },
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 27,
                       "line": 10,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 2,
                       "line": 10,
                     },
                   },
                   "operator": "=",
                   "range": undefined,
-                  "right": Node {
+                  "right": Object {
                     "end": 374,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 27,
                         "line": 10,
                       },
                       "filename": undefined,
                       "identifierName": "retrieveNS",
-                      "start": Position {
+                      "start": Object {
                         "column": 17,
                         "line": 10,
                       },
@@ -6703,14 +6703,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 28,
                     "line": 10,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 10,
                   },
@@ -6720,22 +6720,22 @@ Object {
                 "trailingComments": undefined,
                 "type": "ExpressionStatement",
               },
-              Node {
-                "argument": Node {
+              Object {
+                "argument": Object {
                   "arguments": Array [],
-                  "callee": Node {
+                  "callee": Object {
                     "end": 395,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 19,
                         "line": 11,
                       },
                       "filename": undefined,
                       "identifierName": "retrieveNS",
-                      "start": Position {
+                      "start": Object {
                         "column": 9,
                         "line": 11,
                       },
@@ -6750,14 +6750,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 21,
                       "line": 11,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 9,
                       "line": 11,
                     },
@@ -6771,14 +6771,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 22,
                     "line": 11,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 11,
                   },
@@ -6794,14 +6794,14 @@ Object {
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 1,
                 "line": 12,
               },
               "filename": undefined,
               "identifierName": undefined,
-              "start": Position {
+              "start": Object {
                 "column": 23,
                 "line": 1,
               },
@@ -6814,19 +6814,19 @@ Object {
           "end": 400,
           "extra": undefined,
           "generator": false,
-          "id": Node {
+          "id": Object {
             "end": 21,
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 21,
                 "line": 1,
               },
               "filename": undefined,
               "identifierName": "stryNS_9fa48",
-              "start": Position {
+              "start": Object {
                 "column": 9,
                 "line": 1,
               },
@@ -6838,15 +6838,15 @@ Object {
             "type": "Identifier",
           },
           "innerComments": undefined,
-          "leadingComments": Array [],
-          "loc": SourceLocation {
-            "end": Position {
+          "leadingComments": undefined,
+          "loc": Object {
+            "end": Object {
               "column": 1,
               "line": 12,
             },
             "filename": undefined,
             "identifierName": undefined,
-            "start": Position {
+            "start": Object {
               "column": 0,
               "line": 1,
             },
@@ -6857,23 +6857,23 @@ Object {
           "trailingComments": undefined,
           "type": "FunctionDeclaration",
         },
-        Node {
+        Object {
           "end": 416,
-          "expression": Node {
+          "expression": Object {
             "arguments": Array [],
-            "callee": Node {
+            "callee": Object {
               "end": 413,
               "extra": undefined,
               "innerComments": undefined,
               "leadingComments": undefined,
-              "loc": SourceLocation {
-                "end": Position {
+              "loc": Object {
+                "end": Object {
                   "column": 12,
                   "line": 13,
                 },
                 "filename": undefined,
                 "identifierName": "stryNS_9fa48",
-                "start": Position {
+                "start": Object {
                   "column": 0,
                   "line": 13,
                 },
@@ -6888,14 +6888,14 @@ Object {
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 14,
                 "line": 13,
               },
               "filename": undefined,
               "identifierName": undefined,
-              "start": Position {
+              "start": Object {
                 "column": 0,
                 "line": 13,
               },
@@ -6908,14 +6908,14 @@ Object {
           "extra": undefined,
           "innerComments": undefined,
           "leadingComments": undefined,
-          "loc": SourceLocation {
-            "end": Position {
+          "loc": Object {
+            "end": Object {
               "column": 15,
               "line": 13,
             },
             "filename": undefined,
             "identifierName": undefined,
-            "start": Position {
+            "start": Object {
               "column": 0,
               "line": 13,
             },
@@ -6925,28 +6925,28 @@ Object {
           "trailingComments": undefined,
           "type": "ExpressionStatement",
         },
-        Node {
+        Object {
           "async": false,
-          "body": Node {
+          "body": Object {
             "body": Array [
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 470,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 453,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 8,
                           "line": 16,
                         },
                         "filename": undefined,
                         "identifierName": "ns",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 16,
                         },
@@ -6957,21 +6957,21 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "arguments": Array [],
-                      "callee": Node {
+                      "callee": Object {
                         "end": 468,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 23,
                             "line": 16,
                           },
                           "filename": undefined,
                           "identifierName": "stryNS_9fa48",
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 16,
                           },
@@ -6986,14 +6986,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 25,
                           "line": 16,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 11,
                           "line": 16,
                         },
@@ -7005,14 +7005,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 25,
                         "line": 16,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 16,
                       },
@@ -7028,14 +7028,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 26,
                     "line": 16,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 16,
                   },
@@ -7045,24 +7045,24 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 554,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 481,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 9,
                           "line": 17,
                         },
                         "filename": undefined,
                         "identifierName": "cov",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 17,
                         },
@@ -7073,42 +7073,42 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "end": 554,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "left": Node {
+                      "left": Object {
                         "computed": false,
                         "end": 501,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 29,
                             "line": 17,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 12,
                             "line": 17,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 486,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 14,
                               "line": 17,
                             },
                             "filename": undefined,
                             "identifierName": "ns",
-                            "start": Position {
+                            "start": Object {
                               "column": 12,
                               "line": 17,
                             },
@@ -7119,19 +7119,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 501,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 29,
                               "line": 17,
                             },
                             "filename": undefined,
                             "identifierName": "mutantCoverage",
-                            "start": Position {
+                            "start": Object {
                               "column": 15,
                               "line": 17,
                             },
@@ -7147,21 +7147,21 @@ Object {
                         "trailingComments": undefined,
                         "type": "MemberExpression",
                       },
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 82,
                           "line": 17,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 12,
                           "line": 17,
                         },
                       },
                       "operator": "||",
                       "range": undefined,
-                      "right": Node {
+                      "right": Object {
                         "end": 553,
                         "extra": Object {
                           "parenStart": 505,
@@ -7169,37 +7169,37 @@ Object {
                         },
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 523,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 51,
                               "line": 17,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 34,
                               "line": 17,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 508,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 36,
                                 "line": 17,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 34,
                                 "line": 17,
                               },
@@ -7210,19 +7210,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 523,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 51,
                                 "line": 17,
                               },
                               "filename": undefined,
                               "identifierName": "mutantCoverage",
-                              "start": Position {
+                              "start": Object {
                                 "column": 37,
                                 "line": 17,
                               },
@@ -7238,56 +7238,56 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 81,
                             "line": 17,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 34,
                             "line": 17,
                           },
                         },
                         "operator": "=",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 553,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 81,
                               "line": 17,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 54,
                               "line": 17,
                             },
                           },
                           "properties": Array [
-                            Node {
+                            Object {
                               "computed": false,
                               "end": 538,
                               "extra": undefined,
                               "innerComments": undefined,
-                              "key": Node {
+                              "key": Object {
                                 "end": 534,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 62,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": "static",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 56,
                                     "line": 17,
                                   },
@@ -7299,14 +7299,14 @@ Object {
                                 "type": "Identifier",
                               },
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 66,
                                   "line": 17,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 56,
                                   "line": 17,
                                 },
@@ -7317,19 +7317,19 @@ Object {
                               "start": 528,
                               "trailingComments": undefined,
                               "type": "ObjectProperty",
-                              "value": Node {
+                              "value": Object {
                                 "end": 538,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 66,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 64,
                                     "line": 17,
                                   },
@@ -7341,24 +7341,24 @@ Object {
                                 "type": "ObjectExpression",
                               },
                             },
-                            Node {
+                            Object {
                               "computed": false,
                               "end": 551,
                               "extra": undefined,
                               "innerComments": undefined,
-                              "key": Node {
+                              "key": Object {
                                 "end": 547,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 75,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": "perTest",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 68,
                                     "line": 17,
                                   },
@@ -7370,14 +7370,14 @@ Object {
                                 "type": "Identifier",
                               },
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 79,
                                   "line": 17,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 68,
                                   "line": 17,
                                 },
@@ -7388,19 +7388,19 @@ Object {
                               "start": 540,
                               "trailingComments": undefined,
                               "type": "ObjectProperty",
-                              "value": Node {
+                              "value": Object {
                                 "end": 551,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 79,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 77,
                                     "line": 17,
                                   },
@@ -7428,14 +7428,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 82,
                         "line": 17,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 17,
                       },
@@ -7451,14 +7451,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 83,
                     "line": 17,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 17,
                   },
@@ -7468,28 +7468,28 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "async": false,
-                "body": Node {
+                "body": Object {
                   "body": Array [
-                    Node {
+                    Object {
                       "declarations": Array [
-                        Node {
+                        Object {
                           "end": 599,
                           "extra": undefined,
-                          "id": Node {
+                          "id": Object {
                             "end": 586,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 9,
                                 "line": 19,
                               },
                               "filename": undefined,
                               "identifierName": "c",
-                              "start": Position {
+                              "start": Object {
                                 "column": 8,
                                 "line": 19,
                               },
@@ -7500,37 +7500,37 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "init": Node {
+                          "init": Object {
                             "computed": false,
                             "end": 599,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 22,
                                 "line": 19,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 12,
                                 "line": 19,
                               },
                             },
-                            "object": Node {
+                            "object": Object {
                               "end": 592,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 15,
                                   "line": 19,
                                 },
                                 "filename": undefined,
                                 "identifierName": "cov",
-                                "start": Position {
+                                "start": Object {
                                   "column": 12,
                                   "line": 19,
                                 },
@@ -7541,19 +7541,19 @@ Object {
                               "trailingComments": undefined,
                               "type": "Identifier",
                             },
-                            "property": Node {
+                            "property": Object {
                               "end": 599,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 22,
                                   "line": 19,
                                 },
                                 "filename": undefined,
                                 "identifierName": "static",
-                                "start": Position {
+                                "start": Object {
                                   "column": 16,
                                   "line": 19,
                                 },
@@ -7571,14 +7571,14 @@ Object {
                           },
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 22,
                               "line": 19,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 8,
                               "line": 19,
                             },
@@ -7594,14 +7594,14 @@ Object {
                       "innerComments": undefined,
                       "kind": "var",
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 23,
                           "line": 19,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 19,
                         },
@@ -7611,30 +7611,30 @@ Object {
                       "trailingComments": undefined,
                       "type": "VariableDeclaration",
                     },
-                    Node {
+                    Object {
                       "alternate": null,
-                      "consequent": Node {
+                      "consequent": Object {
                         "body": Array [
-                          Node {
+                          Object {
                             "end": 707,
-                            "expression": Node {
+                            "expression": Object {
                               "end": 706,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "end": 636,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 7,
                                     "line": 21,
                                   },
                                   "filename": undefined,
                                   "identifierName": "c",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 6,
                                     "line": 21,
                                   },
@@ -7645,74 +7645,74 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "Identifier",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 77,
                                   "line": 21,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 6,
                                   "line": 21,
                                 },
                               },
                               "operator": "=",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "end": 706,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "left": Node {
+                                "left": Object {
                                   "computed": true,
                                   "end": 668,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 39,
                                       "line": 21,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 10,
                                       "line": 21,
                                     },
                                   },
-                                  "object": Node {
+                                  "object": Object {
                                     "computed": false,
                                     "end": 650,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 21,
                                         "line": 21,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 10,
                                         "line": 21,
                                       },
                                     },
-                                    "object": Node {
+                                    "object": Object {
                                       "end": 642,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 13,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": "cov",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 10,
                                           "line": 21,
                                         },
@@ -7723,19 +7723,19 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "Identifier",
                                     },
-                                    "property": Node {
+                                    "property": Object {
                                       "end": 650,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 21,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": "perTest",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 14,
                                           "line": 21,
                                         },
@@ -7751,37 +7751,37 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "MemberExpression",
                                   },
-                                  "property": Node {
+                                  "property": Object {
                                     "computed": false,
                                     "end": 667,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 38,
                                         "line": 21,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 22,
                                         "line": 21,
                                       },
                                     },
-                                    "object": Node {
+                                    "object": Object {
                                       "end": 653,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 24,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": "ns",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 22,
                                           "line": 21,
                                         },
@@ -7792,19 +7792,19 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "Identifier",
                                     },
-                                    "property": Node {
+                                    "property": Object {
                                       "end": 667,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 38,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": "currentTestId",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 25,
                                           "line": 21,
                                         },
@@ -7825,74 +7825,74 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "MemberExpression",
                                 },
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 77,
                                     "line": 21,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 10,
                                     "line": 21,
                                   },
                                 },
                                 "operator": "=",
                                 "range": undefined,
-                                "right": Node {
+                                "right": Object {
                                   "end": 706,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "left": Node {
+                                  "left": Object {
                                     "computed": true,
                                     "end": 700,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 71,
                                         "line": 21,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 42,
                                         "line": 21,
                                       },
                                     },
-                                    "object": Node {
+                                    "object": Object {
                                       "computed": false,
                                       "end": 682,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 53,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 42,
                                           "line": 21,
                                         },
                                       },
-                                      "object": Node {
+                                      "object": Object {
                                         "end": 674,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 45,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": "cov",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 42,
                                             "line": 21,
                                           },
@@ -7903,19 +7903,19 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "Identifier",
                                       },
-                                      "property": Node {
+                                      "property": Object {
                                         "end": 682,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 53,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": "perTest",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 46,
                                             "line": 21,
                                           },
@@ -7931,37 +7931,37 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "MemberExpression",
                                     },
-                                    "property": Node {
+                                    "property": Object {
                                       "computed": false,
                                       "end": 699,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 70,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 54,
                                           "line": 21,
                                         },
                                       },
-                                      "object": Node {
+                                      "object": Object {
                                         "end": 685,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 56,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": "ns",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 54,
                                             "line": 21,
                                           },
@@ -7972,19 +7972,19 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "Identifier",
                                       },
-                                      "property": Node {
+                                      "property": Object {
                                         "end": 699,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 70,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": "currentTestId",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 57,
                                             "line": 21,
                                           },
@@ -8005,33 +8005,33 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "MemberExpression",
                                   },
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 77,
                                       "line": 21,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 42,
                                       "line": 21,
                                     },
                                   },
                                   "operator": "||",
                                   "range": undefined,
-                                  "right": Node {
+                                  "right": Object {
                                     "end": 706,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 77,
                                         "line": 21,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 75,
                                         "line": 21,
                                       },
@@ -8057,14 +8057,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 78,
                                 "line": 21,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 21,
                               },
@@ -8080,14 +8080,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 5,
                             "line": 22,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 26,
                             "line": 20,
                           },
@@ -8101,51 +8101,51 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 5,
                           "line": 22,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 20,
                         },
                       },
                       "range": undefined,
                       "start": 605,
-                      "test": Node {
+                      "test": Object {
                         "computed": false,
                         "end": 625,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 24,
                             "line": 20,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 8,
                             "line": 20,
                           },
                         },
-                        "object": Node {
+                        "object": Object {
                           "end": 611,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 10,
                               "line": 20,
                             },
                             "filename": undefined,
                             "identifierName": "ns",
-                            "start": Position {
+                            "start": Object {
                               "column": 8,
                               "line": 20,
                             },
@@ -8156,19 +8156,19 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "property": Node {
+                        "property": Object {
                           "end": 625,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 24,
                               "line": 20,
                             },
                             "filename": undefined,
                             "identifierName": "currentTestId",
-                            "start": Position {
+                            "start": Object {
                               "column": 11,
                               "line": 20,
                             },
@@ -8187,24 +8187,24 @@ Object {
                       "trailingComments": undefined,
                       "type": "IfStatement",
                     },
-                    Node {
+                    Object {
                       "declarations": Array [
-                        Node {
+                        Object {
                           "end": 735,
                           "extra": undefined,
-                          "id": Node {
+                          "id": Object {
                             "end": 723,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 9,
                                 "line": 23,
                               },
                               "filename": undefined,
                               "identifierName": "a",
-                              "start": Position {
+                              "start": Object {
                                 "column": 8,
                                 "line": 23,
                               },
@@ -8215,19 +8215,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "init": Node {
+                          "init": Object {
                             "end": 735,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 21,
                                 "line": 23,
                               },
                               "filename": undefined,
                               "identifierName": "arguments",
-                              "start": Position {
+                              "start": Object {
                                 "column": 12,
                                 "line": 23,
                               },
@@ -8240,14 +8240,14 @@ Object {
                           },
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 21,
                               "line": 23,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 8,
                               "line": 23,
                             },
@@ -8263,14 +8263,14 @@ Object {
                       "innerComments": undefined,
                       "kind": "var",
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 22,
                           "line": 23,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 23,
                         },
@@ -8280,47 +8280,47 @@ Object {
                       "trailingComments": undefined,
                       "type": "VariableDeclaration",
                     },
-                    Node {
-                      "body": Node {
+                    Object {
+                      "body": Object {
                         "body": Array [
-                          Node {
+                          Object {
                             "end": 809,
-                            "expression": Node {
+                            "expression": Object {
                               "end": 808,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "computed": true,
                                 "end": 787,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 13,
                                     "line": 25,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 6,
                                     "line": 25,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "end": 781,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 7,
                                       "line": 25,
                                     },
                                     "filename": undefined,
                                     "identifierName": "c",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 6,
                                       "line": 25,
                                     },
@@ -8331,37 +8331,37 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "computed": true,
                                   "end": 786,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 12,
                                       "line": 25,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 8,
                                       "line": 25,
                                     },
                                   },
-                                  "object": Node {
+                                  "object": Object {
                                     "end": 783,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 9,
                                         "line": 25,
                                       },
                                       "filename": undefined,
                                       "identifierName": "a",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 8,
                                         "line": 25,
                                       },
@@ -8372,19 +8372,19 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "Identifier",
                                   },
-                                  "property": Node {
+                                  "property": Object {
                                     "end": 785,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 11,
                                         "line": 25,
                                       },
                                       "filename": undefined,
                                       "identifierName": "i",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 10,
                                         "line": 25,
                                       },
@@ -8405,26 +8405,26 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "MemberExpression",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 34,
                                   "line": 25,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 6,
                                   "line": 25,
                                 },
                               },
                               "operator": "=",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "end": 808,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "left": Node {
+                                "left": Object {
                                   "end": 803,
                                   "extra": Object {
                                     "parenStart": 790,
@@ -8432,37 +8432,37 @@ Object {
                                   },
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "left": Node {
+                                  "left": Object {
                                     "computed": true,
                                     "end": 798,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 24,
                                         "line": 25,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 17,
                                         "line": 25,
                                       },
                                     },
-                                    "object": Node {
+                                    "object": Object {
                                       "end": 792,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 18,
                                           "line": 25,
                                         },
                                         "filename": undefined,
                                         "identifierName": "c",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 17,
                                           "line": 25,
                                         },
@@ -8473,37 +8473,37 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "Identifier",
                                     },
-                                    "property": Node {
+                                    "property": Object {
                                       "computed": true,
                                       "end": 797,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 23,
                                           "line": 25,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 19,
                                           "line": 25,
                                         },
                                       },
-                                      "object": Node {
+                                      "object": Object {
                                         "end": 794,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 20,
                                             "line": 25,
                                           },
                                           "filename": undefined,
                                           "identifierName": "a",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 19,
                                             "line": 25,
                                           },
@@ -8514,19 +8514,19 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "Identifier",
                                       },
-                                      "property": Node {
+                                      "property": Object {
                                         "end": 796,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 22,
                                             "line": 25,
                                           },
                                           "filename": undefined,
                                           "identifierName": "i",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 21,
                                             "line": 25,
                                           },
@@ -8547,21 +8547,21 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "MemberExpression",
                                   },
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 29,
                                       "line": 25,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 17,
                                       "line": 25,
                                     },
                                   },
                                   "operator": "||",
                                   "range": undefined,
-                                  "right": Node {
+                                  "right": Object {
                                     "end": 803,
                                     "extra": Object {
                                       "raw": "0",
@@ -8569,14 +8569,14 @@ Object {
                                     },
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 29,
                                         "line": 25,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 28,
                                         "line": 25,
                                       },
@@ -8591,21 +8591,21 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "LogicalExpression",
                                 },
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 34,
                                     "line": 25,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 16,
                                     "line": 25,
                                   },
                                 },
                                 "operator": "+",
                                 "range": undefined,
-                                "right": Node {
+                                "right": Object {
                                   "end": 808,
                                   "extra": Object {
                                     "raw": "1",
@@ -8613,14 +8613,14 @@ Object {
                                   },
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 34,
                                       "line": 25,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 33,
                                       "line": 25,
                                     },
@@ -8642,14 +8642,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 35,
                                 "line": 25,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 25,
                               },
@@ -8665,14 +8665,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 5,
                             "line": 26,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 35,
                             "line": 24,
                           },
@@ -8684,24 +8684,24 @@ Object {
                       },
                       "end": 815,
                       "extra": undefined,
-                      "init": Node {
+                      "init": Object {
                         "declarations": Array [
-                          Node {
+                          Object {
                             "end": 752,
                             "extra": undefined,
-                            "id": Node {
+                            "id": Object {
                               "end": 750,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 13,
                                   "line": 24,
                                 },
                                 "filename": undefined,
                                 "identifierName": "i",
-                                "start": Position {
+                                "start": Object {
                                   "column": 12,
                                   "line": 24,
                                 },
@@ -8712,7 +8712,7 @@ Object {
                               "trailingComments": undefined,
                               "type": "Identifier",
                             },
-                            "init": Node {
+                            "init": Object {
                               "end": 752,
                               "extra": Object {
                                 "raw": "0",
@@ -8720,14 +8720,14 @@ Object {
                               },
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 15,
                                   "line": 24,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 14,
                                   "line": 24,
                                 },
@@ -8740,14 +8740,14 @@ Object {
                             },
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 15,
                                 "line": 24,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 12,
                                 "line": 24,
                               },
@@ -8763,14 +8763,14 @@ Object {
                         "innerComments": undefined,
                         "kind": "var",
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 15,
                             "line": 24,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 8,
                             "line": 24,
                           },
@@ -8782,38 +8782,38 @@ Object {
                       },
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 5,
                           "line": 26,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 24,
                         },
                       },
                       "range": undefined,
                       "start": 741,
-                      "test": Node {
+                      "test": Object {
                         "end": 766,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "end": 755,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 18,
                               "line": 24,
                             },
                             "filename": undefined,
                             "identifierName": "i",
-                            "start": Position {
+                            "start": Object {
                               "column": 17,
                               "line": 24,
                             },
@@ -8824,51 +8824,51 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 29,
                             "line": 24,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 17,
                             "line": 24,
                           },
                         },
                         "operator": "<",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "computed": false,
                           "end": 766,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 29,
                               "line": 24,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 21,
                               "line": 24,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 759,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 22,
                                 "line": 24,
                               },
                               "filename": undefined,
                               "identifierName": "a",
-                              "start": Position {
+                              "start": Object {
                                 "column": 21,
                                 "line": 24,
                               },
@@ -8879,19 +8879,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 766,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 29,
                                 "line": 24,
                               },
                               "filename": undefined,
                               "identifierName": "length",
-                              "start": Position {
+                              "start": Object {
                                 "column": 23,
                                 "line": 24,
                               },
@@ -8913,20 +8913,20 @@ Object {
                       },
                       "trailingComments": undefined,
                       "type": "ForStatement",
-                      "update": Node {
-                        "argument": Node {
+                      "update": Object {
+                        "argument": Object {
                           "end": 769,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 32,
                               "line": 24,
                             },
                             "filename": undefined,
                             "identifierName": "i",
-                            "start": Position {
+                            "start": Object {
                               "column": 31,
                               "line": 24,
                             },
@@ -8941,14 +8941,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 34,
                             "line": 24,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 31,
                             "line": 24,
                           },
@@ -8967,14 +8967,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 3,
                       "line": 27,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 19,
                       "line": 18,
                     },
@@ -8987,19 +8987,19 @@ Object {
                 "end": 819,
                 "extra": undefined,
                 "generator": false,
-                "id": Node {
+                "id": Object {
                   "end": 572,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 16,
                       "line": 18,
                     },
                     "filename": undefined,
                     "identifierName": "cover",
-                    "start": Position {
+                    "start": Object {
                       "column": 11,
                       "line": 18,
                     },
@@ -9012,14 +9012,14 @@ Object {
                 },
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 3,
                     "line": 27,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 18,
                   },
@@ -9030,26 +9030,26 @@ Object {
                 "trailingComments": undefined,
                 "type": "FunctionDeclaration",
               },
-              Node {
+              Object {
                 "end": 844,
-                "expression": Node {
+                "expression": Object {
                   "end": 843,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "left": Node {
+                  "left": Object {
                     "end": 835,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 15,
                         "line": 28,
                       },
                       "filename": undefined,
                       "identifierName": "stryCov_9fa48",
-                      "start": Position {
+                      "start": Object {
                         "column": 2,
                         "line": 28,
                       },
@@ -9060,33 +9060,33 @@ Object {
                     "trailingComments": undefined,
                     "type": "Identifier",
                   },
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 23,
                       "line": 28,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 2,
                       "line": 28,
                     },
                   },
                   "operator": "=",
                   "range": undefined,
-                  "right": Node {
+                  "right": Object {
                     "end": 843,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 23,
                         "line": 28,
                       },
                       "filename": undefined,
                       "identifierName": "cover",
-                      "start": Position {
+                      "start": Object {
                         "column": 18,
                         "line": 28,
                       },
@@ -9104,14 +9104,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 24,
                     "line": 28,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 28,
                   },
@@ -9121,23 +9121,23 @@ Object {
                 "trailingComments": undefined,
                 "type": "ExpressionStatement",
               },
-              Node {
+              Object {
                 "end": 876,
-                "expression": Node {
+                "expression": Object {
                   "arguments": Array [
-                    Node {
+                    Object {
                       "end": 863,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 18,
                           "line": 29,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 14,
                           "line": 29,
                         },
@@ -9147,19 +9147,19 @@ Object {
                       "trailingComments": undefined,
                       "type": "NullLiteral",
                     },
-                    Node {
+                    Object {
                       "end": 874,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 29,
                           "line": 29,
                         },
                         "filename": undefined,
                         "identifierName": "arguments",
-                        "start": Position {
+                        "start": Object {
                           "column": 20,
                           "line": 29,
                         },
@@ -9171,37 +9171,37 @@ Object {
                       "type": "Identifier",
                     },
                   ],
-                  "callee": Node {
+                  "callee": Object {
                     "computed": false,
                     "end": 858,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 13,
                         "line": 29,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 2,
                         "line": 29,
                       },
                     },
-                    "object": Node {
+                    "object": Object {
                       "end": 852,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 7,
                           "line": 29,
                         },
                         "filename": undefined,
                         "identifierName": "cover",
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 29,
                         },
@@ -9212,19 +9212,19 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "property": Node {
+                    "property": Object {
                       "end": 858,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 13,
                           "line": 29,
                         },
                         "filename": undefined,
                         "identifierName": "apply",
-                        "start": Position {
+                        "start": Object {
                           "column": 8,
                           "line": 29,
                         },
@@ -9244,14 +9244,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 30,
                       "line": 29,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 2,
                       "line": 29,
                     },
@@ -9264,14 +9264,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 31,
                     "line": 29,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 29,
                   },
@@ -9287,14 +9287,14 @@ Object {
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 1,
                 "line": 30,
               },
               "filename": undefined,
               "identifierName": undefined,
-              "start": Position {
+              "start": Object {
                 "column": 25,
                 "line": 15,
               },
@@ -9307,19 +9307,19 @@ Object {
           "end": 878,
           "extra": undefined,
           "generator": false,
-          "id": Node {
+          "id": Object {
             "end": 440,
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 22,
                 "line": 15,
               },
               "filename": undefined,
               "identifierName": "stryCov_9fa48",
-              "start": Position {
+              "start": Object {
                 "column": 9,
                 "line": 15,
               },
@@ -9332,14 +9332,14 @@ Object {
           },
           "innerComments": undefined,
           "leadingComments": undefined,
-          "loc": SourceLocation {
-            "end": Position {
+          "loc": Object {
+            "end": Object {
               "column": 1,
               "line": 30,
             },
             "filename": undefined,
             "identifierName": undefined,
-            "start": Position {
+            "start": Object {
               "column": 0,
               "line": 15,
             },
@@ -9350,28 +9350,28 @@ Object {
           "trailingComments": undefined,
           "type": "FunctionDeclaration",
         },
-        Node {
+        Object {
           "async": false,
-          "body": Node {
+          "body": Object {
             "body": Array [
-              Node {
+              Object {
                 "declarations": Array [
-                  Node {
+                  Object {
                     "end": 936,
                     "extra": undefined,
-                    "id": Node {
+                    "id": Object {
                       "end": 919,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 8,
                           "line": 32,
                         },
                         "filename": undefined,
                         "identifierName": "ns",
-                        "start": Position {
+                        "start": Object {
                           "column": 6,
                           "line": 32,
                         },
@@ -9382,21 +9382,21 @@ Object {
                       "trailingComments": undefined,
                       "type": "Identifier",
                     },
-                    "init": Node {
+                    "init": Object {
                       "arguments": Array [],
-                      "callee": Node {
+                      "callee": Object {
                         "end": 934,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 23,
                             "line": 32,
                           },
                           "filename": undefined,
                           "identifierName": "stryNS_9fa48",
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 32,
                           },
@@ -9411,14 +9411,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 25,
                           "line": 32,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 11,
                           "line": 32,
                         },
@@ -9430,14 +9430,14 @@ Object {
                     },
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 25,
                         "line": 32,
                       },
                       "filename": undefined,
                       "identifierName": undefined,
-                      "start": Position {
+                      "start": Object {
                         "column": 6,
                         "line": 32,
                       },
@@ -9453,14 +9453,14 @@ Object {
                 "innerComments": undefined,
                 "kind": "var",
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 26,
                     "line": 32,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 32,
                   },
@@ -9470,47 +9470,47 @@ Object {
                 "trailingComments": undefined,
                 "type": "VariableDeclaration",
               },
-              Node {
+              Object {
                 "async": false,
-                "body": Node {
+                "body": Object {
                   "body": Array [
-                    Node {
-                      "argument": Node {
+                    Object {
+                      "argument": Object {
                         "end": 997,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "computed": false,
                           "end": 990,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 26,
                               "line": 34,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 11,
                               "line": 34,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 977,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 13,
                                 "line": 34,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 11,
                                 "line": 34,
                               },
@@ -9521,19 +9521,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 990,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 26,
                                 "line": 34,
                               },
                               "filename": undefined,
                               "identifierName": "activeMutant",
-                              "start": Position {
+                              "start": Object {
                                 "column": 14,
                                 "line": 34,
                               },
@@ -9549,33 +9549,33 @@ Object {
                           "trailingComments": undefined,
                           "type": "MemberExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 33,
                             "line": 34,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 34,
                           },
                         },
                         "operator": "===",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 997,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 33,
                               "line": 34,
                             },
                             "filename": undefined,
                             "identifierName": "id",
-                            "start": Position {
+                            "start": Object {
                               "column": 31,
                               "line": 34,
                             },
@@ -9594,14 +9594,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 34,
                           "line": 34,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 4,
                           "line": 34,
                         },
@@ -9617,14 +9617,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 3,
                       "line": 35,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 24,
                       "line": 33,
                     },
@@ -9637,19 +9637,19 @@ Object {
                 "end": 1002,
                 "extra": undefined,
                 "generator": false,
-                "id": Node {
+                "id": Object {
                   "end": 957,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 19,
                       "line": 33,
                     },
                     "filename": undefined,
                     "identifierName": "isActive",
-                    "start": Position {
+                    "start": Object {
                       "column": 11,
                       "line": 33,
                     },
@@ -9662,32 +9662,32 @@ Object {
                 },
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 3,
                     "line": 35,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 33,
                   },
                 },
                 "params": Array [
-                  Node {
+                  Object {
                     "end": 960,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 22,
                         "line": 33,
                       },
                       "filename": undefined,
                       "identifierName": "id",
-                      "start": Position {
+                      "start": Object {
                         "column": 20,
                         "line": 33,
                       },
@@ -9704,26 +9704,26 @@ Object {
                 "trailingComments": undefined,
                 "type": "FunctionDeclaration",
               },
-              Node {
+              Object {
                 "end": 1033,
-                "expression": Node {
+                "expression": Object {
                   "end": 1032,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "left": Node {
+                  "left": Object {
                     "end": 1021,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 18,
                         "line": 36,
                       },
                       "filename": undefined,
                       "identifierName": "stryMutAct_9fa48",
-                      "start": Position {
+                      "start": Object {
                         "column": 2,
                         "line": 36,
                       },
@@ -9734,33 +9734,33 @@ Object {
                     "trailingComments": undefined,
                     "type": "Identifier",
                   },
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 29,
                       "line": 36,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 2,
                       "line": 36,
                     },
                   },
                   "operator": "=",
                   "range": undefined,
-                  "right": Node {
+                  "right": Object {
                     "end": 1032,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 29,
                         "line": 36,
                       },
                       "filename": undefined,
                       "identifierName": "isActive",
-                      "start": Position {
+                      "start": Object {
                         "column": 21,
                         "line": 36,
                       },
@@ -9778,14 +9778,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 30,
                     "line": 36,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 36,
                   },
@@ -9795,22 +9795,22 @@ Object {
                 "trailingComments": undefined,
                 "type": "ExpressionStatement",
               },
-              Node {
-                "argument": Node {
+              Object {
+                "argument": Object {
                   "arguments": Array [
-                    Node {
+                    Object {
                       "end": 1054,
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 20,
                           "line": 37,
                         },
                         "filename": undefined,
                         "identifierName": "id",
-                        "start": Position {
+                        "start": Object {
                           "column": 18,
                           "line": 37,
                         },
@@ -9822,19 +9822,19 @@ Object {
                       "type": "Identifier",
                     },
                   ],
-                  "callee": Node {
+                  "callee": Object {
                     "end": 1051,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 17,
                         "line": 37,
                       },
                       "filename": undefined,
                       "identifierName": "isActive",
-                      "start": Position {
+                      "start": Object {
                         "column": 9,
                         "line": 37,
                       },
@@ -9849,14 +9849,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 21,
                       "line": 37,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 9,
                       "line": 37,
                     },
@@ -9870,14 +9870,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 22,
                     "line": 37,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 2,
                     "line": 37,
                   },
@@ -9893,14 +9893,14 @@ Object {
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 1,
                 "line": 38,
               },
               "filename": undefined,
               "identifierName": undefined,
-              "start": Position {
+              "start": Object {
                 "column": 30,
                 "line": 31,
               },
@@ -9913,19 +9913,19 @@ Object {
           "end": 1058,
           "extra": undefined,
           "generator": false,
-          "id": Node {
+          "id": Object {
             "end": 904,
             "extra": undefined,
             "innerComments": undefined,
             "leadingComments": undefined,
-            "loc": SourceLocation {
-              "end": Position {
+            "loc": Object {
+              "end": Object {
                 "column": 25,
                 "line": 31,
               },
               "filename": undefined,
               "identifierName": "stryMutAct_9fa48",
-              "start": Position {
+              "start": Object {
                 "column": 9,
                 "line": 31,
               },
@@ -9938,32 +9938,32 @@ Object {
           },
           "innerComments": undefined,
           "leadingComments": undefined,
-          "loc": SourceLocation {
-            "end": Position {
+          "loc": Object {
+            "end": Object {
               "column": 1,
               "line": 38,
             },
             "filename": undefined,
             "identifierName": undefined,
-            "start": Position {
+            "start": Object {
               "column": 0,
               "line": 31,
             },
           },
           "params": Array [
-            Node {
+            Object {
               "end": 907,
               "extra": undefined,
               "innerComments": undefined,
               "leadingComments": undefined,
-              "loc": SourceLocation {
-                "end": Position {
+              "loc": Object {
+                "end": Object {
                   "column": 28,
                   "line": 31,
                 },
                 "filename": undefined,
                 "identifierName": "id",
-                "start": Position {
+                "start": Object {
                   "column": 26,
                   "line": 31,
                 },
@@ -10348,28 +10348,28 @@ Object {
           },
           "program": Node {
             "body": Array [
-              Node {
+              Object {
                 "async": false,
-                "body": Node {
+                "body": Object {
                   "body": Array [
-                    Node {
+                    Object {
                       "declarations": Array [
-                        Node {
+                        Object {
                           "end": 64,
                           "extra": undefined,
-                          "id": Node {
+                          "id": Object {
                             "end": 32,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 7,
                                 "line": 2,
                               },
                               "filename": undefined,
                               "identifierName": "g",
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 2,
                               },
@@ -10380,11 +10380,11 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "init": Node {
+                          "init": Object {
                             "arguments": Array [],
-                            "callee": Node {
+                            "callee": Object {
                               "arguments": Array [
-                                Node {
+                                Object {
                                   "end": 61,
                                   "extra": Object {
                                     "raw": "\\"return this\\"",
@@ -10392,14 +10392,14 @@ Object {
                                   },
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 36,
                                       "line": 2,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 23,
                                       "line": 2,
                                     },
@@ -10411,19 +10411,19 @@ Object {
                                   "value": "return this",
                                 },
                               ],
-                              "callee": Node {
+                              "callee": Object {
                                 "end": 47,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 22,
                                     "line": 2,
                                   },
                                   "filename": undefined,
                                   "identifierName": "Function",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 14,
                                     "line": 2,
                                   },
@@ -10438,14 +10438,14 @@ Object {
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 37,
                                   "line": 2,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 10,
                                   "line": 2,
                                 },
@@ -10459,14 +10459,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 39,
                                 "line": 2,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 10,
                                 "line": 2,
                               },
@@ -10478,14 +10478,14 @@ Object {
                           },
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 39,
                               "line": 2,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 6,
                               "line": 2,
                             },
@@ -10501,14 +10501,14 @@ Object {
                       "innerComments": undefined,
                       "kind": "var",
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 40,
                           "line": 2,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 2,
                         },
@@ -10518,24 +10518,24 @@ Object {
                       "trailingComments": undefined,
                       "type": "VariableDeclaration",
                     },
-                    Node {
+                    Object {
                       "declarations": Array [
-                        Node {
+                        Object {
                           "end": 114,
                           "extra": undefined,
-                          "id": Node {
+                          "id": Object {
                             "end": 74,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 8,
                                 "line": 3,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 3,
                               },
@@ -10546,42 +10546,42 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "init": Node {
+                          "init": Object {
                             "end": 114,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "left": Node {
+                            "left": Object {
                               "computed": false,
                               "end": 90,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 24,
                                   "line": 3,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 11,
                                   "line": 3,
                                 },
                               },
-                              "object": Node {
+                              "object": Object {
                                 "end": 78,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 12,
                                     "line": 3,
                                   },
                                   "filename": undefined,
                                   "identifierName": "g",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 11,
                                     "line": 3,
                                   },
@@ -10592,19 +10592,19 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "Identifier",
                               },
-                              "property": Node {
+                              "property": Object {
                                 "end": 90,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 24,
                                     "line": 3,
                                   },
                                   "filename": undefined,
                                   "identifierName": "__stryker__",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 13,
                                     "line": 3,
                                   },
@@ -10620,21 +10620,21 @@ Object {
                               "trailingComments": undefined,
                               "type": "MemberExpression",
                             },
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 48,
                                 "line": 3,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 11,
                                 "line": 3,
                               },
                             },
                             "operator": "||",
                             "range": undefined,
-                            "right": Node {
+                            "right": Object {
                               "end": 113,
                               "extra": Object {
                                 "parenStart": 94,
@@ -10642,37 +10642,37 @@ Object {
                               },
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "computed": false,
                                 "end": 108,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 42,
                                     "line": 3,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 29,
                                     "line": 3,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "end": 96,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 30,
                                       "line": 3,
                                     },
                                     "filename": undefined,
                                     "identifierName": "g",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 29,
                                       "line": 3,
                                     },
@@ -10683,19 +10683,19 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "end": 108,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 42,
                                       "line": 3,
                                     },
                                     "filename": undefined,
                                     "identifierName": "__stryker__",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 31,
                                       "line": 3,
                                     },
@@ -10711,33 +10711,33 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "MemberExpression",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 47,
                                   "line": 3,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 29,
                                   "line": 3,
                                 },
                               },
                               "operator": "=",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "end": 113,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 47,
                                     "line": 3,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 45,
                                     "line": 3,
                                   },
@@ -10758,14 +10758,14 @@ Object {
                           },
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 48,
                               "line": 3,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 6,
                               "line": 3,
                             },
@@ -10781,14 +10781,14 @@ Object {
                       "innerComments": undefined,
                       "kind": "var",
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 49,
                           "line": 3,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 3,
                         },
@@ -10798,48 +10798,48 @@ Object {
                       "trailingComments": undefined,
                       "type": "VariableDeclaration",
                     },
-                    Node {
+                    Object {
                       "alternate": null,
-                      "consequent": Node {
+                      "consequent": Object {
                         "body": Array [
-                          Node {
+                          Object {
                             "end": 298,
-                            "expression": Node {
+                            "expression": Object {
                               "end": 297,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "computed": false,
                                 "end": 247,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 19,
                                     "line": 5,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 4,
                                     "line": 5,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "end": 234,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 6,
                                       "line": 5,
                                     },
                                     "filename": undefined,
                                     "identifierName": "ns",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 4,
                                       "line": 5,
                                     },
@@ -10850,19 +10850,19 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "end": 247,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 19,
                                       "line": 5,
                                     },
                                     "filename": undefined,
                                     "identifierName": "activeMutant",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 7,
                                       "line": 5,
                                     },
@@ -10878,89 +10878,89 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "MemberExpression",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 69,
                                   "line": 5,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 4,
                                   "line": 5,
                                 },
                               },
                               "operator": "=",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "arguments": Array [
-                                  Node {
+                                  Object {
                                     "computed": false,
                                     "end": 296,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 68,
                                         "line": 5,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 29,
                                         "line": 5,
                                       },
                                     },
-                                    "object": Node {
+                                    "object": Object {
                                       "computed": false,
                                       "end": 270,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 42,
                                           "line": 5,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 29,
                                           "line": 5,
                                         },
                                       },
-                                      "object": Node {
+                                      "object": Object {
                                         "computed": false,
                                         "end": 266,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 38,
                                             "line": 5,
                                           },
                                           "filename": undefined,
                                           "identifierName": undefined,
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 29,
                                             "line": 5,
                                           },
                                         },
-                                        "object": Node {
+                                        "object": Object {
                                           "end": 258,
                                           "extra": undefined,
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 30,
                                               "line": 5,
                                             },
                                             "filename": undefined,
                                             "identifierName": "g",
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 29,
                                               "line": 5,
                                             },
@@ -10971,19 +10971,19 @@ Object {
                                           "trailingComments": undefined,
                                           "type": "Identifier",
                                         },
-                                        "property": Node {
+                                        "property": Object {
                                           "end": 266,
                                           "extra": undefined,
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 38,
                                               "line": 5,
                                             },
                                             "filename": undefined,
                                             "identifierName": "process",
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 31,
                                               "line": 5,
                                             },
@@ -10999,19 +10999,19 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "MemberExpression",
                                       },
-                                      "property": Node {
+                                      "property": Object {
                                         "end": 270,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 42,
                                             "line": 5,
                                           },
                                           "filename": undefined,
                                           "identifierName": "env",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 39,
                                             "line": 5,
                                           },
@@ -11027,19 +11027,19 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "MemberExpression",
                                     },
-                                    "property": Node {
+                                    "property": Object {
                                       "end": 296,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 68,
                                           "line": 5,
                                         },
                                         "filename": undefined,
                                         "identifierName": "__STRYKER_ACTIVE_MUTANT__",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 43,
                                           "line": 5,
                                         },
@@ -11056,19 +11056,19 @@ Object {
                                     "type": "MemberExpression",
                                   },
                                 ],
-                                "callee": Node {
+                                "callee": Object {
                                   "end": 256,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 28,
                                       "line": 5,
                                     },
                                     "filename": undefined,
                                     "identifierName": "Number",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 22,
                                       "line": 5,
                                     },
@@ -11083,14 +11083,14 @@ Object {
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 69,
                                     "line": 5,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 22,
                                     "line": 5,
                                   },
@@ -11107,14 +11107,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 70,
                                 "line": 5,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 4,
                                 "line": 5,
                               },
@@ -11130,14 +11130,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 3,
                             "line": 6,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 110,
                             "line": 4,
                           },
@@ -11151,71 +11151,71 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 3,
                           "line": 6,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 4,
                         },
                       },
                       "range": undefined,
                       "start": 118,
-                      "test": Node {
+                      "test": Object {
                         "end": 224,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "end": 181,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "left": Node {
+                          "left": Object {
                             "end": 164,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "left": Node {
+                            "left": Object {
                               "end": 151,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "computed": false,
                                 "end": 137,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 21,
                                     "line": 4,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 6,
                                     "line": 4,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "end": 124,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 8,
                                       "line": 4,
                                     },
                                     "filename": undefined,
                                     "identifierName": "ns",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 6,
                                       "line": 4,
                                     },
@@ -11226,19 +11226,19 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "end": 137,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 21,
                                       "line": 4,
                                     },
                                     "filename": undefined,
                                     "identifierName": "activeMutant",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 9,
                                       "line": 4,
                                     },
@@ -11254,33 +11254,33 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "MemberExpression",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 35,
                                   "line": 4,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 6,
                                   "line": 4,
                                 },
                               },
                               "operator": "===",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "end": 151,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 35,
                                     "line": 4,
                                   },
                                   "filename": undefined,
                                   "identifierName": "undefined",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 26,
                                     "line": 4,
                                   },
@@ -11295,51 +11295,51 @@ Object {
                               "trailingComments": undefined,
                               "type": "BinaryExpression",
                             },
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 48,
                                 "line": 4,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 4,
                               },
                             },
                             "operator": "&&",
                             "range": undefined,
-                            "right": Node {
+                            "right": Object {
                               "computed": false,
                               "end": 164,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 48,
                                   "line": 4,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 39,
                                   "line": 4,
                                 },
                               },
-                              "object": Node {
+                              "object": Object {
                                 "end": 156,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 40,
                                     "line": 4,
                                   },
                                   "filename": undefined,
                                   "identifierName": "g",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 39,
                                     "line": 4,
                                   },
@@ -11350,19 +11350,19 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "Identifier",
                               },
-                              "property": Node {
+                              "property": Object {
                                 "end": 164,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 48,
                                     "line": 4,
                                   },
                                   "filename": undefined,
                                   "identifierName": "process",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 41,
                                     "line": 4,
                                   },
@@ -11382,69 +11382,69 @@ Object {
                             "trailingComments": undefined,
                             "type": "LogicalExpression",
                           },
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 65,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 6,
                               "line": 4,
                             },
                           },
                           "operator": "&&",
                           "range": undefined,
-                          "right": Node {
+                          "right": Object {
                             "computed": false,
                             "end": 181,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 65,
                                 "line": 4,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 52,
                                 "line": 4,
                               },
                             },
-                            "object": Node {
+                            "object": Object {
                               "computed": false,
                               "end": 177,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 61,
                                   "line": 4,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 52,
                                   "line": 4,
                                 },
                               },
-                              "object": Node {
+                              "object": Object {
                                 "end": 169,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 53,
                                     "line": 4,
                                   },
                                   "filename": undefined,
                                   "identifierName": "g",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 52,
                                     "line": 4,
                                   },
@@ -11455,19 +11455,19 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "Identifier",
                               },
-                              "property": Node {
+                              "property": Object {
                                 "end": 177,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 61,
                                     "line": 4,
                                   },
                                   "filename": undefined,
                                   "identifierName": "process",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 54,
                                     "line": 4,
                                   },
@@ -11483,19 +11483,19 @@ Object {
                               "trailingComments": undefined,
                               "type": "MemberExpression",
                             },
-                            "property": Node {
+                            "property": Object {
                               "end": 181,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 65,
                                   "line": 4,
                                 },
                                 "filename": undefined,
                                 "identifierName": "env",
-                                "start": Position {
+                                "start": Object {
                                   "column": 62,
                                   "line": 4,
                                 },
@@ -11515,87 +11515,87 @@ Object {
                           "trailingComments": undefined,
                           "type": "LogicalExpression",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 108,
                             "line": 4,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 6,
                             "line": 4,
                           },
                         },
                         "operator": "&&",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "computed": false,
                           "end": 224,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 108,
                               "line": 4,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 69,
                               "line": 4,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "computed": false,
                             "end": 198,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 82,
                                 "line": 4,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 69,
                                 "line": 4,
                               },
                             },
-                            "object": Node {
+                            "object": Object {
                               "computed": false,
                               "end": 194,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 78,
                                   "line": 4,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 69,
                                   "line": 4,
                                 },
                               },
-                              "object": Node {
+                              "object": Object {
                                 "end": 186,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 70,
                                     "line": 4,
                                   },
                                   "filename": undefined,
                                   "identifierName": "g",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 69,
                                     "line": 4,
                                   },
@@ -11606,19 +11606,19 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "Identifier",
                               },
-                              "property": Node {
+                              "property": Object {
                                 "end": 194,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 78,
                                     "line": 4,
                                   },
                                   "filename": undefined,
                                   "identifierName": "process",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 71,
                                     "line": 4,
                                   },
@@ -11634,19 +11634,19 @@ Object {
                               "trailingComments": undefined,
                               "type": "MemberExpression",
                             },
-                            "property": Node {
+                            "property": Object {
                               "end": 198,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 82,
                                   "line": 4,
                                 },
                                 "filename": undefined,
                                 "identifierName": "env",
-                                "start": Position {
+                                "start": Object {
                                   "column": 79,
                                   "line": 4,
                                 },
@@ -11662,19 +11662,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "MemberExpression",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 224,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 108,
                                 "line": 4,
                               },
                               "filename": undefined,
                               "identifierName": "__STRYKER_ACTIVE_MUTANT__",
-                              "start": Position {
+                              "start": Object {
                                 "column": 83,
                                 "line": 4,
                               },
@@ -11697,24 +11697,24 @@ Object {
                       "trailingComments": undefined,
                       "type": "IfStatement",
                     },
-                    Node {
+                    Object {
                       "async": false,
-                      "body": Node {
+                      "body": Object {
                         "body": Array [
-                          Node {
-                            "argument": Node {
+                          Object {
+                            "argument": Object {
                               "end": 341,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 13,
                                   "line": 8,
                                 },
                                 "filename": undefined,
                                 "identifierName": "ns",
-                                "start": Position {
+                                "start": Object {
                                   "column": 11,
                                   "line": 8,
                                 },
@@ -11729,14 +11729,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 14,
                                 "line": 8,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 4,
                                 "line": 8,
                               },
@@ -11752,14 +11752,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 3,
                             "line": 9,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 23,
                             "line": 7,
                           },
@@ -11772,19 +11772,19 @@ Object {
                       "end": 346,
                       "extra": undefined,
                       "generator": false,
-                      "id": Node {
+                      "id": Object {
                         "end": 324,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 21,
                             "line": 7,
                           },
                           "filename": undefined,
                           "identifierName": "retrieveNS",
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 7,
                           },
@@ -11797,14 +11797,14 @@ Object {
                       },
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 3,
                           "line": 9,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 7,
                         },
@@ -11815,26 +11815,26 @@ Object {
                       "trailingComments": undefined,
                       "type": "FunctionDeclaration",
                     },
-                    Node {
+                    Object {
                       "end": 375,
-                      "expression": Node {
+                      "expression": Object {
                         "end": 374,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "end": 361,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 14,
                               "line": 10,
                             },
                             "filename": undefined,
                             "identifierName": "stryNS_9fa48",
-                            "start": Position {
+                            "start": Object {
                               "column": 2,
                               "line": 10,
                             },
@@ -11845,33 +11845,33 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 27,
                             "line": 10,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 2,
                             "line": 10,
                           },
                         },
                         "operator": "=",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 374,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 27,
                               "line": 10,
                             },
                             "filename": undefined,
                             "identifierName": "retrieveNS",
-                            "start": Position {
+                            "start": Object {
                               "column": 17,
                               "line": 10,
                             },
@@ -11889,14 +11889,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 28,
                           "line": 10,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 10,
                         },
@@ -11906,22 +11906,22 @@ Object {
                       "trailingComments": undefined,
                       "type": "ExpressionStatement",
                     },
-                    Node {
-                      "argument": Node {
+                    Object {
+                      "argument": Object {
                         "arguments": Array [],
-                        "callee": Node {
+                        "callee": Object {
                           "end": 395,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 19,
                               "line": 11,
                             },
                             "filename": undefined,
                             "identifierName": "retrieveNS",
-                            "start": Position {
+                            "start": Object {
                               "column": 9,
                               "line": 11,
                             },
@@ -11936,14 +11936,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 21,
                             "line": 11,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 9,
                             "line": 11,
                           },
@@ -11957,14 +11957,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 22,
                           "line": 11,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 11,
                         },
@@ -11980,14 +11980,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 1,
                       "line": 12,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 23,
                       "line": 1,
                     },
@@ -12000,19 +12000,19 @@ Object {
                 "end": 400,
                 "extra": undefined,
                 "generator": false,
-                "id": Node {
+                "id": Object {
                   "end": 21,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 21,
                       "line": 1,
                     },
                     "filename": undefined,
                     "identifierName": "stryNS_9fa48",
-                    "start": Position {
+                    "start": Object {
                       "column": 9,
                       "line": 1,
                     },
@@ -12024,15 +12024,15 @@ Object {
                   "type": "Identifier",
                 },
                 "innerComments": undefined,
-                "leadingComments": Array [],
-                "loc": SourceLocation {
-                  "end": Position {
+                "leadingComments": undefined,
+                "loc": Object {
+                  "end": Object {
                     "column": 1,
                     "line": 12,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 0,
                     "line": 1,
                   },
@@ -12043,23 +12043,23 @@ Object {
                 "trailingComments": undefined,
                 "type": "FunctionDeclaration",
               },
-              Node {
+              Object {
                 "end": 416,
-                "expression": Node {
+                "expression": Object {
                   "arguments": Array [],
-                  "callee": Node {
+                  "callee": Object {
                     "end": 413,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 12,
                         "line": 13,
                       },
                       "filename": undefined,
                       "identifierName": "stryNS_9fa48",
-                      "start": Position {
+                      "start": Object {
                         "column": 0,
                         "line": 13,
                       },
@@ -12074,14 +12074,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 14,
                       "line": 13,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 0,
                       "line": 13,
                     },
@@ -12094,14 +12094,14 @@ Object {
                 "extra": undefined,
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 15,
                     "line": 13,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 0,
                     "line": 13,
                   },
@@ -12111,28 +12111,28 @@ Object {
                 "trailingComments": undefined,
                 "type": "ExpressionStatement",
               },
-              Node {
+              Object {
                 "async": false,
-                "body": Node {
+                "body": Object {
                   "body": Array [
-                    Node {
+                    Object {
                       "declarations": Array [
-                        Node {
+                        Object {
                           "end": 470,
                           "extra": undefined,
-                          "id": Node {
+                          "id": Object {
                             "end": 453,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 8,
                                 "line": 16,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 16,
                               },
@@ -12143,21 +12143,21 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "init": Node {
+                          "init": Object {
                             "arguments": Array [],
-                            "callee": Node {
+                            "callee": Object {
                               "end": 468,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 23,
                                   "line": 16,
                                 },
                                 "filename": undefined,
                                 "identifierName": "stryNS_9fa48",
-                                "start": Position {
+                                "start": Object {
                                   "column": 11,
                                   "line": 16,
                                 },
@@ -12172,14 +12172,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 25,
                                 "line": 16,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 11,
                                 "line": 16,
                               },
@@ -12191,14 +12191,14 @@ Object {
                           },
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 25,
                               "line": 16,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 6,
                               "line": 16,
                             },
@@ -12214,14 +12214,14 @@ Object {
                       "innerComments": undefined,
                       "kind": "var",
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 26,
                           "line": 16,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 16,
                         },
@@ -12231,24 +12231,24 @@ Object {
                       "trailingComments": undefined,
                       "type": "VariableDeclaration",
                     },
-                    Node {
+                    Object {
                       "declarations": Array [
-                        Node {
+                        Object {
                           "end": 554,
                           "extra": undefined,
-                          "id": Node {
+                          "id": Object {
                             "end": 481,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 9,
                                 "line": 17,
                               },
                               "filename": undefined,
                               "identifierName": "cov",
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 17,
                               },
@@ -12259,42 +12259,42 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "init": Node {
+                          "init": Object {
                             "end": 554,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "left": Node {
+                            "left": Object {
                               "computed": false,
                               "end": 501,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 29,
                                   "line": 17,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 12,
                                   "line": 17,
                                 },
                               },
-                              "object": Node {
+                              "object": Object {
                                 "end": 486,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 14,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": "ns",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 12,
                                     "line": 17,
                                   },
@@ -12305,19 +12305,19 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "Identifier",
                               },
-                              "property": Node {
+                              "property": Object {
                                 "end": 501,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 29,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": "mutantCoverage",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 15,
                                     "line": 17,
                                   },
@@ -12333,21 +12333,21 @@ Object {
                               "trailingComments": undefined,
                               "type": "MemberExpression",
                             },
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 82,
                                 "line": 17,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 12,
                                 "line": 17,
                               },
                             },
                             "operator": "||",
                             "range": undefined,
-                            "right": Node {
+                            "right": Object {
                               "end": 553,
                               "extra": Object {
                                 "parenStart": 505,
@@ -12355,37 +12355,37 @@ Object {
                               },
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "computed": false,
                                 "end": 523,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 51,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 34,
                                     "line": 17,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "end": 508,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 36,
                                       "line": 17,
                                     },
                                     "filename": undefined,
                                     "identifierName": "ns",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 34,
                                       "line": 17,
                                     },
@@ -12396,19 +12396,19 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "end": 523,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 51,
                                       "line": 17,
                                     },
                                     "filename": undefined,
                                     "identifierName": "mutantCoverage",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 37,
                                       "line": 17,
                                     },
@@ -12424,56 +12424,56 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "MemberExpression",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 81,
                                   "line": 17,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 34,
                                   "line": 17,
                                 },
                               },
                               "operator": "=",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "end": 553,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 81,
                                     "line": 17,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 54,
                                     "line": 17,
                                   },
                                 },
                                 "properties": Array [
-                                  Node {
+                                  Object {
                                     "computed": false,
                                     "end": 538,
                                     "extra": undefined,
                                     "innerComments": undefined,
-                                    "key": Node {
+                                    "key": Object {
                                       "end": 534,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 62,
                                           "line": 17,
                                         },
                                         "filename": undefined,
                                         "identifierName": "static",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 56,
                                           "line": 17,
                                         },
@@ -12485,14 +12485,14 @@ Object {
                                       "type": "Identifier",
                                     },
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 66,
                                         "line": 17,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 56,
                                         "line": 17,
                                       },
@@ -12503,19 +12503,19 @@ Object {
                                     "start": 528,
                                     "trailingComments": undefined,
                                     "type": "ObjectProperty",
-                                    "value": Node {
+                                    "value": Object {
                                       "end": 538,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 66,
                                           "line": 17,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 64,
                                           "line": 17,
                                         },
@@ -12527,24 +12527,24 @@ Object {
                                       "type": "ObjectExpression",
                                     },
                                   },
-                                  Node {
+                                  Object {
                                     "computed": false,
                                     "end": 551,
                                     "extra": undefined,
                                     "innerComments": undefined,
-                                    "key": Node {
+                                    "key": Object {
                                       "end": 547,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 75,
                                           "line": 17,
                                         },
                                         "filename": undefined,
                                         "identifierName": "perTest",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 68,
                                           "line": 17,
                                         },
@@ -12556,14 +12556,14 @@ Object {
                                       "type": "Identifier",
                                     },
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 79,
                                         "line": 17,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 68,
                                         "line": 17,
                                       },
@@ -12574,19 +12574,19 @@ Object {
                                     "start": 540,
                                     "trailingComments": undefined,
                                     "type": "ObjectProperty",
-                                    "value": Node {
+                                    "value": Object {
                                       "end": 551,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 79,
                                           "line": 17,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 77,
                                           "line": 17,
                                         },
@@ -12614,14 +12614,14 @@ Object {
                           },
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 82,
                               "line": 17,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 6,
                               "line": 17,
                             },
@@ -12637,14 +12637,14 @@ Object {
                       "innerComments": undefined,
                       "kind": "var",
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 83,
                           "line": 17,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 17,
                         },
@@ -12654,28 +12654,28 @@ Object {
                       "trailingComments": undefined,
                       "type": "VariableDeclaration",
                     },
-                    Node {
+                    Object {
                       "async": false,
-                      "body": Node {
+                      "body": Object {
                         "body": Array [
-                          Node {
+                          Object {
                             "declarations": Array [
-                              Node {
+                              Object {
                                 "end": 599,
                                 "extra": undefined,
-                                "id": Node {
+                                "id": Object {
                                   "end": 586,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 9,
                                       "line": 19,
                                     },
                                     "filename": undefined,
                                     "identifierName": "c",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 8,
                                       "line": 19,
                                     },
@@ -12686,37 +12686,37 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "init": Node {
+                                "init": Object {
                                   "computed": false,
                                   "end": 599,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 22,
                                       "line": 19,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 12,
                                       "line": 19,
                                     },
                                   },
-                                  "object": Node {
+                                  "object": Object {
                                     "end": 592,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 15,
                                         "line": 19,
                                       },
                                       "filename": undefined,
                                       "identifierName": "cov",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 12,
                                         "line": 19,
                                       },
@@ -12727,19 +12727,19 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "Identifier",
                                   },
-                                  "property": Node {
+                                  "property": Object {
                                     "end": 599,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 22,
                                         "line": 19,
                                       },
                                       "filename": undefined,
                                       "identifierName": "static",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 16,
                                         "line": 19,
                                       },
@@ -12757,14 +12757,14 @@ Object {
                                 },
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 22,
                                     "line": 19,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 8,
                                     "line": 19,
                                   },
@@ -12780,14 +12780,14 @@ Object {
                             "innerComments": undefined,
                             "kind": "var",
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 23,
                                 "line": 19,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 4,
                                 "line": 19,
                               },
@@ -12797,30 +12797,30 @@ Object {
                             "trailingComments": undefined,
                             "type": "VariableDeclaration",
                           },
-                          Node {
+                          Object {
                             "alternate": null,
-                            "consequent": Node {
+                            "consequent": Object {
                               "body": Array [
-                                Node {
+                                Object {
                                   "end": 707,
-                                  "expression": Node {
+                                  "expression": Object {
                                     "end": 706,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "left": Node {
+                                    "left": Object {
                                       "end": 636,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 7,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": "c",
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 6,
                                           "line": 21,
                                         },
@@ -12831,74 +12831,74 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "Identifier",
                                     },
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 77,
                                         "line": 21,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 6,
                                         "line": 21,
                                       },
                                     },
                                     "operator": "=",
                                     "range": undefined,
-                                    "right": Node {
+                                    "right": Object {
                                       "end": 706,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "left": Node {
+                                      "left": Object {
                                         "computed": true,
                                         "end": 668,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 39,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": undefined,
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 10,
                                             "line": 21,
                                           },
                                         },
-                                        "object": Node {
+                                        "object": Object {
                                           "computed": false,
                                           "end": 650,
                                           "extra": undefined,
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 21,
                                               "line": 21,
                                             },
                                             "filename": undefined,
                                             "identifierName": undefined,
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 10,
                                               "line": 21,
                                             },
                                           },
-                                          "object": Node {
+                                          "object": Object {
                                             "end": 642,
                                             "extra": undefined,
                                             "innerComments": undefined,
                                             "leadingComments": undefined,
-                                            "loc": SourceLocation {
-                                              "end": Position {
+                                            "loc": Object {
+                                              "end": Object {
                                                 "column": 13,
                                                 "line": 21,
                                               },
                                               "filename": undefined,
                                               "identifierName": "cov",
-                                              "start": Position {
+                                              "start": Object {
                                                 "column": 10,
                                                 "line": 21,
                                               },
@@ -12909,19 +12909,19 @@ Object {
                                             "trailingComments": undefined,
                                             "type": "Identifier",
                                           },
-                                          "property": Node {
+                                          "property": Object {
                                             "end": 650,
                                             "extra": undefined,
                                             "innerComments": undefined,
                                             "leadingComments": undefined,
-                                            "loc": SourceLocation {
-                                              "end": Position {
+                                            "loc": Object {
+                                              "end": Object {
                                                 "column": 21,
                                                 "line": 21,
                                               },
                                               "filename": undefined,
                                               "identifierName": "perTest",
-                                              "start": Position {
+                                              "start": Object {
                                                 "column": 14,
                                                 "line": 21,
                                               },
@@ -12937,37 +12937,37 @@ Object {
                                           "trailingComments": undefined,
                                           "type": "MemberExpression",
                                         },
-                                        "property": Node {
+                                        "property": Object {
                                           "computed": false,
                                           "end": 667,
                                           "extra": undefined,
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 38,
                                               "line": 21,
                                             },
                                             "filename": undefined,
                                             "identifierName": undefined,
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 22,
                                               "line": 21,
                                             },
                                           },
-                                          "object": Node {
+                                          "object": Object {
                                             "end": 653,
                                             "extra": undefined,
                                             "innerComments": undefined,
                                             "leadingComments": undefined,
-                                            "loc": SourceLocation {
-                                              "end": Position {
+                                            "loc": Object {
+                                              "end": Object {
                                                 "column": 24,
                                                 "line": 21,
                                               },
                                               "filename": undefined,
                                               "identifierName": "ns",
-                                              "start": Position {
+                                              "start": Object {
                                                 "column": 22,
                                                 "line": 21,
                                               },
@@ -12978,19 +12978,19 @@ Object {
                                             "trailingComments": undefined,
                                             "type": "Identifier",
                                           },
-                                          "property": Node {
+                                          "property": Object {
                                             "end": 667,
                                             "extra": undefined,
                                             "innerComments": undefined,
                                             "leadingComments": undefined,
-                                            "loc": SourceLocation {
-                                              "end": Position {
+                                            "loc": Object {
+                                              "end": Object {
                                                 "column": 38,
                                                 "line": 21,
                                               },
                                               "filename": undefined,
                                               "identifierName": "currentTestId",
-                                              "start": Position {
+                                              "start": Object {
                                                 "column": 25,
                                                 "line": 21,
                                               },
@@ -13011,74 +13011,74 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "MemberExpression",
                                       },
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 77,
                                           "line": 21,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 10,
                                           "line": 21,
                                         },
                                       },
                                       "operator": "=",
                                       "range": undefined,
-                                      "right": Node {
+                                      "right": Object {
                                         "end": 706,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "left": Node {
+                                        "left": Object {
                                           "computed": true,
                                           "end": 700,
                                           "extra": undefined,
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 71,
                                               "line": 21,
                                             },
                                             "filename": undefined,
                                             "identifierName": undefined,
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 42,
                                               "line": 21,
                                             },
                                           },
-                                          "object": Node {
+                                          "object": Object {
                                             "computed": false,
                                             "end": 682,
                                             "extra": undefined,
                                             "innerComments": undefined,
                                             "leadingComments": undefined,
-                                            "loc": SourceLocation {
-                                              "end": Position {
+                                            "loc": Object {
+                                              "end": Object {
                                                 "column": 53,
                                                 "line": 21,
                                               },
                                               "filename": undefined,
                                               "identifierName": undefined,
-                                              "start": Position {
+                                              "start": Object {
                                                 "column": 42,
                                                 "line": 21,
                                               },
                                             },
-                                            "object": Node {
+                                            "object": Object {
                                               "end": 674,
                                               "extra": undefined,
                                               "innerComments": undefined,
                                               "leadingComments": undefined,
-                                              "loc": SourceLocation {
-                                                "end": Position {
+                                              "loc": Object {
+                                                "end": Object {
                                                   "column": 45,
                                                   "line": 21,
                                                 },
                                                 "filename": undefined,
                                                 "identifierName": "cov",
-                                                "start": Position {
+                                                "start": Object {
                                                   "column": 42,
                                                   "line": 21,
                                                 },
@@ -13089,19 +13089,19 @@ Object {
                                               "trailingComments": undefined,
                                               "type": "Identifier",
                                             },
-                                            "property": Node {
+                                            "property": Object {
                                               "end": 682,
                                               "extra": undefined,
                                               "innerComments": undefined,
                                               "leadingComments": undefined,
-                                              "loc": SourceLocation {
-                                                "end": Position {
+                                              "loc": Object {
+                                                "end": Object {
                                                   "column": 53,
                                                   "line": 21,
                                                 },
                                                 "filename": undefined,
                                                 "identifierName": "perTest",
-                                                "start": Position {
+                                                "start": Object {
                                                   "column": 46,
                                                   "line": 21,
                                                 },
@@ -13117,37 +13117,37 @@ Object {
                                             "trailingComments": undefined,
                                             "type": "MemberExpression",
                                           },
-                                          "property": Node {
+                                          "property": Object {
                                             "computed": false,
                                             "end": 699,
                                             "extra": undefined,
                                             "innerComments": undefined,
                                             "leadingComments": undefined,
-                                            "loc": SourceLocation {
-                                              "end": Position {
+                                            "loc": Object {
+                                              "end": Object {
                                                 "column": 70,
                                                 "line": 21,
                                               },
                                               "filename": undefined,
                                               "identifierName": undefined,
-                                              "start": Position {
+                                              "start": Object {
                                                 "column": 54,
                                                 "line": 21,
                                               },
                                             },
-                                            "object": Node {
+                                            "object": Object {
                                               "end": 685,
                                               "extra": undefined,
                                               "innerComments": undefined,
                                               "leadingComments": undefined,
-                                              "loc": SourceLocation {
-                                                "end": Position {
+                                              "loc": Object {
+                                                "end": Object {
                                                   "column": 56,
                                                   "line": 21,
                                                 },
                                                 "filename": undefined,
                                                 "identifierName": "ns",
-                                                "start": Position {
+                                                "start": Object {
                                                   "column": 54,
                                                   "line": 21,
                                                 },
@@ -13158,19 +13158,19 @@ Object {
                                               "trailingComments": undefined,
                                               "type": "Identifier",
                                             },
-                                            "property": Node {
+                                            "property": Object {
                                               "end": 699,
                                               "extra": undefined,
                                               "innerComments": undefined,
                                               "leadingComments": undefined,
-                                              "loc": SourceLocation {
-                                                "end": Position {
+                                              "loc": Object {
+                                                "end": Object {
                                                   "column": 70,
                                                   "line": 21,
                                                 },
                                                 "filename": undefined,
                                                 "identifierName": "currentTestId",
-                                                "start": Position {
+                                                "start": Object {
                                                   "column": 57,
                                                   "line": 21,
                                                 },
@@ -13191,33 +13191,33 @@ Object {
                                           "trailingComments": undefined,
                                           "type": "MemberExpression",
                                         },
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 77,
                                             "line": 21,
                                           },
                                           "filename": undefined,
                                           "identifierName": undefined,
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 42,
                                             "line": 21,
                                           },
                                         },
                                         "operator": "||",
                                         "range": undefined,
-                                        "right": Node {
+                                        "right": Object {
                                           "end": 706,
                                           "extra": undefined,
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 77,
                                               "line": 21,
                                             },
                                             "filename": undefined,
                                             "identifierName": undefined,
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 75,
                                               "line": 21,
                                             },
@@ -13243,14 +13243,14 @@ Object {
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 78,
                                       "line": 21,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 6,
                                       "line": 21,
                                     },
@@ -13266,14 +13266,14 @@ Object {
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 5,
                                   "line": 22,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 26,
                                   "line": 20,
                                 },
@@ -13287,51 +13287,51 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 5,
                                 "line": 22,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 4,
                                 "line": 20,
                               },
                             },
                             "range": undefined,
                             "start": 605,
-                            "test": Node {
+                            "test": Object {
                               "computed": false,
                               "end": 625,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 24,
                                   "line": 20,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 8,
                                   "line": 20,
                                 },
                               },
-                              "object": Node {
+                              "object": Object {
                                 "end": 611,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 10,
                                     "line": 20,
                                   },
                                   "filename": undefined,
                                   "identifierName": "ns",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 8,
                                     "line": 20,
                                   },
@@ -13342,19 +13342,19 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "Identifier",
                               },
-                              "property": Node {
+                              "property": Object {
                                 "end": 625,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 24,
                                     "line": 20,
                                   },
                                   "filename": undefined,
                                   "identifierName": "currentTestId",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 11,
                                     "line": 20,
                                   },
@@ -13373,24 +13373,24 @@ Object {
                             "trailingComments": undefined,
                             "type": "IfStatement",
                           },
-                          Node {
+                          Object {
                             "declarations": Array [
-                              Node {
+                              Object {
                                 "end": 735,
                                 "extra": undefined,
-                                "id": Node {
+                                "id": Object {
                                   "end": 723,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 9,
                                       "line": 23,
                                     },
                                     "filename": undefined,
                                     "identifierName": "a",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 8,
                                       "line": 23,
                                     },
@@ -13401,19 +13401,19 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "init": Node {
+                                "init": Object {
                                   "end": 735,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 21,
                                       "line": 23,
                                     },
                                     "filename": undefined,
                                     "identifierName": "arguments",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 12,
                                       "line": 23,
                                     },
@@ -13426,14 +13426,14 @@ Object {
                                 },
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 21,
                                     "line": 23,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 8,
                                     "line": 23,
                                   },
@@ -13449,14 +13449,14 @@ Object {
                             "innerComments": undefined,
                             "kind": "var",
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 22,
                                 "line": 23,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 4,
                                 "line": 23,
                               },
@@ -13466,47 +13466,47 @@ Object {
                             "trailingComments": undefined,
                             "type": "VariableDeclaration",
                           },
-                          Node {
-                            "body": Node {
+                          Object {
+                            "body": Object {
                               "body": Array [
-                                Node {
+                                Object {
                                   "end": 809,
-                                  "expression": Node {
+                                  "expression": Object {
                                     "end": 808,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "left": Node {
+                                    "left": Object {
                                       "computed": true,
                                       "end": 787,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 13,
                                           "line": 25,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 6,
                                           "line": 25,
                                         },
                                       },
-                                      "object": Node {
+                                      "object": Object {
                                         "end": 781,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 7,
                                             "line": 25,
                                           },
                                           "filename": undefined,
                                           "identifierName": "c",
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 6,
                                             "line": 25,
                                           },
@@ -13517,37 +13517,37 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "Identifier",
                                       },
-                                      "property": Node {
+                                      "property": Object {
                                         "computed": true,
                                         "end": 786,
                                         "extra": undefined,
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 12,
                                             "line": 25,
                                           },
                                           "filename": undefined,
                                           "identifierName": undefined,
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 8,
                                             "line": 25,
                                           },
                                         },
-                                        "object": Node {
+                                        "object": Object {
                                           "end": 783,
                                           "extra": undefined,
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 9,
                                               "line": 25,
                                             },
                                             "filename": undefined,
                                             "identifierName": "a",
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 8,
                                               "line": 25,
                                             },
@@ -13558,19 +13558,19 @@ Object {
                                           "trailingComments": undefined,
                                           "type": "Identifier",
                                         },
-                                        "property": Node {
+                                        "property": Object {
                                           "end": 785,
                                           "extra": undefined,
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 11,
                                               "line": 25,
                                             },
                                             "filename": undefined,
                                             "identifierName": "i",
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 10,
                                               "line": 25,
                                             },
@@ -13591,26 +13591,26 @@ Object {
                                       "trailingComments": undefined,
                                       "type": "MemberExpression",
                                     },
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 34,
                                         "line": 25,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 6,
                                         "line": 25,
                                       },
                                     },
                                     "operator": "=",
                                     "range": undefined,
-                                    "right": Node {
+                                    "right": Object {
                                       "end": 808,
                                       "extra": undefined,
                                       "innerComments": undefined,
                                       "leadingComments": undefined,
-                                      "left": Node {
+                                      "left": Object {
                                         "end": 803,
                                         "extra": Object {
                                           "parenStart": 790,
@@ -13618,37 +13618,37 @@ Object {
                                         },
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "left": Node {
+                                        "left": Object {
                                           "computed": true,
                                           "end": 798,
                                           "extra": undefined,
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 24,
                                               "line": 25,
                                             },
                                             "filename": undefined,
                                             "identifierName": undefined,
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 17,
                                               "line": 25,
                                             },
                                           },
-                                          "object": Node {
+                                          "object": Object {
                                             "end": 792,
                                             "extra": undefined,
                                             "innerComments": undefined,
                                             "leadingComments": undefined,
-                                            "loc": SourceLocation {
-                                              "end": Position {
+                                            "loc": Object {
+                                              "end": Object {
                                                 "column": 18,
                                                 "line": 25,
                                               },
                                               "filename": undefined,
                                               "identifierName": "c",
-                                              "start": Position {
+                                              "start": Object {
                                                 "column": 17,
                                                 "line": 25,
                                               },
@@ -13659,37 +13659,37 @@ Object {
                                             "trailingComments": undefined,
                                             "type": "Identifier",
                                           },
-                                          "property": Node {
+                                          "property": Object {
                                             "computed": true,
                                             "end": 797,
                                             "extra": undefined,
                                             "innerComments": undefined,
                                             "leadingComments": undefined,
-                                            "loc": SourceLocation {
-                                              "end": Position {
+                                            "loc": Object {
+                                              "end": Object {
                                                 "column": 23,
                                                 "line": 25,
                                               },
                                               "filename": undefined,
                                               "identifierName": undefined,
-                                              "start": Position {
+                                              "start": Object {
                                                 "column": 19,
                                                 "line": 25,
                                               },
                                             },
-                                            "object": Node {
+                                            "object": Object {
                                               "end": 794,
                                               "extra": undefined,
                                               "innerComments": undefined,
                                               "leadingComments": undefined,
-                                              "loc": SourceLocation {
-                                                "end": Position {
+                                              "loc": Object {
+                                                "end": Object {
                                                   "column": 20,
                                                   "line": 25,
                                                 },
                                                 "filename": undefined,
                                                 "identifierName": "a",
-                                                "start": Position {
+                                                "start": Object {
                                                   "column": 19,
                                                   "line": 25,
                                                 },
@@ -13700,19 +13700,19 @@ Object {
                                               "trailingComments": undefined,
                                               "type": "Identifier",
                                             },
-                                            "property": Node {
+                                            "property": Object {
                                               "end": 796,
                                               "extra": undefined,
                                               "innerComments": undefined,
                                               "leadingComments": undefined,
-                                              "loc": SourceLocation {
-                                                "end": Position {
+                                              "loc": Object {
+                                                "end": Object {
                                                   "column": 22,
                                                   "line": 25,
                                                 },
                                                 "filename": undefined,
                                                 "identifierName": "i",
-                                                "start": Position {
+                                                "start": Object {
                                                   "column": 21,
                                                   "line": 25,
                                                 },
@@ -13733,21 +13733,21 @@ Object {
                                           "trailingComments": undefined,
                                           "type": "MemberExpression",
                                         },
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 29,
                                             "line": 25,
                                           },
                                           "filename": undefined,
                                           "identifierName": undefined,
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 17,
                                             "line": 25,
                                           },
                                         },
                                         "operator": "||",
                                         "range": undefined,
-                                        "right": Node {
+                                        "right": Object {
                                           "end": 803,
                                           "extra": Object {
                                             "raw": "0",
@@ -13755,14 +13755,14 @@ Object {
                                           },
                                           "innerComments": undefined,
                                           "leadingComments": undefined,
-                                          "loc": SourceLocation {
-                                            "end": Position {
+                                          "loc": Object {
+                                            "end": Object {
                                               "column": 29,
                                               "line": 25,
                                             },
                                             "filename": undefined,
                                             "identifierName": undefined,
-                                            "start": Position {
+                                            "start": Object {
                                               "column": 28,
                                               "line": 25,
                                             },
@@ -13777,21 +13777,21 @@ Object {
                                         "trailingComments": undefined,
                                         "type": "LogicalExpression",
                                       },
-                                      "loc": SourceLocation {
-                                        "end": Position {
+                                      "loc": Object {
+                                        "end": Object {
                                           "column": 34,
                                           "line": 25,
                                         },
                                         "filename": undefined,
                                         "identifierName": undefined,
-                                        "start": Position {
+                                        "start": Object {
                                           "column": 16,
                                           "line": 25,
                                         },
                                       },
                                       "operator": "+",
                                       "range": undefined,
-                                      "right": Node {
+                                      "right": Object {
                                         "end": 808,
                                         "extra": Object {
                                           "raw": "1",
@@ -13799,14 +13799,14 @@ Object {
                                         },
                                         "innerComments": undefined,
                                         "leadingComments": undefined,
-                                        "loc": SourceLocation {
-                                          "end": Position {
+                                        "loc": Object {
+                                          "end": Object {
                                             "column": 34,
                                             "line": 25,
                                           },
                                           "filename": undefined,
                                           "identifierName": undefined,
-                                          "start": Position {
+                                          "start": Object {
                                             "column": 33,
                                             "line": 25,
                                           },
@@ -13828,14 +13828,14 @@ Object {
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 35,
                                       "line": 25,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 6,
                                       "line": 25,
                                     },
@@ -13851,14 +13851,14 @@ Object {
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 5,
                                   "line": 26,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 35,
                                   "line": 24,
                                 },
@@ -13870,24 +13870,24 @@ Object {
                             },
                             "end": 815,
                             "extra": undefined,
-                            "init": Node {
+                            "init": Object {
                               "declarations": Array [
-                                Node {
+                                Object {
                                   "end": 752,
                                   "extra": undefined,
-                                  "id": Node {
+                                  "id": Object {
                                     "end": 750,
                                     "extra": undefined,
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 13,
                                         "line": 24,
                                       },
                                       "filename": undefined,
                                       "identifierName": "i",
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 12,
                                         "line": 24,
                                       },
@@ -13898,7 +13898,7 @@ Object {
                                     "trailingComments": undefined,
                                     "type": "Identifier",
                                   },
-                                  "init": Node {
+                                  "init": Object {
                                     "end": 752,
                                     "extra": Object {
                                       "raw": "0",
@@ -13906,14 +13906,14 @@ Object {
                                     },
                                     "innerComments": undefined,
                                     "leadingComments": undefined,
-                                    "loc": SourceLocation {
-                                      "end": Position {
+                                    "loc": Object {
+                                      "end": Object {
                                         "column": 15,
                                         "line": 24,
                                       },
                                       "filename": undefined,
                                       "identifierName": undefined,
-                                      "start": Position {
+                                      "start": Object {
                                         "column": 14,
                                         "line": 24,
                                       },
@@ -13926,14 +13926,14 @@ Object {
                                   },
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 15,
                                       "line": 24,
                                     },
                                     "filename": undefined,
                                     "identifierName": undefined,
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 12,
                                       "line": 24,
                                     },
@@ -13949,14 +13949,14 @@ Object {
                               "innerComments": undefined,
                               "kind": "var",
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 15,
                                   "line": 24,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 8,
                                   "line": 24,
                                 },
@@ -13968,38 +13968,38 @@ Object {
                             },
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 5,
                                 "line": 26,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 4,
                                 "line": 24,
                               },
                             },
                             "range": undefined,
                             "start": 741,
-                            "test": Node {
+                            "test": Object {
                               "end": 766,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "end": 755,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 18,
                                     "line": 24,
                                   },
                                   "filename": undefined,
                                   "identifierName": "i",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 17,
                                     "line": 24,
                                   },
@@ -14010,51 +14010,51 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "Identifier",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 29,
                                   "line": 24,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 17,
                                   "line": 24,
                                 },
                               },
                               "operator": "<",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "computed": false,
                                 "end": 766,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 29,
                                     "line": 24,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 21,
                                     "line": 24,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "end": 759,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 22,
                                       "line": 24,
                                     },
                                     "filename": undefined,
                                     "identifierName": "a",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 21,
                                       "line": 24,
                                     },
@@ -14065,19 +14065,19 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "end": 766,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 29,
                                       "line": 24,
                                     },
                                     "filename": undefined,
                                     "identifierName": "length",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 23,
                                       "line": 24,
                                     },
@@ -14099,20 +14099,20 @@ Object {
                             },
                             "trailingComments": undefined,
                             "type": "ForStatement",
-                            "update": Node {
-                              "argument": Node {
+                            "update": Object {
+                              "argument": Object {
                                 "end": 769,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 32,
                                     "line": 24,
                                   },
                                   "filename": undefined,
                                   "identifierName": "i",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 31,
                                     "line": 24,
                                   },
@@ -14127,14 +14127,14 @@ Object {
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 34,
                                   "line": 24,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 31,
                                   "line": 24,
                                 },
@@ -14153,14 +14153,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 3,
                             "line": 27,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 19,
                             "line": 18,
                           },
@@ -14173,19 +14173,19 @@ Object {
                       "end": 819,
                       "extra": undefined,
                       "generator": false,
-                      "id": Node {
+                      "id": Object {
                         "end": 572,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 16,
                             "line": 18,
                           },
                           "filename": undefined,
                           "identifierName": "cover",
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 18,
                           },
@@ -14198,14 +14198,14 @@ Object {
                       },
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 3,
                           "line": 27,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 18,
                         },
@@ -14216,26 +14216,26 @@ Object {
                       "trailingComments": undefined,
                       "type": "FunctionDeclaration",
                     },
-                    Node {
+                    Object {
                       "end": 844,
-                      "expression": Node {
+                      "expression": Object {
                         "end": 843,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "end": 835,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 15,
                               "line": 28,
                             },
                             "filename": undefined,
                             "identifierName": "stryCov_9fa48",
-                            "start": Position {
+                            "start": Object {
                               "column": 2,
                               "line": 28,
                             },
@@ -14246,33 +14246,33 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 23,
                             "line": 28,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 2,
                             "line": 28,
                           },
                         },
                         "operator": "=",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 843,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 23,
                               "line": 28,
                             },
                             "filename": undefined,
                             "identifierName": "cover",
-                            "start": Position {
+                            "start": Object {
                               "column": 18,
                               "line": 28,
                             },
@@ -14290,14 +14290,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 24,
                           "line": 28,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 28,
                         },
@@ -14307,23 +14307,23 @@ Object {
                       "trailingComments": undefined,
                       "type": "ExpressionStatement",
                     },
-                    Node {
+                    Object {
                       "end": 876,
-                      "expression": Node {
+                      "expression": Object {
                         "arguments": Array [
-                          Node {
+                          Object {
                             "end": 863,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 18,
                                 "line": 29,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 14,
                                 "line": 29,
                               },
@@ -14333,19 +14333,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "NullLiteral",
                           },
-                          Node {
+                          Object {
                             "end": 874,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 29,
                                 "line": 29,
                               },
                               "filename": undefined,
                               "identifierName": "arguments",
-                              "start": Position {
+                              "start": Object {
                                 "column": 20,
                                 "line": 29,
                               },
@@ -14357,37 +14357,37 @@ Object {
                             "type": "Identifier",
                           },
                         ],
-                        "callee": Node {
+                        "callee": Object {
                           "computed": false,
                           "end": 858,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 13,
                               "line": 29,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 2,
                               "line": 29,
                             },
                           },
-                          "object": Node {
+                          "object": Object {
                             "end": 852,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 7,
                                 "line": 29,
                               },
                               "filename": undefined,
                               "identifierName": "cover",
-                              "start": Position {
+                              "start": Object {
                                 "column": 2,
                                 "line": 29,
                               },
@@ -14398,19 +14398,19 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "property": Node {
+                          "property": Object {
                             "end": 858,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 13,
                                 "line": 29,
                               },
                               "filename": undefined,
                               "identifierName": "apply",
-                              "start": Position {
+                              "start": Object {
                                 "column": 8,
                                 "line": 29,
                               },
@@ -14430,14 +14430,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 30,
                             "line": 29,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 2,
                             "line": 29,
                           },
@@ -14450,14 +14450,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 31,
                           "line": 29,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 29,
                         },
@@ -14473,14 +14473,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 1,
                       "line": 30,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 25,
                       "line": 15,
                     },
@@ -14493,19 +14493,19 @@ Object {
                 "end": 878,
                 "extra": undefined,
                 "generator": false,
-                "id": Node {
+                "id": Object {
                   "end": 440,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 22,
                       "line": 15,
                     },
                     "filename": undefined,
                     "identifierName": "stryCov_9fa48",
-                    "start": Position {
+                    "start": Object {
                       "column": 9,
                       "line": 15,
                     },
@@ -14518,14 +14518,14 @@ Object {
                 },
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 1,
                     "line": 30,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 0,
                     "line": 15,
                   },
@@ -14536,28 +14536,28 @@ Object {
                 "trailingComments": undefined,
                 "type": "FunctionDeclaration",
               },
-              Node {
+              Object {
                 "async": false,
-                "body": Node {
+                "body": Object {
                   "body": Array [
-                    Node {
+                    Object {
                       "declarations": Array [
-                        Node {
+                        Object {
                           "end": 936,
                           "extra": undefined,
-                          "id": Node {
+                          "id": Object {
                             "end": 919,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 8,
                                 "line": 32,
                               },
                               "filename": undefined,
                               "identifierName": "ns",
-                              "start": Position {
+                              "start": Object {
                                 "column": 6,
                                 "line": 32,
                               },
@@ -14568,21 +14568,21 @@ Object {
                             "trailingComments": undefined,
                             "type": "Identifier",
                           },
-                          "init": Node {
+                          "init": Object {
                             "arguments": Array [],
-                            "callee": Node {
+                            "callee": Object {
                               "end": 934,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 23,
                                   "line": 32,
                                 },
                                 "filename": undefined,
                                 "identifierName": "stryNS_9fa48",
-                                "start": Position {
+                                "start": Object {
                                   "column": 11,
                                   "line": 32,
                                 },
@@ -14597,14 +14597,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 25,
                                 "line": 32,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 11,
                                 "line": 32,
                               },
@@ -14616,14 +14616,14 @@ Object {
                           },
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 25,
                               "line": 32,
                             },
                             "filename": undefined,
                             "identifierName": undefined,
-                            "start": Position {
+                            "start": Object {
                               "column": 6,
                               "line": 32,
                             },
@@ -14639,14 +14639,14 @@ Object {
                       "innerComments": undefined,
                       "kind": "var",
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 26,
                           "line": 32,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 32,
                         },
@@ -14656,47 +14656,47 @@ Object {
                       "trailingComments": undefined,
                       "type": "VariableDeclaration",
                     },
-                    Node {
+                    Object {
                       "async": false,
-                      "body": Node {
+                      "body": Object {
                         "body": Array [
-                          Node {
-                            "argument": Node {
+                          Object {
+                            "argument": Object {
                               "end": 997,
                               "extra": undefined,
                               "innerComments": undefined,
                               "leadingComments": undefined,
-                              "left": Node {
+                              "left": Object {
                                 "computed": false,
                                 "end": 990,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 26,
                                     "line": 34,
                                   },
                                   "filename": undefined,
                                   "identifierName": undefined,
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 11,
                                     "line": 34,
                                   },
                                 },
-                                "object": Node {
+                                "object": Object {
                                   "end": 977,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 13,
                                       "line": 34,
                                     },
                                     "filename": undefined,
                                     "identifierName": "ns",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 11,
                                       "line": 34,
                                     },
@@ -14707,19 +14707,19 @@ Object {
                                   "trailingComments": undefined,
                                   "type": "Identifier",
                                 },
-                                "property": Node {
+                                "property": Object {
                                   "end": 990,
                                   "extra": undefined,
                                   "innerComments": undefined,
                                   "leadingComments": undefined,
-                                  "loc": SourceLocation {
-                                    "end": Position {
+                                  "loc": Object {
+                                    "end": Object {
                                       "column": 26,
                                       "line": 34,
                                     },
                                     "filename": undefined,
                                     "identifierName": "activeMutant",
-                                    "start": Position {
+                                    "start": Object {
                                       "column": 14,
                                       "line": 34,
                                     },
@@ -14735,33 +14735,33 @@ Object {
                                 "trailingComments": undefined,
                                 "type": "MemberExpression",
                               },
-                              "loc": SourceLocation {
-                                "end": Position {
+                              "loc": Object {
+                                "end": Object {
                                   "column": 33,
                                   "line": 34,
                                 },
                                 "filename": undefined,
                                 "identifierName": undefined,
-                                "start": Position {
+                                "start": Object {
                                   "column": 11,
                                   "line": 34,
                                 },
                               },
                               "operator": "===",
                               "range": undefined,
-                              "right": Node {
+                              "right": Object {
                                 "end": 997,
                                 "extra": undefined,
                                 "innerComments": undefined,
                                 "leadingComments": undefined,
-                                "loc": SourceLocation {
-                                  "end": Position {
+                                "loc": Object {
+                                  "end": Object {
                                     "column": 33,
                                     "line": 34,
                                   },
                                   "filename": undefined,
                                   "identifierName": "id",
-                                  "start": Position {
+                                  "start": Object {
                                     "column": 31,
                                     "line": 34,
                                   },
@@ -14780,14 +14780,14 @@ Object {
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 34,
                                 "line": 34,
                               },
                               "filename": undefined,
                               "identifierName": undefined,
-                              "start": Position {
+                              "start": Object {
                                 "column": 4,
                                 "line": 34,
                               },
@@ -14803,14 +14803,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 3,
                             "line": 35,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 24,
                             "line": 33,
                           },
@@ -14823,19 +14823,19 @@ Object {
                       "end": 1002,
                       "extra": undefined,
                       "generator": false,
-                      "id": Node {
+                      "id": Object {
                         "end": 957,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 19,
                             "line": 33,
                           },
                           "filename": undefined,
                           "identifierName": "isActive",
-                          "start": Position {
+                          "start": Object {
                             "column": 11,
                             "line": 33,
                           },
@@ -14848,32 +14848,32 @@ Object {
                       },
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 3,
                           "line": 35,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 33,
                         },
                       },
                       "params": Array [
-                        Node {
+                        Object {
                           "end": 960,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 22,
                               "line": 33,
                             },
                             "filename": undefined,
                             "identifierName": "id",
-                            "start": Position {
+                            "start": Object {
                               "column": 20,
                               "line": 33,
                             },
@@ -14890,26 +14890,26 @@ Object {
                       "trailingComments": undefined,
                       "type": "FunctionDeclaration",
                     },
-                    Node {
+                    Object {
                       "end": 1033,
-                      "expression": Node {
+                      "expression": Object {
                         "end": 1032,
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "left": Node {
+                        "left": Object {
                           "end": 1021,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 18,
                               "line": 36,
                             },
                             "filename": undefined,
                             "identifierName": "stryMutAct_9fa48",
-                            "start": Position {
+                            "start": Object {
                               "column": 2,
                               "line": 36,
                             },
@@ -14920,33 +14920,33 @@ Object {
                           "trailingComments": undefined,
                           "type": "Identifier",
                         },
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 29,
                             "line": 36,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 2,
                             "line": 36,
                           },
                         },
                         "operator": "=",
                         "range": undefined,
-                        "right": Node {
+                        "right": Object {
                           "end": 1032,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 29,
                               "line": 36,
                             },
                             "filename": undefined,
                             "identifierName": "isActive",
-                            "start": Position {
+                            "start": Object {
                               "column": 21,
                               "line": 36,
                             },
@@ -14964,14 +14964,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 30,
                           "line": 36,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 36,
                         },
@@ -14981,22 +14981,22 @@ Object {
                       "trailingComments": undefined,
                       "type": "ExpressionStatement",
                     },
-                    Node {
-                      "argument": Node {
+                    Object {
+                      "argument": Object {
                         "arguments": Array [
-                          Node {
+                          Object {
                             "end": 1054,
                             "extra": undefined,
                             "innerComments": undefined,
                             "leadingComments": undefined,
-                            "loc": SourceLocation {
-                              "end": Position {
+                            "loc": Object {
+                              "end": Object {
                                 "column": 20,
                                 "line": 37,
                               },
                               "filename": undefined,
                               "identifierName": "id",
-                              "start": Position {
+                              "start": Object {
                                 "column": 18,
                                 "line": 37,
                               },
@@ -15008,19 +15008,19 @@ Object {
                             "type": "Identifier",
                           },
                         ],
-                        "callee": Node {
+                        "callee": Object {
                           "end": 1051,
                           "extra": undefined,
                           "innerComments": undefined,
                           "leadingComments": undefined,
-                          "loc": SourceLocation {
-                            "end": Position {
+                          "loc": Object {
+                            "end": Object {
                               "column": 17,
                               "line": 37,
                             },
                             "filename": undefined,
                             "identifierName": "isActive",
-                            "start": Position {
+                            "start": Object {
                               "column": 9,
                               "line": 37,
                             },
@@ -15035,14 +15035,14 @@ Object {
                         "extra": undefined,
                         "innerComments": undefined,
                         "leadingComments": undefined,
-                        "loc": SourceLocation {
-                          "end": Position {
+                        "loc": Object {
+                          "end": Object {
                             "column": 21,
                             "line": 37,
                           },
                           "filename": undefined,
                           "identifierName": undefined,
-                          "start": Position {
+                          "start": Object {
                             "column": 9,
                             "line": 37,
                           },
@@ -15056,14 +15056,14 @@ Object {
                       "extra": undefined,
                       "innerComments": undefined,
                       "leadingComments": undefined,
-                      "loc": SourceLocation {
-                        "end": Position {
+                      "loc": Object {
+                        "end": Object {
                           "column": 22,
                           "line": 37,
                         },
                         "filename": undefined,
                         "identifierName": undefined,
-                        "start": Position {
+                        "start": Object {
                           "column": 2,
                           "line": 37,
                         },
@@ -15079,14 +15079,14 @@ Object {
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 1,
                       "line": 38,
                     },
                     "filename": undefined,
                     "identifierName": undefined,
-                    "start": Position {
+                    "start": Object {
                       "column": 30,
                       "line": 31,
                     },
@@ -15099,19 +15099,19 @@ Object {
                 "end": 1058,
                 "extra": undefined,
                 "generator": false,
-                "id": Node {
+                "id": Object {
                   "end": 904,
                   "extra": undefined,
                   "innerComments": undefined,
                   "leadingComments": undefined,
-                  "loc": SourceLocation {
-                    "end": Position {
+                  "loc": Object {
+                    "end": Object {
                       "column": 25,
                       "line": 31,
                     },
                     "filename": undefined,
                     "identifierName": "stryMutAct_9fa48",
-                    "start": Position {
+                    "start": Object {
                       "column": 9,
                       "line": 31,
                     },
@@ -15124,32 +15124,32 @@ Object {
                 },
                 "innerComments": undefined,
                 "leadingComments": undefined,
-                "loc": SourceLocation {
-                  "end": Position {
+                "loc": Object {
+                  "end": Object {
                     "column": 1,
                     "line": 38,
                   },
                   "filename": undefined,
                   "identifierName": undefined,
-                  "start": Position {
+                  "start": Object {
                     "column": 0,
                     "line": 31,
                   },
                 },
                 "params": Array [
-                  Node {
+                  Object {
                     "end": 907,
                     "extra": undefined,
                     "innerComments": undefined,
                     "leadingComments": undefined,
-                    "loc": SourceLocation {
-                      "end": Position {
+                    "loc": Object {
+                      "end": Object {
                         "column": 28,
                         "line": 31,
                       },
                       "filename": undefined,
                       "identifierName": "id",
-                      "start": Position {
+                      "start": Object {
                         "column": 26,
                         "line": 31,
                       },

--- a/packages/instrumenter/test/integration/transformers.it.spec.ts.snap
+++ b/packages/instrumenter/test/integration/transformers.it.spec.ts.snap
@@ -1702,7 +1702,7 @@ Object {
             "type": "Identifier",
           },
           "innerComments": undefined,
-          "leadingComments": undefined,
+          "leadingComments": Array [],
           "loc": SourceLocation {
             "end": Position {
               "column": 1,
@@ -6838,7 +6838,7 @@ Object {
             "type": "Identifier",
           },
           "innerComments": undefined,
-          "leadingComments": undefined,
+          "leadingComments": Array [],
           "loc": SourceLocation {
             "end": Position {
               "column": 1,
@@ -12024,7 +12024,7 @@ Object {
                   "type": "Identifier",
                 },
                 "innerComments": undefined,
-                "leadingComments": undefined,
+                "leadingComments": Array [],
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 1,

--- a/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
+++ b/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
@@ -80,10 +80,26 @@ describe('babel-transformer', () => {
     expect(mutantCollectorMock.markMutantsAsPlaced).calledWith([mutant]);
   });
 
-  it('should add the global stuff on top', () => {
-    const ast = createJSAst({ rawContent: 'foo' });
+  it('should add the global stuff on top but after comments that are followed by newline', () => {
+    const ast = createJSAst({ rawContent: '// @flow\n// another comment\n\nconst foo="cat"' });
     mutantCollectorMock.hasPlacedMutants.returns(true);
     transformBabel(ast, mutantCollectorMock, context);
+
+    expect(ast.root.program.body[0].leadingComments![0].value).eq(' @flow');
+    expect(ast.root.program.body[0].leadingComments![1].value).eq(' another comment');
+
+    for (let i = 0; i < instrumentationBabelHeader.length; i++) {
+      expect(ast.root.program.body[i]).eq(instrumentationBabelHeader[i]);
+    }
+  });
+  it('should add the global stuff on top but after comments that are followed by a statement', () => {
+    const ast = createJSAst({ rawContent: '// @flow\n// another comment\nconst foo="cat"' });
+    mutantCollectorMock.hasPlacedMutants.returns(true);
+    transformBabel(ast, mutantCollectorMock, context);
+
+    expect(ast.root.program.body[0].leadingComments![0].value).eq(' @flow');
+    expect(ast.root.program.body[0].leadingComments![1].value).eq(' another comment');
+
     for (let i = 0; i < instrumentationBabelHeader.length; i++) {
       expect(ast.root.program.body[i]).eq(instrumentationBabelHeader[i]);
     }

--- a/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
+++ b/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
@@ -80,29 +80,37 @@ describe('babel-transformer', () => {
     expect(mutantCollectorMock.markMutantsAsPlaced).calledWith([mutant]);
   });
 
-  it('should add the global stuff on top but after comments that are followed by newline', () => {
+  it('should add the global js header on top ', () => {
+    const ast = createJSAst({ rawContent: 'const foo="cat"' });
+    mutantCollectorMock.hasPlacedMutants.returns(true);
+    transformBabel(ast, mutantCollectorMock, context);
+    expect(ast.root.program.body.slice(0, instrumentationBabelHeader.length)).deep.eq(instrumentationBabelHeader);
+  });
+
+  it('should add the global js header on top but after comments that are followed by newline', () => {
     const ast = createJSAst({ rawContent: '// @flow\n// another comment\n\nconst foo="cat"' });
     mutantCollectorMock.hasPlacedMutants.returns(true);
     transformBabel(ast, mutantCollectorMock, context);
 
     expect(ast.root.program.body[0].leadingComments![0].value).eq(' @flow');
     expect(ast.root.program.body[0].leadingComments![1].value).eq(' another comment');
-
-    for (let i = 0; i < instrumentationBabelHeader.length; i++) {
-      expect(ast.root.program.body[i]).eq(instrumentationBabelHeader[i]);
-    }
+    const { leadingComments: _unused, ...actualFirstStatement } = ast.root.program.body[0];
+    const { leadingComments: _unused2, ...expectedFirstStatement } = instrumentationBabelHeader[0];
+    expect(actualFirstStatement).deep.eq(expectedFirstStatement);
+    expect(ast.root.program.body.slice(1, instrumentationBabelHeader.length)).deep.eq(instrumentationBabelHeader.slice(1));
   });
-  it('should add the global stuff on top but after comments that are followed by a statement', () => {
+
+  it('should add the global js header on top but after comments that are followed by a statement', () => {
     const ast = createJSAst({ rawContent: '// @flow\n// another comment\nconst foo="cat"' });
     mutantCollectorMock.hasPlacedMutants.returns(true);
     transformBabel(ast, mutantCollectorMock, context);
 
     expect(ast.root.program.body[0].leadingComments![0].value).eq(' @flow');
     expect(ast.root.program.body[0].leadingComments![1].value).eq(' another comment');
-
-    for (let i = 0; i < instrumentationBabelHeader.length; i++) {
-      expect(ast.root.program.body[i]).eq(instrumentationBabelHeader[i]);
-    }
+    const { leadingComments: _unused, ...actualFirstStatement } = ast.root.program.body[0];
+    const { leadingComments: _unused2, ...expectedFirstStatement } = instrumentationBabelHeader[0];
+    expect(actualFirstStatement).deep.eq(expectedFirstStatement);
+    expect(ast.root.program.body.slice(1, instrumentationBabelHeader.length)).deep.eq(instrumentationBabelHeader.slice(1));
   });
 
   it('should not add global js header if no mutants were placed in the code', () => {

--- a/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
+++ b/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
@@ -80,7 +80,7 @@ describe('babel-transformer', () => {
     expect(mutantCollectorMock.markMutantsAsPlaced).calledWith([mutant]);
   });
 
-  it('should add the global js header on top ', () => {
+  it('should add the global js header on top', () => {
     const ast = createJSAst({ rawContent: 'const foo="cat"' });
     mutantCollectorMock.hasPlacedMutants.returns(true);
     transformBabel(ast, mutantCollectorMock, context);

--- a/packages/instrumenter/test/unit/util/syntax-helpers.spec.ts
+++ b/packages/instrumenter/test/unit/util/syntax-helpers.spec.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+
+import * as syntaxHelpers from '../../../src/util/syntax-helpers';
+
+describe('syntax-helpers', () => {
+  describe('instrumentationBabelHeader', () => {
+    it('should be immutable', () => {
+      expect(syntaxHelpers.instrumentationBabelHeader).frozen;
+      expect(syntaxHelpers.instrumentationBabelHeader[0].leadingComments).frozen;
+    });
+  });
+});


### PR DESCRIPTION
This means that the stryker mutator hooks are no longer just
prepended to the beginning of file. Instead we also add the comments
which means things like flow should behave correctly

Fixes #2704 